### PR TITLE
add basic devices api commands

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,17 @@ module.exports = {
 			'never'
 		],
 		'@typescript-eslint/member-delimiter-style': [
-			'linebreak'
+			'error',
+			{
+				multiline: {
+					delimiter: 'none',
+					requireLast: true
+				},
+				singleline: {
+					delimiter: 'semi',
+					requireLast: false
+				}
+			}
 		]
 	}
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ USAGE
 <!-- commands -->
 * [`smartthings autocomplete [SHELL]`](#smartthings-autocomplete-shell)
 * [`smartthings config [FILE]`](#smartthings-config-file)
+* [`smartthings devices ID`](#smartthings-devices-id)
+* [`smartthings devices:capabilities-status [FILE]`](#smartthings-devicescapabilities-status-file)
+* [`smartthings devices:commands ID`](#smartthings-devicescommands-id)
+* [`smartthings devices:components-status ID COMPONENTID`](#smartthings-devicescomponents-status-id-componentid)
+* [`smartthings devices:list`](#smartthings-deviceslist)
+* [`smartthings devices:status ID`](#smartthings-devicesstatus-id)
 * [`smartthings generate:java`](#smartthings-generatejava)
 * [`smartthings generate:node`](#smartthings-generatenode)
 * [`smartthings help [COMMAND]`](#smartthings-help-command)
@@ -73,6 +79,139 @@ OPTIONS
 ```
 
 _See code: [src/commands/config.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/src/commands/config.ts)_
+
+## `smartthings devices ID`
+
+get device's description
+
+```
+USAGE
+  $ smartthings devices ID
+
+ARGUMENTS
+  ID  the device id
+
+OPTIONS
+  -E, --target-environment=target-environment  target environment
+  -h, --help                                   show CLI help
+  -p, --profile=profile                        [default: default] configuration profile
+  -t, --token=token                            the auth token to use
+```
+
+_See code: [src/commands/devices.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/src/commands/devices.ts)_
+
+## `smartthings devices:capabilities-status [FILE]`
+
+get the current status of a device component's capability
+
+```
+USAGE
+  $ smartthings devices:capabilities-status ID COMPONENTID CAPABILITYID
+
+ARGUMENTS
+  ID           the device id
+  COMPONENTID  the component id
+  CAPABILITYID  the capability id
+
+OPTIONS
+  -E, --target-environment=target-environment  target environment
+  -h, --help                                   show CLI help
+  -p, --profile=profile                        [default: default] configuration profile
+  -t, --token=token                            the auth token to use
+```
+
+_See code: [src/commands/devices/capabilities-status.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/src/commands/devices/capabilities-status.ts)_
+
+## `smartthings devices:commands ID`
+
+execute commands on a device
+
+```
+USAGE
+  $ smartthings devices:commands ID
+
+ARGUMENTS
+  ID  the device on which you want to execute a command
+
+OPTIONS
+  -E, --target-environment=target-environment  target environment
+  -d, --data=data                              JSON data for command(s)
+  -h, --help                                   show CLI help
+  -p, --profile=profile                        [default: default] configuration profile
+  -t, --token=token                            the auth token to use
+```
+
+_See code: [src/commands/devices/commands.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/src/commands/devices/commands.ts)_
+
+## `smartthings devices:components-status ID COMPONENTID`
+
+get the status of all attributes of a the component
+
+```
+USAGE
+  $ smartthings devices:components-status ID COMPONENTID
+
+ARGUMENTS
+  ID           the device id
+  COMPONENTID  the component id
+
+OPTIONS
+  -E, --target-environment=target-environment  target environment
+  -h, --help                                   show CLI help
+  -p, --profile=profile                        [default: default] configuration profile
+  -t, --token=token                            the auth token to use
+```
+
+_See code: [src/commands/devices/components-status.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/src/commands/devices/components-status.ts)_
+
+## `smartthings devices:list`
+
+get a list of devices
+
+```
+USAGE
+  $ smartthings devices:list
+
+OPTIONS
+  -C, --capabilities-mode=and|or               Treat capability filter query params as a logical "or" or "and" with a
+                                               default of "and".
+
+  -E, --target-environment=target-environment  target environment
+
+  -c, --capability=capability                  filter results by capability
+
+  -d, --device-id=device-id                    filter results by device
+
+  -h, --help                                   show CLI help
+
+  -l, --location-id=location-id                filter results by location
+
+  -p, --profile=profile                        [default: default] configuration profile
+
+  -t, --token=token                            the auth token to use
+```
+
+_See code: [src/commands/devices/list.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/src/commands/devices/list.ts)_
+
+## `smartthings devices:status ID`
+
+get the current status of all of a device's component's attributes
+
+```
+USAGE
+  $ smartthings devices:status ID
+
+ARGUMENTS
+  ID  the device id
+
+OPTIONS
+  -E, --target-environment=target-environment  target environment
+  -h, --help                                   show CLI help
+  -p, --profile=profile                        [default: default] configuration profile
+  -t, --token=token                            the auth token to use
+```
+
+_See code: [src/commands/devices/status.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/src/commands/devices/status.ts)_
 
 ## `smartthings generate:java`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -495,6 +495,12 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA=="
     },
+    "@types/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA==",
+      "dev": true
+    },
     "@types/sinon": {
       "version": "7.0.13",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.13.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@types/js-yaml": "^3.12.1",
 		"@types/mocha": "^5.2.7",
 		"@types/node": "^10.14.21",
+		"@types/qs": "^6.5.3",
 		"@types/yeoman-environment": "^2.3.2",
 		"@typescript-eslint/eslint-plugin": "^2.3.3",
 		"@typescript-eslint/parser": "^2.3.3",

--- a/src/api-command.ts
+++ b/src/api-command.ts
@@ -1,0 +1,70 @@
+import Command, { flags } from '@oclif/command'
+
+import SmartThingsCommand from './smartthings-command'
+import { SmartThingsRESTClient } from '@smartthings/rest-client'
+import cliConfig from './lib/cli-config'
+
+
+/**
+ * Base class for Rest API commands.
+ */
+export default abstract class APICommand extends Command {
+	static flags = {
+		...SmartThingsCommand.flags,
+		profile: flags.string({
+			char: 'p',
+			description: 'configuration profile',
+			default: 'default',
+			env: 'SMARTTHINGS_PROFILE',
+		}),
+		token: flags.string({
+			char: 't',
+			description: 'the auth token to use',
+			env: 'SMARTTHINGS_TOKEN',
+		}),
+		'target-environment': flags.string({
+			char: 'E',
+			description: 'target environment',
+			env: 'SMARTTHINGS_ENVIRONMENT'
+		}),
+	}
+
+	protected args?: string[]
+	protected flags?: { [name: string]: any }
+	protected token?: string
+	protected profileName?: string
+	protected profileConfig?: { [name: string]: any }
+	protected targetEnvironment?: string
+	protected _client?: SmartThingsRESTClient
+
+	protected get client(): SmartThingsRESTClient {
+		if (!this._client) {
+			throw new Error('APICommand not properly initialized')
+		}
+		return this._client
+	}
+
+	protected async setup(args: string[], flags: { [name: string]: any }): Promise<void> {
+		this.args = args
+		this.flags = flags
+
+		this.profileName = flags.profile
+		this.profileConfig = cliConfig.getProfile(flags.profile)
+
+		if (flags.token) {
+			this.token = flags.token
+		} else if ('token' in this.profileConfig) {
+			this.token = this.profileConfig.token
+		}
+
+		if (flags['target-environment']) {
+			this.targetEnvironment = flags['target-environment']
+		} else if ('targetEnvironment' in this.profileConfig) {
+			this.targetEnvironment = this.profileConfig.targetEnvironment
+		} else {
+			this.targetEnvironment = 'prod'
+		}
+
+		this._client = new SmartThingsRESTClient(this.token, this.targetEnvironment)
+	}
+}

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,5 +1,8 @@
 import { Command, flags } from '@oclif/command'
 
+import cliConfig from '../lib/cli-config'
+
+
 export default class Config extends Command {
 	static description = 'describe the command here'
 
@@ -15,6 +18,8 @@ export default class Config extends Command {
 
 	async run(): Promise<void> {
 		const { args, flags } = this.parse(Config)
+		const profile = cliConfig.getProfile('dev')
+		this.log(`read profile:\n${JSON.stringify(profile, null, 4)}`)
 
 		const name = flags.name || 'world'
 		this.log(`hello ${name} from config.ts`)

--- a/src/commands/devices.ts
+++ b/src/commands/devices.ts
@@ -1,0 +1,23 @@
+import APICommand from '../api-command'
+
+
+export default class Devices extends APICommand {
+	static description = 'get device\'s description'
+
+	static flags = APICommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'the device id',
+		required: true,
+	}]
+
+	async run(): Promise<void> {
+		const { args, flags } = this.parse(Devices)
+		super.setup(args, flags)
+
+		this.client.devices.find(args.id).then(async device => {
+			this.log(JSON.stringify(device, null, 4))
+		})
+	}
+}

--- a/src/commands/devices/capabilities-status.ts
+++ b/src/commands/devices/capabilities-status.ts
@@ -1,0 +1,31 @@
+import APICommand from '../../api-command'
+
+
+export default class DevicesCapabilitiesStatus extends APICommand {
+	static description = 'get the current status of a device component\'s capability'
+
+	static flags = APICommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'the device id',
+		required: true
+	},{
+		name: 'componentId',
+		description: 'the component id',
+		required: true
+	},{
+		name: 'capabilityId',
+		description: 'the capability id',
+		required: true
+	}]
+
+	async run(): Promise<void> {
+		const { args, flags } = this.parse(DevicesCapabilitiesStatus)
+		super.setup(args, flags)
+
+		this.client.devices.getCapabilitiesStatus(args.id, args.componentId, args.capabilityId).then(async status => {
+			this.log(JSON.stringify(status, null, 4))
+		})
+	}
+}

--- a/src/commands/devices/commands.ts
+++ b/src/commands/devices/commands.ts
@@ -1,0 +1,53 @@
+import { flags } from '@oclif/command'
+
+import APICommand from '../../api-command'
+import { devices } from '@smartthings/rest-client'
+
+
+export default class DevicesCommands extends APICommand {
+	static description = 'execute commands on a device'
+
+	static flags = {
+		...APICommand.flags,
+		data: flags.string({
+			char: 'd',
+			description: 'JSON data for command(s)',
+		}),
+	}
+
+	static args = [{
+		name: 'id',
+		description: 'the device on which you want to execute a command',
+		required: true
+	}]
+
+	private executeAndDisplay(id: string, commands: devices.Command[]): void {
+		try {
+			this.client.devices.executeCommands(id, commands)
+		} catch (err) {
+			this.log(`caught error ${err}`)
+		}
+	}
+
+	async run(): Promise<void> {
+		const { args, flags } = this.parse(DevicesCommands)
+		super.setup(args, flags)
+
+		if (flags.data) {
+			const commandsIn: devices.CommandList = JSON.parse(flags.data)
+			this.executeAndDisplay(args.id, commandsIn.commands)
+		} else {
+			const stdin = process.stdin
+			const inputChunks: string[] = []
+			stdin.resume()
+			stdin.on('data', chunk => {
+				this.log(`pushing chunk ${chunk}`)
+				inputChunks.push(chunk)
+			})
+			stdin.on('end', () => {
+				const commandsIn = JSON.parse(inputChunks.join())
+				this.executeAndDisplay(args.id, commandsIn.commands)
+			})
+		}
+	}
+}

--- a/src/commands/devices/components-status.ts
+++ b/src/commands/devices/components-status.ts
@@ -1,0 +1,27 @@
+import APICommand from '../../api-command'
+
+
+export default class DevicesComponentsStatus extends APICommand {
+	static description = 'Get the status of all attributes of a the component.'
+
+	static flags = APICommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'the device id',
+		required: true
+	},{
+		name: 'componentId',
+		description: 'the component id',
+		required: true
+	}]
+
+	async run(): Promise<void> {
+		const { args, flags } = this.parse(DevicesComponentsStatus)
+		super.setup(args, flags)
+
+		this.client.devices.getComponentsStatus(args.id, args.componentId).then(async status => {
+			this.log(JSON.stringify(status, null, 4))
+		})
+	}
+}

--- a/src/commands/devices/list.ts
+++ b/src/commands/devices/list.ts
@@ -1,0 +1,51 @@
+import { flags } from '@oclif/command'
+
+import APICommand from '../../api-command'
+import { devices } from '@smartthings/rest-client'
+
+
+export default class DevicesList extends APICommand {
+	static description = 'get a list of devices'
+
+	static flags = {
+		...APICommand.flags,
+		'location-id': flags.string({
+			char: 'l',
+			description: 'filter results by location',
+			multiple: true
+		}),
+		capability: flags.string({
+			char: 'c',
+			description: 'filter results by capability',
+			multiple: true
+		}),
+		'capabilities-mode': flags.string({
+			char: 'C',
+			description: 'Treat capability filter query params as a logical "or" or "and" with a default of "and".',
+			dependsOn: ['capability'],
+			options: ['and', 'or']
+		}),
+		'device-id': flags.string({
+			char: 'd',
+			description: 'filter results by device',
+			multiple: true
+		}),
+	}
+
+	async run(): Promise<void> {
+		const { args, flags } = this.parse(DevicesList)
+		super.setup(args, flags)
+
+		const deviceListOptions: devices.DeviceListOptions = {
+			capability: flags.capability,
+			capabilitiesMode: flags['capabilities-mode'] === 'or' ? 'or' : 'and',
+			locationId: flags['location-id'],
+			deviceId: flags['device-id'],
+		}
+		this.client.devices.list(deviceListOptions).then(async devices => {
+			this.log(JSON.stringify(devices, null, 4))
+		}).catch(err => {
+			this.log(`caught error ${err}`)
+		})
+	}
+}

--- a/src/commands/devices/status.ts
+++ b/src/commands/devices/status.ts
@@ -1,0 +1,23 @@
+import APICommand from '../../api-command'
+
+
+export default class DevicesStatus extends APICommand {
+	static description = 'get the current status of all of a device\'s component\'s attributes'
+
+	static flags = APICommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'the device id',
+		required: true
+	}]
+
+	async run(): Promise<void> {
+		const { args, flags } = this.parse(DevicesStatus)
+		super.setup(args, flags)
+
+		this.client.devices.getStatus(args.id).then(async status => {
+			this.log(JSON.stringify(status, null, 4))
+		})
+	}
+}

--- a/src/lib/cli-config.ts
+++ b/src/lib/cli-config.ts
@@ -7,7 +7,7 @@ export class CLIConfig {
 	private _configFile: string|null = null
 	private _config: object|null = null
 
-	public init(configFile: string) {
+	public init(configFile: string): void {
 		this._configFile = configFile
 	}
 
@@ -15,6 +15,7 @@ export class CLIConfig {
 		return this._configFile
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	public loadConfig(): { [name: string]: any } {
 		if (this._configFile == null) {
 			throw new Error('config not yet initialized')
@@ -43,9 +44,10 @@ export class CLIConfig {
 	}
 
 	public getProfile(name: string): object {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const config: { [name: string]: any } = this.loadConfig()
 		if (!(name in config)) {
-			throw new Error(`could not find valid profile ${name} in ${this._configFile}`)
+			return {}
 		}
 		const retVal = config[name]
 		if (typeof retVal === 'object') {

--- a/src/lib/generate-command.ts
+++ b/src/lib/generate-command.ts
@@ -1,18 +1,17 @@
-import { Command, flags } from '@oclif/command'
 import yeoman from 'yeoman-environment'
 
+import SmartThingsCommand from '../smartthings-command'
 
-export default abstract class GenerateCommand extends Command {
-	static flags = {
-		help: flags.help({ char: 'h' }),
-	}
+
+export default abstract class GenerateCommand extends SmartThingsCommand {
+	static flags = SmartThingsCommand.flags
 
 	async generate(name: string): Promise<void> {
 		const env = yeoman.createEnv()
 		env.lookup(() => {
 			env.run(name, (err) => {
 				if (err) {
-					console.log(`failed to run yeoman: ${err}`)
+					this.log(`failed to run yeoman: ${err}`)
 				}
 			})
 		})

--- a/src/smartthings-command.ts
+++ b/src/smartthings-command.ts
@@ -1,0 +1,11 @@
+import Command, { flags } from '@oclif/command'
+
+
+/**
+ * The base class for all commands.
+ */
+export default abstract class SmartThingsCommand extends Command {
+	static flags = {
+		help: flags.help({ char: 'h' }),
+	}
+}

--- a/test/lib/cli-config.test.ts
+++ b/test/lib/cli-config.test.ts
@@ -21,7 +21,7 @@ describe('cliConfig', () => {
 		expect(cliConfig.loadConfig()).to.eql({})
 	})
 
-	it('returns an empty config empty config file', function() {
+	it('returns an empty config for empty config file', function() {
 		const cliConfig = new CLIConfig()
 		cliConfig.init('./test/resources/empty-config.yaml')
 		expect(cliConfig.loadConfig()).to.eql({})
@@ -45,10 +45,10 @@ describe('cliConfig', () => {
 		expect(cliConfig.getProfile('simple')).to.eql({key: 'value'})
 	})
 
-	it('throws error for missing profile', function() {
+	it('returns empty config for missing profile', function() {
 		const cliConfig = new CLIConfig()
 		cliConfig.init('./test/resources/good-config.yaml')
-		expect(cliConfig.getProfile.bind(cliConfig, 'does-not-exist')).to.throw('could not find valid profile')
+		expect(cliConfig.getProfile('does-not-exist')).to.eql({})
 	})
 
 	it('throws error for bad profile', function() {


### PR DESCRIPTION
Added basic devices API commands.

I did not implement:

* create or delete device
* any helper methods on top of basic API--I wanted to make sure the "raw" API works properly first
* there is still no testing (I spent some time trying to get jest working and gave up--oclif is really only set up for mocha/chai and even that isn't amazing)

