### PR TITLE
rename to @smartthings/cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "smartthings-cli",
+	"name": "@smartthings/cli",
 	"description": "SmartThings unified CLI",
 	"version": "0.0.0",
 	"author": "SmartThings, Inc.",


### PR DESCRIPTION
Renamed the package name to put it under @smartthings.

Fixes #3 