### PR TITLE
feat Added basic support for apps and device profiles

### DIFF
--- a/packages/cli/src/commands/apps.ts
+++ b/packages/cli/src/commands/apps.ts
@@ -1,0 +1,108 @@
+import { App } from '@smartthings/core-sdk'
+import {ListableObjectOutputCommand} from '@smartthings/cli-lib'
+import {flags} from '@oclif/command'
+
+export default class AppsList extends ListableObjectOutputCommand<App,App> {
+	static description = 'get a specific app or a list of apps'
+
+	static flags = {
+		...ListableObjectOutputCommand.flags,
+		verbose: flags.boolean({
+			description: 'include URLs and ARNs in table output',
+			char: 'v',
+		}),
+	}
+
+	static args = [{
+		name: 'id',
+		description: 'the app id',
+		required: false,
+	}]
+
+	protected primaryKeyName(): string { return 'appId' }
+	protected sortKeyName(): string { return 'displayName' }
+	protected tableHeadings(): string[] {
+		if (this.flags.verbose) {
+			return ['displayName', 'appType', 'appId', 'ARN/URL']
+		} else {
+			return ['displayName', 'appType', 'appId']
+		}
+	}
+
+	protected buildObjectTableOutput(data: App): string {
+		const table = this.newOutputTable({head: ['property','value']})
+		table.push(['name', data.displayName])
+		table.push(['appId', data.appId])
+		table.push(['appName', data.appName])
+		table.push(['description', data.description])
+		table.push(['singleInstance', data.singleInstance])
+		if (data.classifications) {
+			table.push(['classifications', data.classifications.join('\n')])
+		}
+		if (data.installMetadata && data.installMetadata.certified) {
+			table.push(['certified', data.installMetadata.certified])
+		}
+		if (data.installMetadata && data.installMetadata.maxInstalls) {
+			table.push(['maxInstalls', data.installMetadata.maxInstalls])
+		}
+		table.push(['appType', data.appType])
+		if (data.webhookSmartApp) {
+			table.push(['signatureType', data.webhookSmartApp.signatureType])
+			table.push(['targetUrl', data.webhookSmartApp.targetUrl])
+			table.push(['targetStatus', data.webhookSmartApp.targetStatus])
+		}
+		if (data.webhookSmartApp && data.webhookSmartApp.publicKey) {
+			table.push(['publicKey', data.webhookSmartApp.publicKey.replace(/\r\n/g, '\n')])
+		}
+		if (data.lambdaSmartApp && data.lambdaSmartApp.functions) {
+			table.push(['lambda functions', data.lambdaSmartApp.functions.join('\n')])
+		}
+		if (data.apiOnly && data.apiOnly.subscription) {
+			table.push(['targetUrl', data.apiOnly.subscription.targetUrl])
+			table.push(['targetStatus', data.apiOnly.subscription.targetStatus])
+		}
+		if (data.installMetadata && data.installMetadata.certified !== undefined) {
+			table.push(['certified', data.installMetadata.certified])
+		}
+
+		return table.toString()
+	}
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(AppsList)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => {
+				if (flags.verbose) {
+					return this.client.apps.list().then(list => {
+						const objects = list.map(it => {
+							// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+							// @ts-ignore
+							return this.client.apps.get(it.appId) // TODO appId should not be optional
+						})
+						return Promise.all(objects).then(list => {
+							for (const item of list) {
+								const uri = item.webhookSmartApp ?
+									item.webhookSmartApp.targetUrl :
+									(item.lambdaSmartApp ? item.lambdaSmartApp.functions[0] :
+										(item.apiOnly && item.apiOnly.subscription ?
+											item.apiOnly.subscription.targetUrl : ''))
+
+								item['ARN/URL'] = uri.length < 96 ? uri : uri.slice(0,95) + '...'
+							}
+							return list
+						})
+					})
+				} else {
+					return this.client.apps.list()
+				}
+
+			 },
+			(id: string) => {
+				return this.client.apps.get(id)
+			 },
+		)
+	}
+}

--- a/packages/cli/src/commands/apps/create.ts
+++ b/packages/cli/src/commands/apps/create.ts
@@ -1,0 +1,22 @@
+import { App, AppRequest, AppCreationResponse} from '@smartthings/core-sdk'
+import { ListableObjectInputOutputCommand } from '@smartthings/cli-lib'
+
+export default class AppCreateCommand extends ListableObjectInputOutputCommand<App, AppCreationResponse, AppRequest> {
+	static description = 'update the OAuth settings of the app'
+
+	static flags = ListableObjectInputOutputCommand.flags
+
+	protected primaryKeyName(): string { return 'appId' }
+	protected sortKeyName(): string { return 'displayName' }
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(AppCreateCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => { return this.client.apps.list() },
+			(id, data) => { return this.client.apps.create(data) },
+		)
+	}
+}

--- a/packages/cli/src/commands/apps/delete.ts
+++ b/packages/cli/src/commands/apps/delete.ts
@@ -1,0 +1,28 @@
+import { App, Count } from '@smartthings/core-sdk'
+import { ListableObjectOutputCommand } from '@smartthings/cli-lib'
+
+export default class AppDeleteCommand extends ListableObjectOutputCommand<App, Count> {
+	static description = 'delete the app'
+
+	static flags = ListableObjectOutputCommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'the app id',
+		required: true,
+	}]
+
+	protected primaryKeyName(): string { return 'appId' }
+	protected sortKeyName(): string { return 'displayName' }
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(AppDeleteCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => { return this.client.apps.list() },
+			(id) => { return this.client.apps.delete(id) },
+		)
+	}
+}

--- a/packages/cli/src/commands/apps/oauth.ts
+++ b/packages/cli/src/commands/apps/oauth.ts
@@ -1,0 +1,28 @@
+import { App, AppOAuth } from '@smartthings/core-sdk'
+import { ListableObjectOutputCommand } from '@smartthings/cli-lib'
+
+export default class AppOauthCommand extends ListableObjectOutputCommand<App, AppOAuth> {
+	static description = 'get OAuth settings of the app'
+
+	static flags = ListableObjectOutputCommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'the app id',
+		required: true,
+	}]
+
+	protected primaryKeyName(): string { return 'appId' }
+	protected sortKeyName(): string { return 'displayName' }
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(AppOauthCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => { return this.client.apps.list() },
+			(id) => { return this.client.apps.getOauth(id) },
+		)
+	}
+}

--- a/packages/cli/src/commands/apps/oauth/generate.ts
+++ b/packages/cli/src/commands/apps/oauth/generate.ts
@@ -1,0 +1,28 @@
+import { App, AppOAuth, AppOAuthResponse } from '@smartthings/core-sdk'
+import { ListableObjectInputOutputCommand } from '@smartthings/cli-lib'
+
+export default class AppOauthGenerateCommand extends ListableObjectInputOutputCommand<App, AppOAuthResponse, AppOAuth> {
+	static description = 'update the OAuth settings of the app and regenerate the clientId and clientSecret'
+
+	static flags = ListableObjectInputOutputCommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'the app id',
+		required: true,
+	}]
+
+	protected primaryKeyName(): string { return 'appId' }
+	protected sortKeyName(): string { return 'displayName' }
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(AppOauthGenerateCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => { return this.client.apps.list() },
+			(id, data) => { return this.client.apps.regenerateOauth(id, data) },
+		)
+	}
+}

--- a/packages/cli/src/commands/apps/oauth/update.ts
+++ b/packages/cli/src/commands/apps/oauth/update.ts
@@ -1,0 +1,28 @@
+import { App, AppOAuth } from '@smartthings/core-sdk'
+import { ListableObjectInputOutputCommand } from '@smartthings/cli-lib'
+
+export default class AppOauthUpdateCommand extends ListableObjectInputOutputCommand<App, AppOAuth, AppOAuth> {
+	static description = 'update the OAuth settings of the app'
+
+	static flags = ListableObjectInputOutputCommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'the app id',
+		required: true,
+	}]
+
+	protected primaryKeyName(): string { return 'appId' }
+	protected sortKeyName(): string { return 'displayName' }
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(AppOauthUpdateCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => { return this.client.apps.list() },
+			(id, data) => { return this.client.apps.updateOauth(id, data) },
+		)
+	}
+}

--- a/packages/cli/src/commands/apps/register.ts
+++ b/packages/cli/src/commands/apps/register.ts
@@ -1,0 +1,28 @@
+import { App, Status } from '@smartthings/core-sdk'
+import { ListableObjectOutputCommand } from '@smartthings/cli-lib'
+
+export default class AppRegisterCommand extends ListableObjectOutputCommand<App, Status> {
+	static description = 'register the app'
+
+	static flags = ListableObjectOutputCommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'the app id',
+		required: true,
+	}]
+
+	protected primaryKeyName(): string { return 'appId' }
+	protected sortKeyName(): string { return 'displayName' }
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(AppRegisterCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => { return this.client.apps.list() },
+			(id) => { return this.client.apps.register(id) },
+		)
+	}
+}

--- a/packages/cli/src/commands/apps/settings.ts
+++ b/packages/cli/src/commands/apps/settings.ts
@@ -1,0 +1,36 @@
+import { App, AppSettings } from '@smartthings/core-sdk'
+import { ListableObjectOutputCommand } from '@smartthings/cli-lib'
+
+export default class AppSettingsCommand extends ListableObjectOutputCommand<App, AppSettings> {
+	static description = 'get OAuth settings of the app'
+
+	static flags = ListableObjectOutputCommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'the app id',
+		required: true,
+	}]
+
+	protected primaryKeyName(): string { return 'appId' }
+	protected sortKeyName(): string { return 'displayName' }
+	protected buildObjectTableOutput(data: AppSettings): string {
+		const table = this.newOutputTable({head: ['name','value']})
+		if (data.settings) {
+			for (const key of Object.keys(data.settings)) {
+				table.push([key, data.settings[key]])
+			}
+		}
+		return table.toString()
+	}
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(AppSettingsCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => { return this.client.apps.list() },
+			(id) => { return this.client.apps.getSettings(id) },
+		)
+	}
+}

--- a/packages/cli/src/commands/apps/settings/update.ts
+++ b/packages/cli/src/commands/apps/settings/update.ts
@@ -1,0 +1,36 @@
+import { App, AppSettings } from '@smartthings/core-sdk'
+import { ListableObjectInputOutputCommand } from '@smartthings/cli-lib'
+
+export default class AppSettingsUpdateCommand extends ListableObjectInputOutputCommand<App, AppSettings, AppSettings> {
+	static description = 'update the OAuth settings of the app'
+
+	static flags = ListableObjectInputOutputCommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'the app id',
+		required: true,
+	}]
+
+	protected primaryKeyName(): string { return 'appId' }
+	protected sortKeyName(): string { return 'displayName' }
+	protected buildObjectTableOutput(data: AppSettings): string {
+		const table = this.newOutputTable({head: ['name','value']})
+		if (data.settings) {
+			for (const key of Object.keys(data.settings)) {
+				table.push([key, data.settings[key]])
+			}
+		}
+		return table.toString()
+	}
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(AppSettingsUpdateCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => { return this.client.apps.list() },
+			(id, data) => { return this.client.apps.updateSettings(id, data) },
+		)
+	}
+}

--- a/packages/cli/src/commands/apps/update.ts
+++ b/packages/cli/src/commands/apps/update.ts
@@ -1,0 +1,28 @@
+import { App, AppRequest} from '@smartthings/core-sdk'
+import { ListableObjectInputOutputCommand } from '@smartthings/cli-lib'
+
+export default class AppUpdateCommand extends ListableObjectInputOutputCommand<App, App, AppRequest> {
+	static description = 'update the OAuth settings of the app'
+
+	static flags = ListableObjectInputOutputCommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'the app id',
+		required: true,
+	}]
+
+	protected primaryKeyName(): string { return 'appId' }
+	protected sortKeyName(): string { return 'displayName' }
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(AppUpdateCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => { return this.client.apps.list() },
+			(id, data) => { return this.client.apps.update(id, data) },
+		)
+	}
+}

--- a/packages/cli/src/commands/deviceprofiles.ts
+++ b/packages/cli/src/commands/deviceprofiles.ts
@@ -1,0 +1,53 @@
+import { DeviceProfile } from '@smartthings/core-sdk'
+import { ListableObjectOutputCommand } from '@smartthings/cli-lib'
+
+export default class DeviceProfilesList extends ListableObjectOutputCommand<DeviceProfile, DeviceProfile> {
+	static description = 'Lists all device profiles available in a user account or retrieves a single profile'
+
+	static flags = ListableObjectOutputCommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'Device profile to retrieve. Can be a UUID or the number of the profile in the list',
+		required: false,
+	}]
+
+	static examples = [
+		'$ smartthings deviceprofiles                      #list all device profiles',
+		'$ smartthings deviceprofiles bb0fdc5-...-a8bd2ea  #show device profile with the specified UUID',
+		'$ smartthings deviceprofiles 2                    #show the second device profile in the list',
+		'$ smartthings deviceprofiles 3 -j                 #show the profile in JSON format',
+		'$ smartthings deviceprofiles 5 -y                 #show the profile in YAML format',
+		'$ smartthings deviceprofiles 4 -j -o profile.json #write the profile to the file "profile.json"',
+	]
+
+	protected primaryKeyName(): string { return 'id' }
+	protected sortKeyName(): string { return 'name' }
+	protected tableHeadings(): string[] { return ['name', 'status', 'id'] }
+
+	protected buildObjectTableOutput(data: DeviceProfile): string {
+		const table = this.newOutputTable({head: ['property','value']})
+		table.push(['name', data.name])
+		for (const comp of data.components) {
+			table.push([`${comp.id} component`,  comp.capabilities ? comp.capabilities.map(it => it.id).join('\n') : ''])
+		}
+		table.push(['id', data.id])
+		table.push(['deviceType', data.metadata ? data.metadata.deviceType : ''])
+		table.push(['ocfDeviceType', data.metadata ? data.metadata.ocfDeviceType : ''])
+		table.push(['mnmn', data.metadata ? data.metadata.mnmn : ''])
+		table.push(['vid', data.metadata ? data.metadata.vid : ''])
+		table.push(['status', data.status])
+		return table.toString()
+	}
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(DeviceProfilesList)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => { return this.client.deviceProfiles.list() },
+			(id) => { return this.client.deviceProfiles.get(id) },
+		)
+	}
+}

--- a/packages/cli/src/commands/deviceprofiles/create.ts
+++ b/packages/cli/src/commands/deviceprofiles/create.ts
@@ -1,0 +1,46 @@
+import { DeviceProfile, DeviceProfileRequest } from '@smartthings/core-sdk'
+import { InputOutputAPICommand } from '@smartthings/cli-lib'
+import Table from 'cli-table'
+
+export default class DeviceProfileCreateCommand extends InputOutputAPICommand<DeviceProfileRequest, DeviceProfile> {
+	static description = 'Create a new device profile'
+
+	static flags = InputOutputAPICommand.flags
+
+	static examples = [
+		'$ smartthings deviceprofiles:create -i myprofile.json    #create a device profile from the JSON file definition',
+		'$ smartthings deviceprofiles:create -i myprofile.yaml    #create a device profile from the YAML file definition',
+	]
+
+	protected buildTableOutput(data: DeviceProfile): string {
+		const table: Table = this.newOutputTable({head: ['property','value']})
+		table.push(['name', data.name])
+		table.push(['id', data.id])
+		table.push(['deviceType', data.metadata ? data.metadata.deviceType : ''])
+		table.push(['mnmn', data.metadata ? data.metadata.mnmn : ''])
+		table.push(['vid', data.metadata ? data.metadata.vid : ''])
+		return table.toString()
+	}
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(DeviceProfileCreateCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally((data) => {
+			return this.client.deviceProfiles.create(cleanupRequest(data))
+		})
+	}
+}
+
+// Cleanup is done so that the result of a device profile get can be modified and
+// used in an update operation without having to delete the status, owner, and
+// component name fields, which aren't accepted in the update API call.
+function cleanupRequest(deviceProfileRequest: any): DeviceProfileRequest {
+	delete deviceProfileRequest.id
+	delete deviceProfileRequest.status
+	delete deviceProfileRequest.owner
+	for (const component of deviceProfileRequest.components) {
+		delete component.label
+	}
+	return deviceProfileRequest
+}

--- a/packages/cli/src/commands/deviceprofiles/delete.ts
+++ b/packages/cli/src/commands/deviceprofiles/delete.ts
@@ -1,0 +1,33 @@
+import { DeviceProfile, Status } from '@smartthings/core-sdk'
+import { ListableObjectOutputCommand } from '@smartthings/cli-lib'
+
+export default class DeviceProfileDeleteCommand extends ListableObjectOutputCommand<DeviceProfile, Status> {
+	static description = 'Delete a device profile'
+
+	static flags = ListableObjectOutputCommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'Device profile UUID or number in the list',
+		required: true,
+	}]
+
+	static examples = [
+		'$ smartthings deviceprofiles:delete 63b8c91e-9686-4c43-9afb-fbd9f77e3bb0  #delete profile with this UUID',
+		'$ smartthings deviceprofiles:delete 5                                     #delete the 5th profile in the list',
+	]
+
+	protected primaryKeyName(): string { return 'id' }
+	protected sortKeyName(): string { return 'name' }
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(DeviceProfileDeleteCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => { return this.client.deviceProfiles.list() },
+			(id) => { return this.client.deviceProfiles.delete(id) },
+		)
+	}
+}

--- a/packages/cli/src/commands/deviceprofiles/publish.ts
+++ b/packages/cli/src/commands/deviceprofiles/publish.ts
@@ -1,0 +1,35 @@
+import { DeviceProfile, DeviceProfileStatus } from '@smartthings/core-sdk'
+import { ListableObjectOutputCommand } from '@smartthings/cli-lib'
+
+export default class DeviceProfilePublishCommand extends ListableObjectOutputCommand<DeviceProfile, DeviceProfile> {
+	static description = 'Publishes a device profile. Published profiles cannot be modified'
+
+	static flags = ListableObjectOutputCommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'Device profile UUID or number in the list',
+		required: true,
+	}]
+
+	static examples = [
+		'$ smartthings deviceprofiles:publish 63b8c91e-9686-4c43-9afb-fbd9f77e3bb0  #publish the profile with this UUID',
+		'$ smartthings deviceprofiles:publish 5                                     #publish the 5th profile in the list',
+	]
+
+	protected primaryKeyName(): string { return 'id' }
+	protected sortKeyName(): string { return 'name' }
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(DeviceProfilePublishCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => { return this.client.deviceProfiles.list() },
+			(id) => {
+				return this.client.deviceProfiles.updateStatus(id, DeviceProfileStatus.PUBLISHED)
+			 },
+		)
+	}
+}

--- a/packages/cli/src/commands/deviceprofiles/update.ts
+++ b/packages/cli/src/commands/deviceprofiles/update.ts
@@ -1,0 +1,44 @@
+import { DeviceProfile, DeviceProfileRequest } from '@smartthings/core-sdk'
+import { ListableObjectInputOutputCommand } from '@smartthings/cli-lib'
+
+export default class DeviceProfileUpdateCommand extends ListableObjectInputOutputCommand<DeviceProfile, DeviceProfile, DeviceProfileRequest> {
+	static description = 'Update a device profile'
+
+	static flags = ListableObjectInputOutputCommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'Device profile UUID or number in the list',
+		required: true,
+	}]
+
+	protected primaryKeyName(): string { return 'id' }
+	protected sortKeyName(): string { return 'name' }
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(DeviceProfileUpdateCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => { return this.client.deviceProfiles.list() },
+			(id, data) => {
+				return this.client.deviceProfiles.update(id, cleanupRequest(data))
+			},
+		)
+	}
+}
+
+// Cleanup is done so that the result of a device profile get can be modified and
+// used in an update operation without having to delete the status, owner, and
+// component name fields, which aren't accepted in the update API call.
+function cleanupRequest(deviceProfileRequest: any): DeviceProfileRequest {
+	delete deviceProfileRequest.id
+	delete deviceProfileRequest.status
+	delete deviceProfileRequest.owner
+	delete deviceProfileRequest.name
+	for (const component of deviceProfileRequest.components) {
+		delete component.label
+	}
+	return deviceProfileRequest
+}

--- a/packages/lib/src/api-command.ts
+++ b/packages/lib/src/api-command.ts
@@ -1,5 +1,6 @@
 import { flags } from '@oclif/command'
 
+import Table from 'cli-table'
 import { SmartThingsClient } from '@smartthings/core-sdk'
 import { BearerTokenAuthenticator } from '@smartthings/core-sdk'
 
@@ -58,6 +59,27 @@ export abstract class APICommand extends SmartThingsCommand {
 			throw new Error('APICommand not properly initialized')
 		}
 		return this._client
+	}
+
+	protected newOutputTable(options?: { [name: string]: any }): Table {
+		const defaultOptions = this.profileConfig ? this.profileConfig.tableOptions || {} : {}
+		if (this.flags.compact) {
+			if (defaultOptions.style) {
+				defaultOptions.style.compact = true
+			} else {
+				defaultOptions.style = {compact: true}
+			}
+		} else if (this.flags.expanded) {
+			if (defaultOptions.style) {
+				defaultOptions.style.compact = false
+			} else {
+				defaultOptions.style = {compact: false}
+			}
+		}
+		if (options) {
+			return new Table({...defaultOptions, ...options})
+		}
+		return new Table(defaultOptions)
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,6 +1,11 @@
 export { APICommand } from './api-command'
 export { SmartThingsCommand } from './smartthings-command'
 export { cliConfig } from './cli-config'
-export { InputAPICommand, OutputAPICommand, InputOutputAPICommand } from './io-command'
+export {
+	InputAPICommand,
+	OutputAPICommand,
+	InputOutputAPICommand,
+	ListableObjectOutputCommand,
+	ListableObjectInputOutputCommand } from './io-command'
 export { logManager } from './logger'
 export { LoginAuthenticator } from './login-authenticator'


### PR DESCRIPTION
Besides adding CRUD operations for apps and device profiles, this PR makes the following changes to the cli architecture as a whole:
1. Adding compact table format to the config file, with the default being true
1. Adding command line options (but not shortcuts) for changing the table format
1. Changing the syntax of list commands for these new entities to be `apps` rather than `apps:list` (retrofit of others will be in a separate PR)
1. Introduce row number in list commands and the ability to show an object with its row number rather having to copy and paste a UUID (thought that still works as well)
1. Adding `ListableObjectOutputCommand` and `ListableObjectOutputCommand` to implement the numbered list behavior without having to copy and paste a lot of code between commands.