### PR TITLE
fix handling of basic command name for strings

### DIFF
--- a/packages/cli/src/commands/capabilities/create.ts
+++ b/packages/cli/src/commands/capabilities/create.ts
@@ -146,7 +146,7 @@ export default class CapabilitiesCreate extends InputOutputAPICommand<Capability
 							}
 							return true
 						},
-					}))
+					})).basicCommandValue
 				} else if (type === Type.BOOLEAN) {
 					basicCommandValue = (await inquirer.prompt({
 						type: 'list',


### PR DESCRIPTION
Fixed handling of basic command name for strings.