### PR TITLE
standardization part 2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,7 @@ module.exports = {
 		'no-process-exit': 'error',
 		'no-template-curly-in-string': 'error',
 		'require-await': 'off',
+		'no-inner-declarations': 'off',
 		semi: 'off', // disable to allow @typescript-eslint/semi to do its job
 		'@typescript-eslint/semi': ['error', 'never'],
 		'@typescript-eslint/member-delimiter-style': [
@@ -77,6 +78,7 @@ module.exports = {
 			{ functions: false, classes: false, enums: false, variables: true }
 		],
 		'@typescript-eslint/no-var-requires': 'error',
+		'@typescript-eslint/ban-ts-ignore': 0,
 
 		// disallow non-import statements appearing before import statements
 		'import/first': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14458,9 +14458,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "3.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+			"integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
 		"lerna": "^3.20.2",
 		"ts-jest": "^25.3.1",
 		"ts-node": "^8.8.2",
-		"typescript": "^3.8.3"
+		"typescript": "^3.9.3"
 	}
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -64,7 +64,7 @@ USAGE
 * [`smartthings config [FILE]`](#smartthings-config-file)
 * [`smartthings deviceprofiles [ID]`](#smartthings-deviceprofiles-id)
 * [`smartthings deviceprofiles:create`](#smartthings-deviceprofilescreate)
-* [`smartthings deviceprofiles:delete ID`](#smartthings-deviceprofilesdelete-id)
+* [`smartthings deviceprofiles:delete [ID]`](#smartthings-deviceprofilesdelete-id)
 * [`smartthings deviceprofiles:publish ID`](#smartthings-deviceprofilespublish-id)
 * [`smartthings deviceprofiles:update ID`](#smartthings-deviceprofilesupdate-id)
 * [`smartthings devices ID`](#smartthings-devices-id)
@@ -419,8 +419,14 @@ ARGUMENTS
 
 OPTIONS
   -h, --help             show CLI help
+  -j, --json             use JSON format of input and/or output
+  -o, --output=output    specify output file
   -p, --profile=profile  [default: default] configuration profile
   -t, --token=token      the auth token to use
+  -y, --yaml             use YAML format of input and/or output
+  --compact              use compact table format with no lines between body rows
+  --expanded             use expanded table format with a line between each body row
+  --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
 _See code: [dist/commands/capabilities/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/capabilities/delete.ts)_
@@ -642,6 +648,9 @@ OPTIONS
   --expanded             use expanded table format with a line between each body row
   --indent=indent        specify indentation for formatting JSON or YAML output
 
+ALIASES
+  $ smartthings device-profiles
+
 EXAMPLES
   $ smartthings deviceprofiles                      # list all device profiles
   $ smartthings deviceprofiles bb0fdc5-...-a8bd2ea  # show device profile with the specified UUID
@@ -681,21 +690,27 @@ EXAMPLES
 
 _See code: [dist/commands/deviceprofiles/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/deviceprofiles/create.ts)_
 
-## `smartthings deviceprofiles:delete ID`
+## `smartthings deviceprofiles:delete [ID]`
 
 delete a device profile
 
 ```
 USAGE
-  $ smartthings deviceprofiles:delete ID
+  $ smartthings deviceprofiles:delete [ID]
 
 ARGUMENTS
   ID  Device profile UUID or number in the list
 
 OPTIONS
   -h, --help             show CLI help
+  -j, --json             use JSON format of input and/or output
+  -o, --output=output    specify output file
   -p, --profile=profile  [default: default] configuration profile
   -t, --token=token      the auth token to use
+  -y, --yaml             use YAML format of input and/or output
+  --compact              use compact table format with no lines between body rows
+  --expanded             use expanded table format with a line between each body row
+  --indent=indent        specify indentation for formatting JSON or YAML output
 
 EXAMPLES
   $ smartthings deviceprofiles:delete 63b8c91e-9686-4c43-9afb-fbd9f77e3bb0  # delete profile with this UUID

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -62,7 +62,7 @@
 		"@types/cli-table": "^0.3.0",
 		"@types/yeoman-environment": "^2.3.3",
 		"pkg": "^4.4.8",
-		"typescript": "^3.8.3"
+		"typescript": "^3.9.3"
 	},
 	"scripts": {
 		"lint": "eslint --ext ts src",

--- a/packages/cli/src/commands/apps.ts
+++ b/packages/cli/src/commands/apps.ts
@@ -2,7 +2,7 @@ import { flags } from '@oclif/command'
 
 import { App } from '@smartthings/core-sdk'
 
-import { ListableObjectOutputCommand, TableGenerator } from '@smartthings/cli-lib'
+import { ListingOutputAPICommand, TableGenerator } from '@smartthings/cli-lib'
 
 
 export function buildTableOutput(tableGenerator: TableGenerator, data: App): string {
@@ -44,11 +44,11 @@ export function buildTableOutput(tableGenerator: TableGenerator, data: App): str
 	return table.toString()
 }
 
-export default class AppsList extends ListableObjectOutputCommand<App, App> {
+export default class AppsList extends ListingOutputAPICommand<App, App> {
 	static description = 'get a specific app or a list of apps'
 
 	static flags = {
-		...ListableObjectOutputCommand.flags,
+		...ListingOutputAPICommand.flags,
 		verbose: flags.boolean({
 			description: 'include URLs and ARNs in table output',
 			char: 'v',
@@ -61,8 +61,8 @@ export default class AppsList extends ListableObjectOutputCommand<App, App> {
 		required: false,
 	}]
 
-	protected primaryKeyName(): string { return 'appId' }
-	protected sortKeyName(): string { return 'displayName' }
+	protected primaryKeyName = 'appId'
+	protected sortKeyName = 'displayName'
 	protected tableHeadings(): string[] {
 		if (this.flags.verbose) {
 			return ['displayName', 'appType', 'appId', 'ARN/URL']
@@ -85,7 +85,6 @@ export default class AppsList extends ListableObjectOutputCommand<App, App> {
 				if (flags.verbose) {
 					return this.client.apps.list().then(list => {
 						const objects = list.map(it => {
-							// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 							// @ts-ignore
 							return this.client.apps.get(it.appId) // TODO appId should not be optional
 						})
@@ -93,10 +92,10 @@ export default class AppsList extends ListableObjectOutputCommand<App, App> {
 							for (const item of list) {
 								const uri = item.webhookSmartApp ?
 									item.webhookSmartApp.targetUrl :
-									(item.lambdaSmartApp ? item.lambdaSmartApp.functions[0] :
-										(item.apiOnly && item.apiOnly.subscription ?
-											item.apiOnly.subscription.targetUrl : ''))
+									(item.lambdaSmartApp ? (item.lambdaSmartApp?.functions?.length ? item.lambdaSmartApp?.functions[0] : '') :
+										(item.apiOnly?.subscription?.targetUrl ?? ''))
 
+								// @ts-ignore
 								item['ARN/URL'] = uri.length < 96 ? uri : uri.slice(0,95) + '...'
 							}
 							return list

--- a/packages/cli/src/commands/apps/delete.ts
+++ b/packages/cli/src/commands/apps/delete.ts
@@ -12,8 +12,8 @@ export default class AppDeleteCommand extends SimpleAPICommand {
 		required: true,
 	}]
 
-	protected primaryKeyName(): string { return 'appId' }
-	protected sortKeyName(): string { return 'displayName' }
+	protected primaryKeyName = 'appId'
+	protected sortKeyName = 'displayName'
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(AppDeleteCommand)

--- a/packages/cli/src/commands/apps/oauth.ts
+++ b/packages/cli/src/commands/apps/oauth.ts
@@ -24,8 +24,8 @@ export default class AppOauthCommand extends OutputAPICommand<AppOAuth> {
 		required: true,
 	}]
 
-	protected primaryKeyName(): string { return 'appId' }
-	protected sortKeyName(): string { return 'displayName' }
+	protected primaryKeyName = 'appId'
+	protected sortKeyName = 'displayName'
 
 	protected buildTableOutput(appOAuth: AppOAuth): string {
 		const table = buildTableForOutput(this, appOAuth)

--- a/packages/cli/src/commands/apps/oauth/generate.ts
+++ b/packages/cli/src/commands/apps/oauth/generate.ts
@@ -15,8 +15,8 @@ export default class AppOauthGenerateCommand extends InputOutputAPICommand<AppOA
 		required: true,
 	}]
 
-	protected primaryKeyName(): string { return 'appId' }
-	protected sortKeyName(): string { return 'displayName' }
+	protected primaryKeyName = 'appId'
+	protected sortKeyName = 'displayName'
 
 	protected buildTableOutput(appOAuthResponse: AppOAuthResponse): string {
 		const table = buildTableForOutput(this, appOAuthResponse)

--- a/packages/cli/src/commands/apps/oauth/update.ts
+++ b/packages/cli/src/commands/apps/oauth/update.ts
@@ -16,8 +16,8 @@ export default class AppOauthUpdateCommand extends InputOutputAPICommand<AppOAut
 		required: true,
 	}]
 
-	protected primaryKeyName(): string { return 'appId' }
-	protected sortKeyName(): string { return 'displayName' }
+	protected primaryKeyName = 'appId'
+	protected sortKeyName = 'displayName'
 
 	protected buildTableOutput(appOAuth: AppOAuth): string {
 		const table = buildTableForOutput(this, appOAuth)

--- a/packages/cli/src/commands/apps/register.ts
+++ b/packages/cli/src/commands/apps/register.ts
@@ -12,8 +12,8 @@ export default class AppRegisterCommand extends SimpleAPICommand {
 		required: true,
 	}]
 
-	protected primaryKeyName(): string { return 'appId' }
-	protected sortKeyName(): string { return 'displayName' }
+	protected primaryKeyName = 'appId'
+	protected sortKeyName = 'displayName'
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(AppRegisterCommand)

--- a/packages/cli/src/commands/apps/settings.ts
+++ b/packages/cli/src/commands/apps/settings.ts
@@ -1,11 +1,11 @@
 import { App, AppSettings } from '@smartthings/core-sdk'
-import { ListableObjectOutputCommand } from '@smartthings/cli-lib'
+import { ListingOutputAPICommand } from '@smartthings/cli-lib'
 
 
-export default class AppSettingsCommand extends ListableObjectOutputCommand<AppSettings, App> {
+export default class AppSettingsCommand extends ListingOutputAPICommand<AppSettings, App> {
 	static description = 'get OAuth settings of the app'
 
-	static flags = ListableObjectOutputCommand.flags
+	static flags = ListingOutputAPICommand.flags
 
 	static args = [{
 		name: 'id',
@@ -13,8 +13,8 @@ export default class AppSettingsCommand extends ListableObjectOutputCommand<AppS
 		required: true,
 	}]
 
-	protected primaryKeyName(): string { return 'appId' }
-	protected sortKeyName(): string { return 'displayName' }
+	protected primaryKeyName = 'appId'
+	protected sortKeyName = 'displayName'
 	protected buildObjectTableOutput(data: AppSettings): string {
 		const table = this.newOutputTable({head: ['name','value']})
 		if (data.settings) {

--- a/packages/cli/src/commands/apps/update.ts
+++ b/packages/cli/src/commands/apps/update.ts
@@ -15,8 +15,8 @@ export default class AppUpdateCommand extends InputOutputAPICommand<AppRequest, 
 		required: true,
 	}]
 
-	protected primaryKeyName(): string { return 'appId' }
-	protected sortKeyName(): string { return 'displayName' }
+	protected primaryKeyName = 'appId'
+	protected sortKeyName = 'displayName'
 
 	protected buildTableOutput(app: App): string {
 		return buildTableOutput(this, app)

--- a/packages/cli/src/commands/capabilities/create.ts
+++ b/packages/cli/src/commands/capabilities/create.ts
@@ -26,9 +26,7 @@ export default class CapabilitiesCreate extends InputOutputAPICommand<Capability
 
 	static flags = InputOutputAPICommand.flags
 
-	protected buildTableOutput(capability: Capability): string {
-		return buildTableOutput(capability)
-	}
+	protected buildTableOutput = buildTableOutput
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(CapabilitiesCreate)

--- a/packages/cli/src/commands/capabilities/list-standard.ts
+++ b/packages/cli/src/commands/capabilities/list-standard.ts
@@ -1,7 +1,8 @@
+import { CapabilitySummary } from '@smartthings/core-sdk'
+
 import { OutputAPICommand } from '@smartthings/cli-lib'
 
-import { buildTableOutput } from './list'
-import { CapabilitySummary } from '@smartthings/core-sdk'
+import { buildListTableOutput } from '../capabilities'
 
 
 export default class CapabilitiesListStandard extends OutputAPICommand<CapabilitySummary[]> {
@@ -9,9 +10,7 @@ export default class CapabilitiesListStandard extends OutputAPICommand<Capabilit
 
 	static flags = OutputAPICommand.flags
 
-	protected buildTableOutput(capabilities: CapabilitySummary[]): string {
-		return buildTableOutput(capabilities)
-	}
+	protected buildTableOutput = buildListTableOutput
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(CapabilitiesListStandard)

--- a/packages/cli/src/commands/capabilities/list.ts
+++ b/packages/cli/src/commands/capabilities/list.ts
@@ -1,22 +1,10 @@
-import Table from 'cli-table'
-
-import { CapabilitySummary } from '@smartthings/core-sdk'
-
 import { OutputAPICommand } from '@smartthings/cli-lib'
 
+import { buildListTableOutput, getCustomByNamespace, CapabilitySummaryWithNamespace } from '../capabilities'
 
-export function buildTableOutput(capabilities: CapabilitySummary[]): string {
-	const table = new Table({
-		head: ['Capability', 'Version', 'Status'],
-		colWidths: [80, 10, 10],
-	})
-	for (const capability of capabilities) {
-		table.push([capability.id, capability.version, capability.status || ''])
-	}
-	return table.toString()
-}
 
-export default class CapabilitiesList extends OutputAPICommand<({ namespace: string } & CapabilitySummary)[]> {
+// TODO: update to new style
+export default class CapabilitiesList extends OutputAPICommand<CapabilitySummaryWithNamespace[]> {
 	static description = 'list all capabilities currently available in a user account'
 
 	static flags = OutputAPICommand.flags
@@ -28,35 +16,14 @@ export default class CapabilitiesList extends OutputAPICommand<({ namespace: str
 		},
 	]
 
-	protected buildTableOutput(capabilities: ({ namespace: string } & CapabilitySummary)[]): string {
-		return buildTableOutput(capabilities)
-	}
+	getCustomByNamespace = getCustomByNamespace
+
+	protected buildTableOutput = buildListTableOutput
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(CapabilitiesList)
 		await super.setup(args, argv, flags)
 
-		this.processNormally(async () => {
-			let namespaces: string[] = []
-			if (args.namespace) {
-				this.log(`namespace specified: ${args.namespace}`)
-				namespaces = [args.namespace]
-			} else {
-				namespaces = (await this.client.capabilities.listNamespaces()).map(ns => ns.name)
-			}
-
-			if (!namespaces || namespaces.length == 0) {
-				this.log('could not find any namespaces for you account. Perhaps ' +
-					"you haven't created any capabilities yet.")
-				this.exit(1)
-			}
-
-			let capabilities: ({ namespace: string } & CapabilitySummary)[] = []
-			for (const namespace of namespaces) {
-				const caps = await this.client.capabilities.list(namespace)
-				capabilities = capabilities.concat(caps.map(capability => { return { ...capability, namespace } }))
-			}
-			return capabilities
-		})
+		this.processNormally(async () => this.getCustomByNamespace(args.namespace))
 	}
 }

--- a/packages/cli/src/commands/capabilities/update.ts
+++ b/packages/cli/src/commands/capabilities/update.ts
@@ -11,9 +11,7 @@ export default class CapabilitiesUpdate extends InputOutputAPICommand<Capability
 
 	static args = capabilityIdInputArgs
 
-	protected buildTableOutput(capability: Capability): string {
-		return buildTableOutput(capability)
-	}
+	protected buildTableOutput = buildTableOutput
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(CapabilitiesUpdate)

--- a/packages/cli/src/commands/deviceprofiles.ts
+++ b/packages/cli/src/commands/deviceprofiles.ts
@@ -1,6 +1,6 @@
 import { DeviceProfile } from '@smartthings/core-sdk'
 
-import { ListableObjectOutputCommand, TableGenerator } from '@smartthings/cli-lib'
+import { ListingOutputAPICommand, TableGenerator } from '@smartthings/cli-lib'
 
 
 export function buildTableOutput(tableGenerator: TableGenerator, data: DeviceProfile): string {
@@ -18,10 +18,10 @@ export function buildTableOutput(tableGenerator: TableGenerator, data: DevicePro
 	return table.toString()
 }
 
-export default class DeviceProfilesList extends ListableObjectOutputCommand<DeviceProfile, DeviceProfile> {
+export default class DeviceProfilesList extends ListingOutputAPICommand<DeviceProfile, DeviceProfile> {
 	static description = 'list all device profiles available in a user account or retrieve a single profile'
 
-	static flags = ListableObjectOutputCommand.flags
+	static flags = ListingOutputAPICommand.flags
 
 	static args = [{
 		name: 'id',
@@ -38,8 +38,10 @@ export default class DeviceProfilesList extends ListableObjectOutputCommand<Devi
 		'$ smartthings deviceprofiles 4 -j -o profile.json # write the profile to the file "profile.json"',
 	]
 
-	protected primaryKeyName(): string { return 'id' }
-	protected sortKeyName(): string { return 'name' }
+	static aliases = ['device-profiles']
+
+	protected primaryKeyName = 'id'
+	protected sortKeyName = 'name'
 	protected tableHeadings(): string[] { return ['name', 'status', 'id'] }
 
 	protected buildObjectTableOutput(deviceProfile: DeviceProfile): string {

--- a/packages/cli/src/commands/deviceprofiles/delete.ts
+++ b/packages/cli/src/commands/deviceprofiles/delete.ts
@@ -1,19 +1,20 @@
-import { SimpleAPICommand } from '@smartthings/cli-lib'
+import { DeviceProfile } from '@smartthings/core-sdk'
+
+import { StringSelectingInputAPICommand } from '@smartthings/cli-lib'
 
 
-export default class DeviceProfileDeleteCommand extends SimpleAPICommand {
+export default class DeviceProfileDeleteCommand extends StringSelectingInputAPICommand<DeviceProfile> {
 	static description = 'delete a device profile'
 
-	static flags = SimpleAPICommand.flags
+	static flags = StringSelectingInputAPICommand.flags
 
 	static args = [{
 		name: 'id',
 		description: 'Device profile UUID or number in the list',
-		required: true,
 	}]
 
-	protected primaryKeyName(): string { return 'id' }
-	protected sortKeyName(): string { return 'name' }
+	protected primaryKeyName = 'id'
+	protected sortKeyName = 'name'
 
 	static examples = [
 		'$ smartthings deviceprofiles:delete 63b8c91e-9686-4c43-9afb-fbd9f77e3bb0  # delete profile with this UUID',
@@ -24,7 +25,9 @@ export default class DeviceProfileDeleteCommand extends SimpleAPICommand {
 		const { args, argv, flags } = this.parse(DeviceProfileDeleteCommand)
 		await super.setup(args, argv, flags)
 
-		this.processNormally(`device profile ${args.id}} deleted`,
-			async () => { await this.client.deviceProfiles.delete(args.id) })
+		this.processNormally(args.id,
+			async () => await this.client.deviceProfiles.list(),
+			async (id) => { await this.client.deviceProfiles.delete(id) },
+			'device profile {{id}} deleted')
 	}
 }

--- a/packages/cli/src/commands/deviceprofiles/publish.ts
+++ b/packages/cli/src/commands/deviceprofiles/publish.ts
@@ -15,8 +15,8 @@ export default class DeviceProfilePublishCommand extends OutputAPICommand<Device
 		required: true,
 	}]
 
-	protected primaryKeyName(): string { return 'id' }
-	protected sortKeyName(): string { return 'name' }
+	protected primaryKeyName = 'id'
+	protected sortKeyName = 'name'
 
 	static examples = [
 		'$ smartthings deviceprofiles:publish 63b8c91e-9686-4c43-9afb-fbd9f77e3bb0  # publish the profile with this UUID',

--- a/packages/cli/src/commands/deviceprofiles/update.ts
+++ b/packages/cli/src/commands/deviceprofiles/update.ts
@@ -15,8 +15,8 @@ export default class DeviceProfileUpdateCommand extends InputOutputAPICommand<De
 		required: true,
 	}]
 
-	protected primaryKeyName(): string { return 'id' }
-	protected sortKeyName(): string { return 'name' }
+	protected primaryKeyName = 'id'
+	protected sortKeyName = 'name'
 
 	protected buildTableOutput(deviceProfile: DeviceProfile): string {
 		return buildTableOutput(this, deviceProfile)

--- a/packages/cli/src/commands/devices.ts
+++ b/packages/cli/src/commands/devices.ts
@@ -1,7 +1,7 @@
 import { APICommand } from '@smartthings/cli-lib'
 
 
-export default class Devices extends APICommand {
+export default class DevicesCommand extends APICommand {
 	static description = "get device's description"
 
 	static flags = APICommand.flags
@@ -13,7 +13,7 @@ export default class Devices extends APICommand {
 	}]
 
 	async run(): Promise<void> {
-		const { args, argv, flags } = this.parse(Devices)
+		const { args, argv, flags } = this.parse(DevicesCommand)
 		await super.setup(args, argv, flags)
 
 		this.client.devices.get(args.id).then(async device => {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -29,7 +29,7 @@
 	"devDependencies": {
 		"@types/express": "^4.17.6",
 		"@types/qs": "^6.9.1",
-		"typescript": "^3.8.3"
+		"typescript": "^3.9.3"
 	},
 	"scripts": {
 		"lint": "eslint --ext ts src",

--- a/packages/lib/src/api-command.ts
+++ b/packages/lib/src/api-command.ts
@@ -9,7 +9,8 @@ import { LoginAuthenticator, defaultClientIdProvider } from './login-authenticat
 
 
 /**
- * Base class for Rest API commands.
+ * Base class for commands that need to use Rest API commands via the
+ * SmartThings Core SDK.
  */
 export abstract class APICommand extends SmartThingsCommand {
 	static flags = {
@@ -56,6 +57,10 @@ export abstract class APICommand extends SmartThingsCommand {
 	}
 }
 
+/**
+ * TODO: most or all classes that use this should be updated soon to use
+ * `StringSelectingInputAPICommand` (or in a few cases `SelectingInputAPICommand`).
+ */
 export abstract class SimpleAPICommand extends APICommand {
 	/**
 	 * This is just a convenience method that outputs a simple string message

--- a/packages/lib/src/login-authenticator.ts
+++ b/packages/lib/src/login-authenticator.ts
@@ -22,15 +22,28 @@ export const defaultClientIdProvider: ClientIdProvider = {
 	...defaultSmartThingsURLProvider,
 	baseOAuthInURL: 'https://oauthin-regional.api.smartthings.com/oauth',
 	oauthAuthTokenRefreshURL: 'https://auth-global.api.smartthings.com/oauth/token',
-	clientId: 'none yet',
+	clientId: 'd18cf96e-c626-4433-bf51-ddbb10c5d1ed',
 }
 
 // All the scopes the clientId we are using is configured to use.
 const scopes = [
 	'r:devices:*',
+	// 'l:devices',
 	'w:devices:*',
+	'x:devices:*',
+
 	'r:locations:*',
 	'w:locations:*',
+	'x:locations:*',
+
+	// 'r:customcapability',
+	// 'w:customcapability',
+
+	'r:deviceprofiles',
+	// 'w:deviceprofiles',
+
+	// 'r:apps:*',
+	// 'w:apps:*',
 ]
 const postConfig = {
 	headers: {
@@ -189,9 +202,10 @@ export class LoginAuthenticator implements Authenticator {
 
 		const startTime = Date.now()
 		const maxDelay = 10 * 60 * 1000 // wait up to ten minutes for login
-		return new Promise((resolve, reject) => {
+		// eslint-disable-next-line no-async-promise-executor
+		return new Promise(async (resolve, reject) => {
 			while (!this.authenticationInfo && Date.now() < startTime + maxDelay) {
-				this.delay(1000)
+				await this.delay(1000)
 			}
 			server.close((err) => {
 				if (err) {

--- a/packages/lib/src/smartthings-command.ts
+++ b/packages/lib/src/smartthings-command.ts
@@ -104,7 +104,7 @@ export interface TableGenerator {
 }
 
 /**
- * The base class for all commands.
+ * The base class for all commands in the SmartThings CLI.
  */
 export abstract class SmartThingsCommand extends Command implements TableGenerator {
 	static flags = {
@@ -163,7 +163,6 @@ export abstract class SmartThingsCommand extends Command implements TableGenerat
 
 		this._profileName = flags.profile || 'default'
 		this._profileConfig = cliConfig.getProfile(flags.profile)
-
 	}
 
 	newOutputTable(options?: Partial<TableOptions>): Table {

--- a/packages/testlib/package.json
+++ b/packages/testlib/package.json
@@ -22,7 +22,7 @@
 		"node": "^12.16.2"
 	},
 	"devDependencies": {
-		"typescript": "^3.8.3"
+		"typescript": "^3.9.3"
 	},
 	"scripts": {
 		"lint": "eslint --ext ts src",


### PR DESCRIPTION
* Use "Listing" instead of "Listable" for command classes that list things.
* Updated TypeScript to 3.9.3.
* Made `primaryKeyName` and `sortKeyName` properties instead of functions.
* Started using functions with "this" methods that can be added directly to the class where shared functions are used.
* added "device-profiles" alias for "deviceprofiles" command
* Added new `SelectingInputAPICommand` class for commands that can ask the user to choose from a list of items to take an action on.
* updated deviceprofiles:delete command to use this new class
* Started work on making capabilities use the new structure...this is a little more complicated because the ids aren't simple strings like most everything else.
* fixed bug in PKCE auth flow (recently introduced) and added PROD client id (system still doesn't work for many scopes so those are commented out)