### PR TITLE
update locations:delete 

### DIFF
--- a/packages/cli/src/commands/locations/delete.ts
+++ b/packages/cli/src/commands/locations/delete.ts
@@ -1,25 +1,28 @@
-import { APICommand } from '@smartthings/cli-lib'
+import { LocationItem } from '@smartthings/core-sdk'
+
+import { StringSelectingInputAPICommand } from '@smartthings/cli-lib'
 
 
-export default class LocationsDelete extends APICommand {
+export default class LocationsDeleteCommand extends StringSelectingInputAPICommand<LocationItem> {
 	static description = 'delete a location'
 
-	static flags = APICommand.flags
+	static flags = StringSelectingInputAPICommand.flags
 
 	static args = [{
 		name: 'id',
-		description: 'the location id',
-		required: true,
+		description: 'location UUID or number in the list',
 	}]
 
+	protected primaryKeyName = 'locationId'
+	protected sortKeyName = 'name'
+
 	async run(): Promise<void> {
-		const { args, argv, flags } = this.parse(LocationsDelete)
+		const { args, argv, flags } = this.parse(LocationsDeleteCommand)
 		await super.setup(args, argv, flags)
 
-		this.client.locations.delete(args.id).then(async () => {
-			this.log(`location ${args.id} deleted`)
-		}).catch(err => {
-			this.log(`caught error ${err}`)
-		})
+		this.processNormally(args.id,
+			async () => await this.client.locations.list(),
+			async (id) => { await this.client.locations.delete(id) },
+			'location {{id}} deleted')
 	}
 }


### PR DESCRIPTION
I updated the locations:delete command to be able to delete from a list when no id is included. Users can now call locations:delete and delete locations with an index from the list or with a specific location id. 