### PR TITLE
create devices:delete command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -71,6 +71,7 @@ USAGE
 * [`smartthings devices:capabilities-status ID COMPONENTID CAPABILITYID`](#smartthings-devicescapabilities-status-id-componentid-capabilityid)
 * [`smartthings devices:commands ID`](#smartthings-devicescommands-id)
 * [`smartthings devices:components-status ID COMPONENTID`](#smartthings-devicescomponents-status-id-componentid)
+* [`smartthings devices:delete [ID]`](#smartthings-devicesdelete-id)
 * [`smartthings devices:list`](#smartthings-deviceslist)
 * [`smartthings devices:status ID`](#smartthings-devicesstatus-id)
 * [`smartthings generate:java`](#smartthings-generatejava)
@@ -853,6 +854,31 @@ OPTIONS
 ```
 
 _See code: [dist/commands/devices/components-status.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/devices/components-status.ts)_
+
+## `smartthings devices:delete [ID]`
+
+delete a device
+
+```
+USAGE
+  $ smartthings devices:delete [ID]
+
+ARGUMENTS
+  ID  device UUID
+
+OPTIONS
+  -h, --help             show CLI help
+  -j, --json             use JSON format of input and/or output
+  -o, --output=output    specify output file
+  -p, --profile=profile  [default: default] configuration profile
+  -t, --token=token      the auth token to use
+  -y, --yaml             use YAML format of input and/or output
+  --compact              use compact table format with no lines between body rows
+  --expanded             use expanded table format with a line between each body row
+  --indent=indent        specify indentation for formatting JSON or YAML output
+```
+
+_See code: [dist/commands/devices/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/devices/delete.ts)_
 
 ## `smartthings devices:list`
 

--- a/packages/cli/src/commands/devices/delete.ts
+++ b/packages/cli/src/commands/devices/delete.ts
@@ -1,0 +1,28 @@
+import { Device } from '@smartthings/core-sdk'
+
+import { StringSelectingInputAPICommand } from '@smartthings/cli-lib'
+
+
+export default class DeviceDeleteCommand extends StringSelectingInputAPICommand<Device> {
+	static description = 'delete a device'
+
+	static flags = StringSelectingInputAPICommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'device UUID',
+	}]
+
+	protected primaryKeyName = 'deviceId'
+	protected sortKeyName = 'name'
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(DeviceDeleteCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(args.id,
+			async () => await this.client.devices.list(),
+			async (id) => { await this.client.devices.delete(id) },
+			'device {{id}} deleted')
+	}
+}


### PR DESCRIPTION
I created the devices:delete command to be able to delete from a list when no id is included. Users can now call devices:delete and delete devices with an index from the list or with a specific device id.