### PR TITLE
update capabilities:delete to match new standards

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -43,7 +43,7 @@ USAGE
 * [`smartthings apps [ID]`](#smartthings-apps-id)
 * [`smartthings apps:create`](#smartthings-appscreate)
 * [`smartthings apps:delete [ID]`](#smartthings-appsdelete-id)
-* [`smartthings apps:oauth ID`](#smartthings-appsoauth-id)
+* [`smartthings apps:oauth [ID]`](#smartthings-appsoauth-id)
 * [`smartthings apps:oauth:generate ID`](#smartthings-appsoauthgenerate-id)
 * [`smartthings apps:oauth:update ID`](#smartthings-appsoauthupdate-id)
 * [`smartthings apps:register ID`](#smartthings-appsregister-id)
@@ -51,16 +51,16 @@ USAGE
 * [`smartthings apps:settings:update ID`](#smartthings-appssettingsupdate-id)
 * [`smartthings apps:update ID`](#smartthings-appsupdate-id)
 * [`smartthings autocomplete [SHELL]`](#smartthings-autocomplete-shell)
-* [`smartthings capabilities ID VERSION`](#smartthings-capabilities-id-version)
+* [`smartthings capabilities [ID] [VERSION]`](#smartthings-capabilities-id-version)
 * [`smartthings capabilities:create`](#smartthings-capabilitiescreate)
-* [`smartthings capabilities:delete ID VERSION`](#smartthings-capabilitiesdelete-id-version)
+* [`smartthings capabilities:delete [ID] [VERSION]`](#smartthings-capabilitiesdelete-id-version)
 * [`smartthings capabilities:list [NAMESPACE]`](#smartthings-capabilitieslist-namespace)
 * [`smartthings capabilities:list-namespaces`](#smartthings-capabilitieslist-namespaces)
 * [`smartthings capabilities:list-standard`](#smartthings-capabilitieslist-standard)
-* [`smartthings capabilities:presentation ID VERSION`](#smartthings-capabilitiespresentation-id-version)
-* [`smartthings capabilities:presentation:create ID VERSION`](#smartthings-capabilitiespresentationcreate-id-version)
-* [`smartthings capabilities:presentation:update ID VERSION`](#smartthings-capabilitiespresentationupdate-id-version)
-* [`smartthings capabilities:update ID VERSION`](#smartthings-capabilitiesupdate-id-version)
+* [`smartthings capabilities:presentation [ID] [VERSION]`](#smartthings-capabilitiespresentation-id-version)
+* [`smartthings capabilities:presentation:create [ID] [VERSION]`](#smartthings-capabilitiespresentationcreate-id-version)
+* [`smartthings capabilities:presentation:update [ID] [VERSION]`](#smartthings-capabilitiespresentationupdate-id-version)
+* [`smartthings capabilities:update [ID] [VERSION]`](#smartthings-capabilitiesupdate-id-version)
 * [`smartthings config [FILE]`](#smartthings-config-file)
 * [`smartthings deviceprofiles [ID]`](#smartthings-deviceprofiles-id)
 * [`smartthings deviceprofiles:create`](#smartthings-deviceprofilescreate)
@@ -161,16 +161,16 @@ OPTIONS
 
 _See code: [dist/commands/apps/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/apps/delete.ts)_
 
-## `smartthings apps:oauth ID`
+## `smartthings apps:oauth [ID]`
 
 get OAuth settings of the app
 
 ```
 USAGE
-  $ smartthings apps:oauth ID
+  $ smartthings apps:oauth [ID]
 
 ARGUMENTS
-  ID  the app id
+  ID  the app id or number in the list
 
 OPTIONS
   -h, --help             show CLI help
@@ -361,28 +361,29 @@ EXAMPLES
 
 _See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v0.1.5/src/commands/autocomplete/index.ts)_
 
-## `smartthings capabilities ID VERSION`
+## `smartthings capabilities [ID] [VERSION]`
 
 get a specific capability
 
 ```
 USAGE
-  $ smartthings capabilities ID VERSION
+  $ smartthings capabilities [ID] [VERSION]
 
 ARGUMENTS
-  ID       the capability id
+  ID       the capability id number in list
   VERSION  the capability version
 
 OPTIONS
-  -h, --help             show CLI help
-  -j, --json             use JSON format of input and/or output
-  -o, --output=output    specify output file
-  -p, --profile=profile  [default: default] configuration profile
-  -t, --token=token      the auth token to use
-  -y, --yaml             use YAML format of input and/or output
-  --compact              use compact table format with no lines between body rows
-  --expanded             use expanded table format with a line between each body row
-  --indent=indent        specify indentation for formatting JSON or YAML output
+  -h, --help                 show CLI help
+  -j, --json                 use JSON format of input and/or output
+  -n, --namespace=namespace  a specific namespace to query; will use all by default
+  -o, --output=output        specify output file
+  -p, --profile=profile      [default: default] configuration profile
+  -t, --token=token          the auth token to use
+  -y, --yaml                 use YAML format of input and/or output
+  --compact                  use compact table format with no lines between body rows
+  --expanded                 use expanded table format with a line between each body row
+  --indent=indent            specify indentation for formatting JSON or YAML output
 ```
 
 _See code: [dist/commands/capabilities.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/capabilities.ts)_
@@ -411,13 +412,13 @@ OPTIONS
 
 _See code: [dist/commands/capabilities/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/capabilities/create.ts)_
 
-## `smartthings capabilities:delete ID VERSION`
+## `smartthings capabilities:delete [ID] [VERSION]`
 
 delete a capability
 
 ```
 USAGE
-  $ smartthings capabilities:delete ID VERSION
+  $ smartthings capabilities:delete [ID] [VERSION]
 
 ARGUMENTS
   ID       the capability id
@@ -425,8 +426,14 @@ ARGUMENTS
 
 OPTIONS
   -h, --help             show CLI help
+  -j, --json             use JSON format of input and/or output
+  -o, --output=output    specify output file
   -p, --profile=profile  [default: default] configuration profile
   -t, --token=token      the auth token to use
+  -y, --yaml             use YAML format of input and/or output
+  --compact              use compact table format with no lines between body rows
+  --expanded             use expanded table format with a line between each body row
+  --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
 _See code: [dist/commands/capabilities/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/capabilities/delete.ts)_
@@ -500,39 +507,40 @@ OPTIONS
 
 _See code: [dist/commands/capabilities/list-standard.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/capabilities/list-standard.ts)_
 
-## `smartthings capabilities:presentation ID VERSION`
+## `smartthings capabilities:presentation [ID] [VERSION]`
 
 get presentation information for a specific capability
 
 ```
 USAGE
-  $ smartthings capabilities:presentation ID VERSION
+  $ smartthings capabilities:presentation [ID] [VERSION]
 
 ARGUMENTS
-  ID       the capability id
+  ID       the capability id or number in list
   VERSION  the capability version
 
 OPTIONS
-  -h, --help             show CLI help
-  -j, --json             use JSON format of input and/or output
-  -o, --output=output    specify output file
-  -p, --profile=profile  [default: default] configuration profile
-  -t, --token=token      the auth token to use
-  -y, --yaml             use YAML format of input and/or output
-  --compact              use compact table format with no lines between body rows
-  --expanded             use expanded table format with a line between each body row
-  --indent=indent        specify indentation for formatting JSON or YAML output
+  -h, --help                 show CLI help
+  -j, --json                 use JSON format of input and/or output
+  -n, --namespace=namespace  a specific namespace to query; will use all by default
+  -o, --output=output        specify output file
+  -p, --profile=profile      [default: default] configuration profile
+  -t, --token=token          the auth token to use
+  -y, --yaml                 use YAML format of input and/or output
+  --compact                  use compact table format with no lines between body rows
+  --expanded                 use expanded table format with a line between each body row
+  --indent=indent            specify indentation for formatting JSON or YAML output
 ```
 
 _See code: [dist/commands/capabilities/presentation.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/capabilities/presentation.ts)_
 
-## `smartthings capabilities:presentation:create ID VERSION`
+## `smartthings capabilities:presentation:create [ID] [VERSION]`
 
 create presentation model for a capability
 
 ```
 USAGE
-  $ smartthings capabilities:presentation:create ID VERSION
+  $ smartthings capabilities:presentation:create [ID] [VERSION]
 
 ARGUMENTS
   ID       the capability id
@@ -554,13 +562,13 @@ OPTIONS
 
 _See code: [dist/commands/capabilities/presentation/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/capabilities/presentation/create.ts)_
 
-## `smartthings capabilities:presentation:update ID VERSION`
+## `smartthings capabilities:presentation:update [ID] [VERSION]`
 
 update presentation model for a capability
 
 ```
 USAGE
-  $ smartthings capabilities:presentation:update ID VERSION
+  $ smartthings capabilities:presentation:update [ID] [VERSION]
 
 ARGUMENTS
   ID       the capability id
@@ -582,22 +590,20 @@ OPTIONS
 
 _See code: [dist/commands/capabilities/presentation/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/capabilities/presentation/update.ts)_
 
-## `smartthings capabilities:update ID VERSION`
+## `smartthings capabilities:update [ID] [VERSION]`
 
 update a capability
 
 ```
 USAGE
-  $ smartthings capabilities:update ID VERSION
+  $ smartthings capabilities:update [ID] [VERSION]
 
 ARGUMENTS
   ID       the capability id
   VERSION  the capability version
 
 OPTIONS
-  -d, --dry-run          produce JSON but don't actually submit
   -h, --help             show CLI help
-  -i, --input=input      specify input file
   -j, --json             use JSON format of input and/or output
   -o, --output=output    specify output file
   -p, --profile=profile  [default: default] configuration profile
@@ -635,7 +641,7 @@ USAGE
   $ smartthings deviceprofiles [ID]
 
 ARGUMENTS
-  ID  Device profile to retrieve. Can be a UUID or the number of the profile in the list
+  ID  device profile to retrieve; UUID or the number of the profile from list
 
 OPTIONS
   -h, --help             show CLI help
@@ -757,7 +763,7 @@ USAGE
   $ smartthings deviceprofiles:update ID
 
 ARGUMENTS
-  ID  Device profile UUID or number in the list
+  ID  device profile UUID or number in the list
 
 OPTIONS
   -d, --dry-run          produce JSON but don't actually submit

--- a/packages/cli/src/commands/apps.ts
+++ b/packages/cli/src/commands/apps.ts
@@ -61,8 +61,8 @@ export default class AppsList extends ListingOutputAPICommand<App, App> {
 		required: false,
 	}]
 
-	protected primaryKeyName = 'appId'
-	protected sortKeyName = 'displayName'
+	primaryKeyName = 'appId'
+	sortKeyName = 'displayName'
 	protected tableHeadings(): string[] {
 		if (this.flags.verbose) {
 			return ['displayName', 'appType', 'appId', 'ARN/URL']

--- a/packages/cli/src/commands/apps/delete.ts
+++ b/packages/cli/src/commands/apps/delete.ts
@@ -1,20 +1,20 @@
 import { App } from '@smartthings/core-sdk'
 
-import { StringSelectingInputAPICommand } from '@smartthings/cli-lib'
+import { SelectingInputAPICommand } from '@smartthings/cli-lib'
 
 
-export default class AppDeleteCommand extends StringSelectingInputAPICommand<App> {
+export default class AppDeleteCommand extends SelectingInputAPICommand<App> {
 	static description = 'delete the app'
 
-	static flags = StringSelectingInputAPICommand.flags
+	static flags = SelectingInputAPICommand.flags
 
 	static args = [{
 		name: 'id',
 		description: 'App profile UUID or number in the list',
 	}]
 
-	protected primaryKeyName = 'appId'
-	protected sortKeyName = 'displayName'
+	primaryKeyName = 'appId'
+	sortKeyName = 'displayName'
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(AppDeleteCommand)

--- a/packages/cli/src/commands/apps/oauth.ts
+++ b/packages/cli/src/commands/apps/oauth.ts
@@ -1,34 +1,35 @@
 import Table from 'cli-table'
 
-import { AppOAuth } from '@smartthings/core-sdk'
+import { App, AppOAuth } from '@smartthings/core-sdk'
 
-import { OutputAPICommand, TableGenerator } from '@smartthings/cli-lib'
+import { APICommand, OutputAPICommand, ListingOutputAPICommand } from '@smartthings/cli-lib'
 
 
-export function buildTableForOutput(tableGenerator: TableGenerator, appOAuth: AppOAuth): Table {
-	const table = tableGenerator.newOutputTable()
+export function buildTableForOutput(this: APICommand, appOAuth: AppOAuth): Table {
+	const table = this.newOutputTable()
 	table.push(['Client Name', appOAuth.clientName])
 	table.push(['Scope', appOAuth.scope])
 	table.push(['Redirect URIs', appOAuth.redirectUris])
 	return table
 }
 
-export default class AppOauthCommand extends OutputAPICommand<AppOAuth> {
+export default class AppOauthCommand extends ListingOutputAPICommand<AppOAuth, App> {
 	static description = 'get OAuth settings of the app'
 
 	static flags = OutputAPICommand.flags
 
 	static args = [{
 		name: 'id',
-		description: 'the app id',
-		required: true,
+		description: 'the app id or number in the list',
 	}]
 
-	protected primaryKeyName = 'appId'
-	protected sortKeyName = 'displayName'
+	primaryKeyName = 'appId'
+	sortKeyName = 'displayName'
 
-	protected buildTableOutput(appOAuth: AppOAuth): string {
-		const table = buildTableForOutput(this, appOAuth)
+	protected buildTableForOutput = buildTableForOutput
+
+	protected buildObjectTableOutput(appOAuth: AppOAuth): string {
+		const table = this.buildTableForOutput(appOAuth)
 		return table.toString()
 	}
 
@@ -36,6 +37,10 @@ export default class AppOauthCommand extends OutputAPICommand<AppOAuth> {
 		const { args, argv, flags } = this.parse(AppOauthCommand)
 		await super.setup(args, argv, flags)
 
-		this.processNormally(() => { return this.client.apps.getOauth(args.id) })
+		this.processNormally(
+			args.id,
+			() => this.client.apps.list(),
+			(id) => this.client.apps.getOauth(id),
+		)
 	}
 }

--- a/packages/cli/src/commands/apps/oauth/generate.ts
+++ b/packages/cli/src/commands/apps/oauth/generate.ts
@@ -15,11 +15,13 @@ export default class AppOauthGenerateCommand extends InputOutputAPICommand<AppOA
 		required: true,
 	}]
 
-	protected primaryKeyName = 'appId'
-	protected sortKeyName = 'displayName'
+	primaryKeyName = 'appId'
+	sortKeyName = 'displayName'
+
+	protected buildTableForOutput = buildTableForOutput
 
 	protected buildTableOutput(appOAuthResponse: AppOAuthResponse): string {
-		const table = buildTableForOutput(this, appOAuthResponse)
+		const table = this.buildTableForOutput(appOAuthResponse)
 		table.push(['Client Id', appOAuthResponse.oauthClientId])
 		table.push(['Client Secret', appOAuthResponse.oauthClientSecret])
 		return table.toString()

--- a/packages/cli/src/commands/apps/oauth/update.ts
+++ b/packages/cli/src/commands/apps/oauth/update.ts
@@ -16,11 +16,13 @@ export default class AppOauthUpdateCommand extends InputOutputAPICommand<AppOAut
 		required: true,
 	}]
 
-	protected primaryKeyName = 'appId'
-	protected sortKeyName = 'displayName'
+	primaryKeyName = 'appId'
+	sortKeyName = 'displayName'
+
+	protected buildTableForOutput = buildTableForOutput
 
 	protected buildTableOutput(appOAuth: AppOAuth): string {
-		const table = buildTableForOutput(this, appOAuth)
+		const table = this.buildTableForOutput(appOAuth)
 		return table.toString()
 	}
 

--- a/packages/cli/src/commands/apps/register.ts
+++ b/packages/cli/src/commands/apps/register.ts
@@ -12,8 +12,8 @@ export default class AppRegisterCommand extends SimpleAPICommand {
 		required: true,
 	}]
 
-	protected primaryKeyName = 'appId'
-	protected sortKeyName = 'displayName'
+	primaryKeyName = 'appId'
+	sortKeyName = 'displayName'
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(AppRegisterCommand)

--- a/packages/cli/src/commands/apps/settings.ts
+++ b/packages/cli/src/commands/apps/settings.ts
@@ -13,8 +13,8 @@ export default class AppSettingsCommand extends ListingOutputAPICommand<AppSetti
 		required: true,
 	}]
 
-	protected primaryKeyName = 'appId'
-	protected sortKeyName = 'displayName'
+	primaryKeyName = 'appId'
+	sortKeyName = 'displayName'
 	protected buildObjectTableOutput(data: AppSettings): string {
 		const table = this.newOutputTable({head: ['name','value']})
 		if (data.settings) {

--- a/packages/cli/src/commands/apps/update.ts
+++ b/packages/cli/src/commands/apps/update.ts
@@ -15,8 +15,8 @@ export default class AppUpdateCommand extends InputOutputAPICommand<AppRequest, 
 		required: true,
 	}]
 
-	protected primaryKeyName = 'appId'
-	protected sortKeyName = 'displayName'
+	primaryKeyName = 'appId'
+	sortKeyName = 'displayName'
 
 	protected buildTableOutput(app: App): string {
 		return buildTableOutput(this, app)

--- a/packages/cli/src/commands/capabilities/delete.ts
+++ b/packages/cli/src/commands/capabilities/delete.ts
@@ -1,19 +1,33 @@
-import { SimpleAPICommand } from '@smartthings/cli-lib'
-import { capabilityIdInputArgs } from '../capabilities'
+import { SelectingInputAPICommandBase } from '@smartthings/cli-lib'
+
+import { capabilityIdInputArgs, getCustomByNamespace, getIdFromUser,
+	CapabilityId, CapabilitySummaryWithNamespace } from '../capabilities'
 
 
-export default class CapabilitiesDelete extends SimpleAPICommand {
+export default class CapabilitiesDeleteCommand extends SelectingInputAPICommandBase<CapabilityId, CapabilitySummaryWithNamespace> {
 	static description = 'delete a capability'
 
-	static flags = SimpleAPICommand.flags
+	static flags = SelectingInputAPICommandBase.flags
 
 	static args = capabilityIdInputArgs
 
+	primaryKeyName = 'id'
+	sortKeyName = 'id'
+
+	protected tableHeadings(): string[] {
+		return ['id', 'version']
+	}
+
+	private getCustomByNamespace = getCustomByNamespace
+	protected getIdFromUser = getIdFromUser
+
 	async run(): Promise<void> {
-		const { args, argv, flags } = this.parse(CapabilitiesDelete)
+		const { args, argv, flags } = this.parse(CapabilitiesDeleteCommand)
 		await super.setup(args, argv, flags)
 
-		this.processNormally(`capability ${args.id}, version ${args.version} deleted`,
-			async () => { this.client.capabilities.delete(args.id, args.version)})
+		this.processNormally(args.id,
+			async () => this.getCustomByNamespace(),
+			async (id) => { this.client.capabilities.delete(id.id, id.version)},
+			'capability {{id}} deleted')
 	}
 }

--- a/packages/cli/src/commands/capabilities/presentation/update.ts
+++ b/packages/cli/src/commands/capabilities/presentation/update.ts
@@ -2,7 +2,7 @@ import { InputOutputAPICommand } from '@smartthings/cli-lib'
 import { CapabilityPresentationCreate, CapabilityPresentation } from '@smartthings/core-sdk'
 
 import { buildTableOutput } from '../presentation'
-import CapabilitiesPresentationCreate from './create'
+import { capabilityIdInputArgs } from '../../capabilities'
 
 
 export default class CapabilitiesPresentationUpdate extends InputOutputAPICommand<CapabilityPresentationCreate, CapabilityPresentation> {
@@ -10,7 +10,7 @@ export default class CapabilitiesPresentationUpdate extends InputOutputAPIComman
 
 	static flags = InputOutputAPICommand.flags
 
-	static args = CapabilitiesPresentationCreate.args
+	static args = capabilityIdInputArgs
 
 	protected buildTableOutput(presentation: CapabilityPresentation): string {
 		return buildTableOutput(presentation)

--- a/packages/cli/src/commands/deviceprofiles.ts
+++ b/packages/cli/src/commands/deviceprofiles.ts
@@ -25,7 +25,7 @@ export default class DeviceProfilesList extends ListingOutputAPICommand<DevicePr
 
 	static args = [{
 		name: 'id',
-		description: 'Device profile to retrieve. Can be a UUID or the number of the profile in the list',
+		description: 'device profile to retrieve; UUID or the number of the profile from list',
 		required: false,
 	}]
 
@@ -40,8 +40,8 @@ export default class DeviceProfilesList extends ListingOutputAPICommand<DevicePr
 
 	static aliases = ['device-profiles']
 
-	protected primaryKeyName = 'id'
-	protected sortKeyName = 'name'
+	primaryKeyName = 'id'
+	sortKeyName = 'name'
 	protected tableHeadings(): string[] { return ['name', 'status', 'id'] }
 
 	protected buildObjectTableOutput(deviceProfile: DeviceProfile): string {

--- a/packages/cli/src/commands/deviceprofiles/delete.ts
+++ b/packages/cli/src/commands/deviceprofiles/delete.ts
@@ -1,20 +1,20 @@
 import { DeviceProfile } from '@smartthings/core-sdk'
 
-import { StringSelectingInputAPICommand } from '@smartthings/cli-lib'
+import { SelectingInputAPICommand } from '@smartthings/cli-lib'
 
 
-export default class DeviceProfileDeleteCommand extends StringSelectingInputAPICommand<DeviceProfile> {
+export default class DeviceProfileDeleteCommand extends SelectingInputAPICommand<DeviceProfile> {
 	static description = 'delete a device profile'
 
-	static flags = StringSelectingInputAPICommand.flags
+	static flags = SelectingInputAPICommand.flags
 
 	static args = [{
 		name: 'id',
 		description: 'Device profile UUID or number in the list',
 	}]
 
-	protected primaryKeyName = 'id'
-	protected sortKeyName = 'name'
+	primaryKeyName = 'id'
+	sortKeyName = 'name'
 
 	static examples = [
 		'$ smartthings deviceprofiles:delete 63b8c91e-9686-4c43-9afb-fbd9f77e3bb0  # delete profile with this UUID',

--- a/packages/cli/src/commands/deviceprofiles/publish.ts
+++ b/packages/cli/src/commands/deviceprofiles/publish.ts
@@ -15,8 +15,8 @@ export default class DeviceProfilePublishCommand extends OutputAPICommand<Device
 		required: true,
 	}]
 
-	protected primaryKeyName = 'id'
-	protected sortKeyName = 'name'
+	primaryKeyName = 'id'
+	sortKeyName = 'name'
 
 	static examples = [
 		'$ smartthings deviceprofiles:publish 63b8c91e-9686-4c43-9afb-fbd9f77e3bb0  # publish the profile with this UUID',

--- a/packages/cli/src/commands/deviceprofiles/update.ts
+++ b/packages/cli/src/commands/deviceprofiles/update.ts
@@ -11,12 +11,12 @@ export default class DeviceProfileUpdateCommand extends InputOutputAPICommand<De
 
 	static args = [{
 		name: 'id',
-		description: 'Device profile UUID or number in the list',
+		description: 'device profile UUID or number in the list',
 		required: true,
 	}]
 
-	protected primaryKeyName = 'id'
-	protected sortKeyName = 'name'
+	primaryKeyName = 'id'
+	sortKeyName = 'name'
 
 	protected buildTableOutput(deviceProfile: DeviceProfile): string {
 		return buildTableOutput(this, deviceProfile)

--- a/packages/cli/src/commands/devices/delete.ts
+++ b/packages/cli/src/commands/devices/delete.ts
@@ -1,20 +1,20 @@
 import { Device } from '@smartthings/core-sdk'
 
-import { StringSelectingInputAPICommand } from '@smartthings/cli-lib'
+import { SelectingInputAPICommand } from '@smartthings/cli-lib'
 
 
-export default class DeviceDeleteCommand extends StringSelectingInputAPICommand<Device> {
+export default class DeviceDeleteCommand extends SelectingInputAPICommand<Device> {
 	static description = 'delete a device'
 
-	static flags = StringSelectingInputAPICommand.flags
+	static flags = SelectingInputAPICommand.flags
 
 	static args = [{
 		name: 'id',
 		description: 'device UUID',
 	}]
 
-	protected primaryKeyName = 'deviceId'
-	protected sortKeyName = 'name'
+	primaryKeyName = 'deviceId'
+	sortKeyName = 'name'
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(DeviceDeleteCommand)

--- a/packages/cli/src/commands/locations.ts
+++ b/packages/cli/src/commands/locations.ts
@@ -19,24 +19,24 @@ export function buildTableOutput(this: APICommand, data: Location): string {
 	return table.toString()
 }
 
-export default class Locations extends ListingOutputAPICommand<Location, LocationItem> {
+export default class LocationsCommand extends ListingOutputAPICommand<Location, LocationItem> {
 	static description = 'get a specific Location'
 
 	static flags = ListingOutputAPICommand.flags
 
 	static args = [{
 		name: 'id',
+		// TODO: fix description
 		description: 'the location id',
-		required: false,
 	}]
 
-	protected primaryKeyName = 'locationId'
-	protected sortKeyName = 'name'
+	primaryKeyName = 'locationId'
+	sortKeyName = 'name'
 
 	protected buildObjectTableOutput = buildTableOutput
 
 	async run(): Promise<void> {
-		const { args, argv, flags } = this.parse(Locations)
+		const { args, argv, flags } = this.parse(LocationsCommand)
 		await super.setup(args, argv, flags)
 
 		this.processNormally(

--- a/packages/cli/src/commands/locations/delete.ts
+++ b/packages/cli/src/commands/locations/delete.ts
@@ -1,20 +1,20 @@
 import { LocationItem } from '@smartthings/core-sdk'
 
-import { StringSelectingInputAPICommand } from '@smartthings/cli-lib'
+import { SelectingInputAPICommand } from '@smartthings/cli-lib'
 
 
-export default class LocationsDeleteCommand extends StringSelectingInputAPICommand<LocationItem> {
+export default class LocationsDeleteCommand extends SelectingInputAPICommand<LocationItem> {
 	static description = 'delete a location'
 
-	static flags = StringSelectingInputAPICommand.flags
+	static flags = SelectingInputAPICommand.flags
 
 	static args = [{
 		name: 'id',
 		description: 'location UUID or number in the list',
 	}]
 
-	protected primaryKeyName = 'locationId'
-	protected sortKeyName = 'name'
+	primaryKeyName = 'locationId'
+	sortKeyName = 'name'
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(LocationsDeleteCommand)

--- a/packages/cli/src/commands/locations/update.ts
+++ b/packages/cli/src/commands/locations/update.ts
@@ -16,8 +16,8 @@ export default class LocationsUpdateCommand extends InputOutputAPICommand <Locat
 		required: true,
 	}]
 
-	protected primaryKeyName = 'locationId'
-	protected sortKeyName = 'name'
+	primaryKeyName = 'locationId'
+	sortKeyName = 'name'
 
 	protected buildTableOutput = buildTableOutput
 

--- a/packages/cli/src/commands/presentation.ts
+++ b/packages/cli/src/commands/presentation.ts
@@ -5,7 +5,7 @@ import { PresentationDevicePresentation } from '@smartthings/core-sdk'
 import { OutputAPICommand } from '@smartthings/cli-lib'
 
 
-export default class Devices extends OutputAPICommand<PresentationDevicePresentation> {
+export default class PresentationCommand extends OutputAPICommand<PresentationDevicePresentation> {
 	static description = 'query device presentation by vid'
 
 	static flags = OutputAPICommand.flags
@@ -100,7 +100,7 @@ export default class Devices extends OutputAPICommand<PresentationDevicePresenta
 	}
 
 	async run(): Promise<void> {
-		const { args, argv, flags } = this.parse(Devices)
+		const { args, argv, flags } = this.parse(PresentationCommand)
 		await super.setup(args, argv, flags)
 
 		this.processNormally(() => {

--- a/packages/lib/src/api-command.ts
+++ b/packages/lib/src/api-command.ts
@@ -59,7 +59,7 @@ export abstract class APICommand extends SmartThingsCommand {
 
 /**
  * TODO: most or all classes that use this should be updated soon to use
- * `StringSelectingInputAPICommand` (or in a few cases `SelectingInputAPICommand`).
+ * `SelectingInputAPICommand` (or in a few cases `SelectingInputAPICommandBase`).
  */
 export abstract class SimpleAPICommand extends APICommand {
 	/**


### PR DESCRIPTION
This pull request updates a couple of the capabilities commands to work with the new list and query mode. They are more complicated than most because the full id is a two part containing "id" and "version" parts.

* updates the capabilities method to work with the new list and query mode
* updates the capabilities:delete method similarly
* updates the capabilities:update method similarly
* renamed SelectingInputAPICommand to SelectingInputAPICommandBase
* renamed StringSelectingInputAPICommand to SelectingInputAPICommand
* fixed apps:oauth command to use listing class again