### PR TITLE
bug fixes and update capabilities:presentation:create command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -370,7 +370,7 @@ USAGE
   $ smartthings capabilities [ID] [VERSION]
 
 ARGUMENTS
-  ID       the capability id number in list
+  ID       the capability id or number in list
   VERSION  the capability version
 
 OPTIONS
@@ -547,7 +547,6 @@ ARGUMENTS
   VERSION  the capability version
 
 OPTIONS
-  -d, --dry-run          produce JSON but don't actually submit
   -h, --help             show CLI help
   -i, --input=input      specify input file
   -j, --json             use JSON format of input and/or output
@@ -604,6 +603,7 @@ ARGUMENTS
 
 OPTIONS
   -h, --help             show CLI help
+  -i, --input=input      specify input file
   -j, --json             use JSON format of input and/or output
   -o, --output=output    specify output file
   -p, --profile=profile  [default: default] configuration profile

--- a/packages/cli/src/commands/capabilities.ts
+++ b/packages/cli/src/commands/capabilities.ts
@@ -20,7 +20,7 @@ export const capabilityIdInputArgs = [
 export const capabilityIdOrIndexInputArgs = [
 	{
 		name: 'id',
-		description: 'the capability id number in list',
+		description: 'the capability id or number in list',
 	},
 	{
 		name: 'version',

--- a/packages/cli/src/commands/capabilities/presentation.ts
+++ b/packages/cli/src/commands/capabilities/presentation.ts
@@ -5,7 +5,8 @@ import { CapabilityPresentation } from '@smartthings/core-sdk'
 
 import { ListingOutputAPICommandBase } from '@smartthings/cli-lib'
 
-import { getCustomByNamespace, translateToId, CapabilityId, CapabilitySummaryWithNamespace } from '../capabilities'
+import { capabilityIdOrIndexInputArgs, getCustomByNamespace, translateToId,
+	CapabilityId, CapabilitySummaryWithNamespace } from '../capabilities'
 
 
 export function buildTableOutput(presentation: CapabilityPresentation): string {
@@ -96,14 +97,7 @@ export default class PresentationsCommand extends ListingOutputAPICommandBase<Ca
 		}),
 	}
 
-	static args = [{
-		name: 'id',
-		description: 'the capability id or number in list',
-	},
-	{
-		name: 'version',
-		description: 'the capability version',
-	}]
+	static args = capabilityIdOrIndexInputArgs
 
 	primaryKeyName = 'id'
 	sortKeyName = 'id'

--- a/packages/cli/src/commands/capabilities/update.ts
+++ b/packages/cli/src/commands/capabilities/update.ts
@@ -27,7 +27,10 @@ export default class CapabilitiesUpdate extends SelectingInputOutputAPICommandBa
 		const { args, argv, flags } = this.parse(CapabilitiesUpdate)
 		await super.setup(args, argv, flags)
 
-		this.processNormally(args.id,
+		const idOrIndex = args.version
+			? { id: args.id, version: args.version }
+			: args.id
+		this.processNormally(idOrIndex,
 			async () => this.getCustomByNamespace(),
 			async (id, capability) => this.client.capabilities.update(id.id, id.version, capability))
 	}

--- a/packages/lib/src/io-command.ts
+++ b/packages/lib/src/io-command.ts
@@ -546,8 +546,9 @@ export abstract class SelectingInputOutputAPICommandBase<ID, I, O, L> extends Li
 		try {
 			let inputId: ID
 			if (id) {
+				this.log(`using id from command line = ${id}`)
 				inputId = id
-			} else if (this.inputOptions.filename) {
+			} else if (this.inputOptions.filename || process.stdin.isTTY) {
 				const items = this.sort(await listCallback())
 				if (items.length === 0) {
 					this.log('no items found')


### PR DESCRIPTION
* Updated "capabilities:presentation:create" command to new standards.
* Fixed bug in capabilities:update command where id from command line wasn't handled correctly.
* Fixed a bug causing a confusing error message to be displayed. 