### PR TITLE
Added ability to authorize app Lambda functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4227,6 +4227,39 @@
 			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
 			"dev": true
 		},
+		"aws-sdk": {
+			"version": "2.690.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.690.0.tgz",
+			"integrity": "sha512-KZasSKw/nKVA+LnOCaccGbFZ9eLDTz7oDc/6IYp9lbvN+XrdCBb8cQveDX3N9i4uDS2G5nz/47UxtP+MYMBynQ==",
+			"requires": {
+				"buffer": "4.9.2",
+				"events": "1.1.1",
+				"ieee754": "1.1.13",
+				"jmespath": "0.15.0",
+				"querystring": "0.2.0",
+				"sax": "1.2.1",
+				"url": "0.10.3",
+				"uuid": "3.3.2",
+				"xml2js": "0.4.19"
+			},
+			"dependencies": {
+				"buffer": {
+					"version": "4.9.2",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4",
+						"isarray": "^1.0.0"
+					}
+				},
+				"uuid": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+				}
+			}
+		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -4420,8 +4453,7 @@
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-			"dev": true
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -6550,6 +6582,11 @@
 			"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
 			"dev": true
 		},
+		"events": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+		},
 		"exec-sh": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
@@ -8310,8 +8347,7 @@
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-			"dev": true
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"iferr": {
 			"version": "0.1.5",
@@ -10224,6 +10260,11 @@
 					}
 				}
 			}
+		},
+		"jmespath": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -12553,6 +12594,11 @@
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
 			"integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
 		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+		},
 		"quick-lru": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
@@ -13231,6 +13277,11 @@
 					}
 				}
 			}
+		},
+		"sax": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+			"integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
 		},
 		"saxes": {
 			"version": "3.1.11",
@@ -14613,6 +14664,22 @@
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
 			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
+		"url": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+			"integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+			"requires": {
+				"punycode": "1.3.2",
+				"querystring": "0.2.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+				}
+			}
+		},
 		"url-parse-lax": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -15083,6 +15150,20 @@
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
 			"dev": true
+		},
+		"xml2js": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+			"requires": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~9.0.1"
+			}
+		},
+		"xmlbuilder": {
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 		},
 		"xmlchars": {
 			"version": "2.2.0",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -41,6 +41,7 @@ USAGE
 # Commands
 <!-- commands -->
 * [`smartthings apps [ID]`](#smartthings-apps-id)
+* [`smartthings apps:authorize ARN`](#smartthings-appsauthorize-arn)
 * [`smartthings apps:create`](#smartthings-appscreate)
 * [`smartthings apps:delete [ID]`](#smartthings-appsdelete-id)
 * [`smartthings apps:oauth [ID]`](#smartthings-appsoauth-id)
@@ -112,6 +113,36 @@ OPTIONS
 
 _See code: [dist/commands/apps.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/apps.ts)_
 
+## `smartthings apps:authorize ARN`
+
+authorize calls to your AWS Lambda function from SmartThings
+
+```
+USAGE
+  $ smartthings apps:authorize ARN
+
+ARGUMENTS
+  ARN  the ARN of the AWS Lambda function
+
+OPTIONS
+  -h, --help             show CLI help
+  -p, --profile=profile  [default: default] configuration profile
+  -t, --token=token      the auth token to use
+
+EXAMPLES
+  $ smartthings apps:authorize arn:aws:lambda:us-east-1:1234567890:function:your-test-app
+
+  Note that this command is the same as running the following with the AWS CLI:
+
+  $ aws lambda add-permission --region us-east-1 \
+       --function-name arn:aws:lambda:us-east-1:1234567890:function:your-test-app \
+       --statement-id smartthings --principal 906037444270 --action lambda:InvokeFunction
+
+  It requires your machine to be configured to run the AWS CLI
+```
+
+_See code: [dist/commands/apps/authorize.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/apps/authorize.ts)_
+
 ## `smartthings apps:create`
 
 update the OAuth settings of the app
@@ -129,6 +160,7 @@ OPTIONS
   -p, --profile=profile  [default: default] configuration profile
   -t, --token=token      the auth token to use
   -y, --yaml             use YAML format of input and/or output
+  --authorize            authorize Lambda functions to be called by SmartThings
   --compact              use compact table format with no lines between body rows
   --expanded             use expanded table format with a line between each body row
   --indent=indent        specify indentation for formatting JSON or YAML output
@@ -331,6 +363,7 @@ OPTIONS
   -p, --profile=profile  [default: default] configuration profile
   -t, --token=token      the auth token to use
   -y, --yaml             use YAML format of input and/or output
+  --authorize            authorize Lambda functions to be called by SmartThings
   --compact              use compact table format with no lines between body rows
   --expanded             use expanded table format with a line between each body row
   --indent=indent        specify indentation for formatting JSON or YAML output
@@ -604,6 +637,7 @@ ARGUMENTS
 
 OPTIONS
   -h, --help             show CLI help
+  -i, --input=input      specify input file
   -j, --json             use JSON format of input and/or output
   -o, --output=output    specify output file
   -p, --profile=profile  [default: default] configuration profile

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -772,6 +772,29 @@
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
+		"aws-sdk": {
+			"version": "2.690.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.690.0.tgz",
+			"integrity": "sha512-KZasSKw/nKVA+LnOCaccGbFZ9eLDTz7oDc/6IYp9lbvN+XrdCBb8cQveDX3N9i4uDS2G5nz/47UxtP+MYMBynQ==",
+			"requires": {
+				"buffer": "4.9.2",
+				"events": "1.1.1",
+				"ieee754": "1.1.13",
+				"jmespath": "0.15.0",
+				"querystring": "0.2.0",
+				"sax": "1.2.1",
+				"url": "0.10.3",
+				"uuid": "3.3.2",
+				"xml2js": "0.4.19"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+				}
+			}
+		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -846,6 +869,11 @@
 				}
 			}
 		},
+		"base64-js": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -875,6 +903,16 @@
 			"dev": true,
 			"requires": {
 				"fill-range": "^7.0.1"
+			}
+		},
+		"buffer": {
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+			"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+			"requires": {
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4",
+				"isarray": "^1.0.0"
 			}
 		},
 		"byline": {
@@ -1414,6 +1452,11 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
+		},
+		"events": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
 		},
 		"execa": {
 			"version": "4.0.2",
@@ -2088,6 +2131,11 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
+		"ieee754": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+		},
 		"ignore": {
 			"version": "5.1.4",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
@@ -2391,6 +2439,11 @@
 				"editions": "^2.2.0",
 				"textextensions": "^2.5.0"
 			}
+		},
+		"jmespath": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -3396,6 +3449,11 @@
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+		},
 		"read-chunk": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.2.0.tgz",
@@ -3603,6 +3661,11 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"sax": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+			"integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
 		},
 		"scoped-regex": {
 			"version": "1.0.0",
@@ -4253,6 +4316,22 @@
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
 			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
+		"url": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+			"integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+			"requires": {
+				"punycode": "1.3.2",
+				"querystring": "0.2.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+				}
+			}
+		},
 		"url-parse-lax": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -4435,6 +4514,20 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"xml2js": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+			"requires": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~9.0.1"
+			}
+		},
+		"xmlbuilder": {
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,9 @@
 		}
 	},
 	"pkg": {
-		"scripts": ["dist/**/*.js"],
+		"scripts": [
+			"dist/**/*.js"
+		],
 		"assets": [
 			"../../node_modules/generator-smartthings",
 			"../../node_modules/istextorbinary"
@@ -52,6 +54,7 @@
 		"@oclif/plugin-help": "^2.2.3",
 		"@oclif/plugin-not-found": "^1.2.3",
 		"@smartthings/cli-lib": "^0.0.0",
+		"aws-sdk": "^2.690.0",
 		"generator-smartthings": "^1.5.0",
 		"node": "^12.16.2",
 		"open": "^7.0.3",

--- a/packages/cli/src/commands/apps/authorize.ts
+++ b/packages/cli/src/commands/apps/authorize.ts
@@ -1,0 +1,43 @@
+import { APICommand } from '@smartthings/cli-lib'
+import {addPermission} from '../../lib/aws-utils'
+
+
+interface AuthorizeResponse {
+	error?: string
+	functions?: { [key: string]: string }
+}
+
+export default class AppAuthorize extends APICommand {
+	static description = 'authorize calls to your AWS Lambda function from SmartThings'
+
+	static flags = APICommand.flags
+
+	static args = [{
+		name: 'arn',
+		description: 'the ARN of the AWS Lambda function',
+		required: true,
+	}]
+
+	static examples = [
+		'$ smartthings apps:authorize arn:aws:lambda:us-east-1:1234567890:function:your-test-app',
+		'',
+		'Note that this command is the same as running the following with the AWS CLI:',
+		'',
+		'$ aws lambda add-permission --region us-east-1 \\',
+		'    --function-name arn:aws:lambda:us-east-1:1234567890:function:your-test-app \\',
+		'    --statement-id smartthings --principal 906037444270 --action lambda:InvokeFunction',
+		'',
+		'It requires your machine to be configured to run the AWS CLI',
+	]
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(AppAuthorize)
+		await super.setup(args, argv, flags)
+
+		addPermission(args.arn).then(async (message) => {
+			this.log(message)
+		}).catch(err => {
+			this.log(`caught error ${err}`)
+		})
+	}
+}

--- a/packages/cli/src/commands/apps/create.ts
+++ b/packages/cli/src/commands/apps/create.ts
@@ -1,14 +1,18 @@
 import { AppRequest, AppCreationResponse} from '@smartthings/core-sdk'
-
 import { InputOutputAPICommand } from '@smartthings/cli-lib'
-
+import { flags } from '@oclif/command'
 import { buildTableOutput } from '../apps'
+import { addPermission } from '../../lib/aws-utils'
 
 
 export default class AppCreateCommand extends InputOutputAPICommand<AppRequest, AppCreationResponse> {
 	static description = 'update the OAuth settings of the app'
 
-	static flags = InputOutputAPICommand.flags
+	static flags = {
+		...InputOutputAPICommand.flags,
+		authorize: flags.boolean({
+			description: 'authorize Lambda functions to be called by SmartThings',
+		})}
 
 	protected buildTableOutput(data: AppCreationResponse): string {
 		return buildTableOutput(this, data.app)
@@ -18,6 +22,22 @@ export default class AppCreateCommand extends InputOutputAPICommand<AppRequest, 
 		const { args, argv, flags } = this.parse(AppCreateCommand)
 		await super.setup(args, argv, flags)
 
-		this.processNormally(data => { return this.client.apps.create(data) })
+		this.processNormally(async data => {
+			if (flags.authorize) {
+				if (data.lambdaSmartApp) {
+					if (data.lambdaSmartApp.functions) {
+						const requests = data.lambdaSmartApp.functions.map((it) => {
+							return addPermission(it)
+						})
+						await Promise.all(requests)
+					}
+				} else {
+					this.logger.error('Authorization is not applicable to web-hook SmartApps')
+					// eslint-disable-next-line no-process-exit
+					process.exit(1)
+				}
+			}
+			return this.client.apps.create(data)
+		})
 	}
 }

--- a/packages/cli/src/commands/apps/update.ts
+++ b/packages/cli/src/commands/apps/update.ts
@@ -1,13 +1,18 @@
 import { App, AppRequest} from '@smartthings/core-sdk'
-
+import { flags } from '@oclif/command'
 import { InputOutputAPICommand } from '@smartthings/cli-lib'
 import { buildTableOutput } from '../apps'
+import {addPermission} from '../../lib/aws-utils'
 
 
 export default class AppUpdateCommand extends InputOutputAPICommand<AppRequest, App> {
 	static description = 'update the OAuth settings of the app'
 
-	static flags = InputOutputAPICommand.flags
+	static flags = {
+		...InputOutputAPICommand.flags,
+		authorize: flags.boolean({
+			description: 'authorize Lambda functions to be called by SmartThings',
+		})}
 
 	static args = [{
 		name: 'id',
@@ -26,6 +31,22 @@ export default class AppUpdateCommand extends InputOutputAPICommand<AppRequest, 
 		const { args, argv, flags } = this.parse(AppUpdateCommand)
 		await super.setup(args, argv, flags)
 
-		this.processNormally(data => { return this.client.apps.update(args.id, data) })
+		this.processNormally(async data => {
+			if (flags.authorize) {
+				if (data.lambdaSmartApp) {
+					if (data.lambdaSmartApp.functions) {
+						const requests = data.lambdaSmartApp.functions.map((it) => {
+							return addPermission(it)
+						})
+						await Promise.all(requests)
+					}
+				} else {
+					this.logger.error('Authorization is not applicable to web-hook SmartApps')
+					// eslint-disable-next-line no-process-exit
+					process.exit(1)
+				}
+			}
+			return this.client.apps.update(args.id, data)
+		})
 	}
 }

--- a/packages/cli/src/lib/aws-utils.ts
+++ b/packages/cli/src/lib/aws-utils.ts
@@ -1,0 +1,31 @@
+import AWS from 'aws-sdk'
+import {AddPermissionRequest} from 'aws-sdk/clients/lambda'
+
+
+export async function addPermission(arn: string): Promise<string> {
+	const segs = arn.split(':')
+	if (segs.length < 7) {
+		return 'Invalid Lambda ARN'
+	}
+
+	try {
+		const region = segs[3]
+		AWS.config.update({region})
+		const lambda = new AWS.Lambda()
+
+		const params: AddPermissionRequest = {
+			Action: 'lambda:InvokeFunction',
+			FunctionName: arn,
+			Principal: '906037444270', // TODO environment dependent
+			StatementId: 'smartthings',
+		}
+
+		await lambda.addPermission(params).promise()
+		return 'Authorization added'
+	} catch (error) {
+		if (error.code === 'ResourceConflictException') {
+			return 'Already authorized'
+		}
+		throw error
+	}
+}


### PR DESCRIPTION
Adds the ability to authorize calls to app Lambda functions from the CLI. Such authorization can be done from the AWS CLI, but integrating it here means developers don't have to look up the SmartThings principal ID from the documentation. It also allows functions to be authorized when the app is created or updated.