### PR TITLE
update capabilities:presentation:update command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -640,7 +640,7 @@ _See code: [dist/commands/capabilities/presentation/create.ts](https://github.co
 
 ## `smartthings capabilities:presentation:update [ID] [VERSION]`
 
-update presentation model for a capability
+update presentation information of a capability
 
 ```
 USAGE
@@ -651,7 +651,6 @@ ARGUMENTS
   VERSION  the capability version
 
 OPTIONS
-  -d, --dry-run          produce JSON but don't actually submit
   -h, --help             show CLI help
   -i, --input=input      specify input file
   -j, --json             use JSON format of input and/or output


### PR DESCRIPTION
Updated the capabilities:presentation:update command to match standards. Users can either call the command with a specific capability's ID and version or a table of capabilities will be outputted and the user will be prompted to enter the index or id of the specific capability presentation to be updated. 