### PR TITLE
PI-901 Added installed apps list, get, and delete commands

### DIFF
--- a/packages/cli/src/commands/installedapps.ts
+++ b/packages/cli/src/commands/installedapps.ts
@@ -13,7 +13,7 @@ export default class InstalledAppsList extends ListingOutputAPICommand<Installed
 	static flags = {
 		...ListingOutputAPICommand.flags,
 		verbose: flags.boolean({
-			description: 'include location name in table output',
+			description: 'include location name in output',
 			char: 'v',
 		}),
 	}
@@ -28,14 +28,14 @@ export default class InstalledAppsList extends ListingOutputAPICommand<Installed
 	sortKeyName = 'displayName'
 	protected tableHeadings(): string[] {
 		if (this.flags.verbose) {
-			return ['displayName', 'installedAppType', 'location', 'installedAppId']
+			return ['displayName', 'installedAppType', 'installedAppStatus', 'location', 'installedAppId']
 		} else {
-			return ['displayName', 'installedAppType', 'installedAppId']
+			return ['displayName', 'installedAppType', 'installedAppStatus', 'installedAppId']
 		}
 	}
 
 	protected buildObjectTableOutput(data: InstalledApp): string {
-		const table = this.newOutputTable({head: ['property','value']})
+		const table = this.newOutputTable()
 		table.push(['name', data.displayName])
 		table.push(['installedAppId', data.installedAppId])
 		table.push(['installedAppType', data.installedAppType])

--- a/packages/cli/src/commands/installedapps/delete.ts
+++ b/packages/cli/src/commands/installedapps/delete.ts
@@ -1,0 +1,30 @@
+import { InstalledApp } from '@smartthings/core-sdk'
+
+import { SelectingInputAPICommand } from '@smartthings/cli-lib'
+
+
+export default class InstalledAppDeleteCommand extends SelectingInputAPICommand<InstalledApp> {
+	static description = 'delete the installed app instance'
+
+	static flags = SelectingInputAPICommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'InstalledApp UUID or number in the list',
+	}]
+
+	primaryKeyName = 'installedAppId'
+	sortKeyName = 'displayName'
+	protected tableHeadings(): string[] {
+		return ['displayName', 'installedAppType', 'installedAppStatus', 'installedAppId']
+	}
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(InstalledAppDeleteCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(args.id,
+			async () => await this.client.installedApps.list(),
+			async (id) => { await this.client.installedApps.delete(id) },
+			'installed app {{id}} deleted')
+	}
+}


### PR DESCRIPTION
Added basic commands for installed apps. There is no create command because apps are installed via either strongman or an OAuth-In journey. There is the possibility of updating the installed app but only to rename it. Putting that off until it can be done with the interactive approach that doesn't require cutting and pasting UUIDs