### PR TITLE
add rules CRUD commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -127,13 +127,17 @@ Commands are organized in a hierarchy that maps the API hierarchy.
 * [`smartthings locations:delete [ID]`](#smartthings-locationsdelete-id)
 * [`smartthings locations:rooms [IDORINDEX]`](#smartthings-locationsrooms-idorindex)
 * [`smartthings locations:rooms:create`](#smartthings-locationsroomscreate)
-* [`smartthings locations:rooms:delete [IDORINDEX]`](#smartthings-locationsroomsdelete-idorindex)
-* [`smartthings locations:rooms:update [IDORINDEX]`](#smartthings-locationsroomsupdate-idorindex)
+* [`smartthings locations:rooms:delete [ID]`](#smartthings-locationsroomsdelete-id)
+* [`smartthings locations:rooms:update [ID]`](#smartthings-locationsroomsupdate-id)
 * [`smartthings locations:update [ID]`](#smartthings-locationsupdate-id)
 * [`smartthings presentation VID`](#smartthings-presentation-vid)
 * [`smartthings presentation:device-config VID`](#smartthings-presentationdevice-config-vid)
 * [`smartthings presentation:device-config:create`](#smartthings-presentationdevice-configcreate)
 * [`smartthings presentation:device-config:generate ID`](#smartthings-presentationdevice-configgenerate-id)
+* [`smartthings rules [IDORINDEX]`](#smartthings-rules-idorindex)
+* [`smartthings rules:create`](#smartthings-rulescreate)
+* [`smartthings rules:delete [ID]`](#smartthings-rulesdelete-id)
+* [`smartthings rules:update [ID]`](#smartthings-rulesupdate-id)
 * [`smartthings schema [ID]`](#smartthings-schema-id)
 * [`smartthings schema:create`](#smartthings-schemacreate)
 * [`smartthings schema:delete [ID]`](#smartthings-schemadelete-id)
@@ -1144,7 +1148,7 @@ USAGE
   $ smartthings locations:rooms [IDORINDEX]
 
 ARGUMENTS
-  IDORINDEX  the room id
+  IDORINDEX  room UUID or index
 
 OPTIONS
   -h, --help                   show CLI help
@@ -1192,16 +1196,16 @@ ALIASES
 
 _See code: [dist/commands/locations/rooms/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/locations/rooms/create.ts)_
 
-## `smartthings locations:rooms:delete [IDORINDEX]`
+## `smartthings locations:rooms:delete [ID]`
 
 delete a room
 
 ```
 USAGE
-  $ smartthings locations:rooms:delete [IDORINDEX]
+  $ smartthings locations:rooms:delete [ID]
 
 ARGUMENTS
-  IDORINDEX  room UUID or number in the list
+  ID  room UUID
 
 OPTIONS
   -h, --help                   show CLI help
@@ -1215,16 +1219,16 @@ ALIASES
 
 _See code: [dist/commands/locations/rooms/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/locations/rooms/delete.ts)_
 
-## `smartthings locations:rooms:update [IDORINDEX]`
+## `smartthings locations:rooms:update [ID]`
 
 update a room
 
 ```
 USAGE
-  $ smartthings locations:rooms:update [IDORINDEX]
+  $ smartthings locations:rooms:update [ID]
 
 ARGUMENTS
-  IDORINDEX  room UUID
+  ID  room UUID
 
 OPTIONS
   -h, --help                   show CLI help
@@ -1373,6 +1377,104 @@ OPTIONS
 ```
 
 _See code: [dist/commands/presentation/device-config/generate.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/presentation/device-config/generate.ts)_
+
+## `smartthings rules [IDORINDEX]`
+
+get a specific rule
+
+```
+USAGE
+  $ smartthings rules [IDORINDEX]
+
+ARGUMENTS
+  IDORINDEX  rule UUID or index
+
+OPTIONS
+  -h, --help                   show CLI help
+  -j, --json                   use JSON format of input and/or output
+  -l, --locationId=locationId  a specific locationId to query
+  -o, --output=output          specify output file
+  -p, --profile=profile        [default: default] configuration profile
+  -t, --token=token            the auth token to use
+  -y, --yaml                   use YAML format of input and/or output
+  --compact                    use compact table format with no lines between body rows
+  --expanded                   use expanded table format with a line between each body row
+  --indent=indent              specify indentation for formatting JSON or YAML output
+```
+
+_See code: [dist/commands/rules.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/rules.ts)_
+
+## `smartthings rules:create`
+
+create a rule
+
+```
+USAGE
+  $ smartthings rules:create
+
+OPTIONS
+  -d, --dry-run                produce JSON but don't actually submit
+  -h, --help                   show CLI help
+  -i, --input=input            specify input file
+  -j, --json                   use JSON format of input and/or output
+  -l, --locationid=locationid  a specific location to query
+  -o, --output=output          specify output file
+  -p, --profile=profile        [default: default] configuration profile
+  -t, --token=token            the auth token to use
+  -y, --yaml                   use YAML format of input and/or output
+  --compact                    use compact table format with no lines between body rows
+  --expanded                   use expanded table format with a line between each body row
+  --indent=indent              specify indentation for formatting JSON or YAML output
+```
+
+_See code: [dist/commands/rules/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/rules/create.ts)_
+
+## `smartthings rules:delete [ID]`
+
+delete a rule
+
+```
+USAGE
+  $ smartthings rules:delete [ID]
+
+ARGUMENTS
+  ID  rule UUID
+
+OPTIONS
+  -h, --help                   show CLI help
+  -l, --locationId=locationId  a specific location to query
+  -p, --profile=profile        [default: default] configuration profile
+  -t, --token=token            the auth token to use
+```
+
+_See code: [dist/commands/rules/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/rules/delete.ts)_
+
+## `smartthings rules:update [ID]`
+
+update a rule
+
+```
+USAGE
+  $ smartthings rules:update [ID]
+
+ARGUMENTS
+  ID  rule UUID
+
+OPTIONS
+  -h, --help                   show CLI help
+  -i, --input=input            specify input file
+  -j, --json                   use JSON format of input and/or output
+  -l, --locationId=locationId  a specific locationId to query
+  -o, --output=output          specify output file
+  -p, --profile=profile        [default: default] configuration profile
+  -t, --token=token            the auth token to use
+  -y, --yaml                   use YAML format of input and/or output
+  --compact                    use compact table format with no lines between body rows
+  --expanded                   use expanded table format with a line between each body row
+  --indent=indent              specify indentation for formatting JSON or YAML output
+```
+
+_See code: [dist/commands/rules/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/rules/update.ts)_
 
 ## `smartthings schema [ID]`
 

--- a/packages/cli/src/commands/locations/rooms.ts
+++ b/packages/cli/src/commands/locations/rooms.ts
@@ -16,7 +16,7 @@ export async function getRoomsByLocation(this: APICommand, locationId?: string):
 	}
 
 	if (!locations || locations.length == 0) {
-		throw Error('could not find any locations for you account. Perhaps ' +
+		throw Error('could not find any locations for your account. Perhaps ' +
 			"you haven't created any locations yet.")
 	}
 
@@ -45,7 +45,7 @@ export default class RoomsCommand extends ListingOutputAPICommand<Room, RoomWith
 
 	static args = [{
 		name: 'idOrIndex',
-		description: 'the room id',
+		description: 'room UUID or index',
 	}]
 
 	static aliases = ['rooms']

--- a/packages/cli/src/commands/locations/rooms/delete.ts
+++ b/packages/cli/src/commands/locations/rooms/delete.ts
@@ -17,8 +17,8 @@ export default class RoomsDeleteCommand extends SelectingAPICommand<Room> {
 	}
 
 	static args = [{
-		name: 'idOrIndex',
-		description: 'room UUID or number in the list',
+		name: 'id',
+		description: 'room UUID',
 	}]
 
 	static aliases = ['rooms:delete']
@@ -35,7 +35,7 @@ export default class RoomsDeleteCommand extends SelectingAPICommand<Room> {
 
 		const roomsPromise = this.getRoomsByLocation(flags.locationId)
 		this.processNormally(
-			args.idOrIndex,
+			args.id,
 			() => roomsPromise,
 			async (id) => {
 				const room = (await roomsPromise).find(room => room.roomId === id)

--- a/packages/cli/src/commands/locations/rooms/update.ts
+++ b/packages/cli/src/commands/locations/rooms/update.ts
@@ -17,7 +17,7 @@ export default class RoomsUpdateCommand extends SelectingInputOutputAPICommand <
 	}
 
 	static args = [{
-		name: 'idOrIndex',
+		name: 'id',
 		description: 'room UUID',
 	}]
 
@@ -37,7 +37,7 @@ export default class RoomsUpdateCommand extends SelectingInputOutputAPICommand <
 
 		const roomsPromise = this.getRoomsByLocation(flags.locationId)
 		this.processNormally(
-			args.idOrIndex,
+			args.id,
 			() => roomsPromise,
 			async (id, data) => {
 				const room = (await roomsPromise).find(room => room.roomId === id)

--- a/packages/cli/src/commands/rules.ts
+++ b/packages/cli/src/commands/rules.ts
@@ -1,0 +1,71 @@
+import { flags } from '@oclif/command'
+import { LocationItem, Rule } from '@smartthings/core-sdk'
+
+import { APICommand, ListingOutputAPICommand, TableFieldDefinition } from '@smartthings/cli-lib'
+
+
+export const tableFieldDefinitions: TableFieldDefinition<Rule>[] = ['name', 'id',
+	{ label: 'Num Actions', value: (rule) => rule.actions.length.toString() },
+	'timeZoneId']
+
+export async function getRulesByLocation(this: APICommand, locationId?: string): Promise<RuleWithLocation[]> {
+	let locations: LocationItem[] = []
+	if (locationId) {
+		this.log(`location specified: ${locationId}`)
+		locations = [await this.client.locations.get(locationId)]
+	} else {
+		locations = await this.client.locations.list()
+	}
+
+	if (!locations || locations.length == 0) {
+		throw Error('could not find any locations for your account. Perhaps ' +
+			"you haven't created any locations yet.")
+	}
+
+	let rules: RuleWithLocation[] = []
+	for (const location of locations) {
+		const locationRules = await this.client.rules.list(location.locationId) ?? []
+		rules = rules.concat(locationRules.map(rule => { return { ...rule, locationId: location.locationId, locationName: location.name } }))
+	}
+	return rules
+}
+
+export type RuleWithLocation = Rule & {
+	locationId?: string
+	locationName?: string
+}
+
+export default class RulesCommand extends ListingOutputAPICommand<Rule, RuleWithLocation> {
+	static description = 'get a specific rule'
+
+	static flags = {
+		...ListingOutputAPICommand.flags,
+		locationId: flags.string({
+			char: 'l',
+			description: 'a specific locationId to query',
+		}),
+	}
+
+	static args = [{
+		name: 'idOrIndex',
+		description: 'rule UUID or index',
+	}]
+
+	primaryKeyName = 'id'
+	sortKeyName = 'name'
+
+	protected getRulesByLocation = getRulesByLocation
+	protected listTableFieldDefinitions = ['name', 'roomId', 'locationId', 'locationName']
+	protected tableFieldDefinitions = tableFieldDefinitions
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(RulesCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.idOrIndex,
+			() => { return this.getRulesByLocation(flags.locationId) },
+			(id) => { return this.client.rules.get(id, flags.locationId) },
+		)
+	}
+}

--- a/packages/cli/src/commands/rules/create.ts
+++ b/packages/cli/src/commands/rules/create.ts
@@ -1,0 +1,29 @@
+import { flags } from '@oclif/command'
+import { Rule, RuleRequest } from '@smartthings/core-sdk'
+
+import { tableFieldDefinitions } from '../rules'
+import { InputOutputAPICommand } from '@smartthings/cli-lib'
+
+
+export default class RulesCreate extends InputOutputAPICommand<RuleRequest, Rule> {
+	static description = 'create a rule'
+
+	static flags = {
+		...InputOutputAPICommand.flags,
+		locationid: flags.string({
+			char: 'l',
+			description: 'a specific location to query',
+		}),
+	}
+
+	protected tableFieldDefinitions = tableFieldDefinitions
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(RulesCreate)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(rule => {
+			return this.client.rules.create(rule, flags.locationid)
+		})
+	}
+}

--- a/packages/cli/src/commands/rules/delete.ts
+++ b/packages/cli/src/commands/rules/delete.ts
@@ -1,0 +1,47 @@
+import { flags } from '@oclif/command'
+import { Rule } from '@smartthings/core-sdk'
+
+import { getRulesByLocation } from '../rules'
+import { SelectingAPICommand } from '@smartthings/cli-lib'
+
+
+export default class RulesDeleteCommand extends SelectingAPICommand<Rule> {
+	static description = 'delete a rule'
+
+	static flags = {
+		...SelectingAPICommand.flags,
+		locationId: flags.string({
+			char: 'l',
+			description: 'a specific location to query',
+		}),
+	}
+
+	static args = [{
+		name: 'id',
+		description: 'rule UUID',
+	}]
+
+	primaryKeyName = 'id'
+	sortKeyName = 'name'
+
+	protected getRulesByLocation = getRulesByLocation
+	protected listTableFieldDefinitions = ['name', 'id', 'locationId', 'locationName']
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(RulesDeleteCommand)
+		await super.setup(args, argv, flags)
+
+		const rulesPromise = this.getRulesByLocation(flags.locationId)
+		this.processNormally(
+			args.id,
+			() => rulesPromise,
+			async (id) => {
+				const rule = (await rulesPromise).find(RuleWithLocation => RuleWithLocation.id === id)
+				if (!rule) {
+					throw Error(flags.locationId ? `could not find rule with id ${id} in room ${flags.locationId}` : `could not find rule with id ${id}`)
+				}
+				this.client.rules.delete(id, rule.locationId)
+			},
+			'rule {{id}} deleted')
+	}
+}

--- a/packages/cli/src/commands/rules/update.ts
+++ b/packages/cli/src/commands/rules/update.ts
@@ -1,0 +1,47 @@
+import { flags } from '@oclif/command'
+import { Rule, RuleRequest } from '@smartthings/core-sdk'
+
+import { tableFieldDefinitions, getRulesByLocation, RuleWithLocation } from '../rules'
+import { SelectingInputOutputAPICommand } from '@smartthings/cli-lib'
+
+
+export default class RulesUpdateCommand extends SelectingInputOutputAPICommand <RuleRequest, Rule, RuleWithLocation> {
+	static description = 'update a rule'
+
+	static flags = {
+		...SelectingInputOutputAPICommand.flags,
+		locationId: flags.string({
+			char: 'l',
+			description: 'a specific locationId to query',
+		}),
+	}
+
+	static args = [{
+		name: 'id',
+		description: 'rule UUID',
+	}]
+
+	primaryKeyName = 'id'
+	sortKeyName = 'name'
+
+	protected getRulesByLocation = getRulesByLocation
+	protected listTableFieldDefinitions = ['name', 'id', 'locationId', 'locationName']
+	protected tableFieldDefinitions = tableFieldDefinitions
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(RulesUpdateCommand)
+		await super.setup(args, argv, flags)
+
+		const rulesPromise = this.getRulesByLocation(flags.locationId)
+		this.processNormally(
+			args.id,
+			() => rulesPromise,
+			async (id, data) => {
+				const rule = (await rulesPromise).find(RuleWithLocation => RuleWithLocation.id === id)
+				if (!rule) {
+					throw Error(flags.locationId ? `could not find rule with id ${id} in room ${flags.locationId}` : `could not find rule with id ${id}`)
+				}
+				return this.client.rules.update(id, data, rule.locationId)},
+		)
+	}
+}


### PR DESCRIPTION
Added rules CRUD commands:
- Added rules:create command. Users can now create rules using a locationId and a form of input.
- Added rules command to display a list of all rules when called with no rule Id and no locationId. Users can also call the rules command with a rule Id or index from the table to display a particular rule's information. If the command is called with a locationId, the rules of that location will be listed.
- Added rules:update command. Users can now update rules using the rule Id, a form of input, and the locationId.
- Added rules:delete command. Users can now delete rules using the rule Id and locationId. If no rule Id is included, a table containing all of the rules will be outputted and users can choose which rule to be deleted by index or rule Id.

I also updated the arguments for the rooms command to be more accurate. 