### PR TITLE
Fixed device presentation display

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -109,6 +109,7 @@ Commands are organized in a hierarchy that maps the API hierarchy.
 * [`smartthings deviceprofiles [ID]`](#smartthings-deviceprofiles-id)
 * [`smartthings deviceprofiles:create`](#smartthings-deviceprofilescreate)
 * [`smartthings deviceprofiles:delete [ID]`](#smartthings-deviceprofilesdelete-id)
+* [`smartthings deviceprofiles:presentation [ID]`](#smartthings-deviceprofilespresentation-id)
 * [`smartthings deviceprofiles:publish ID`](#smartthings-deviceprofilespublish-id)
 * [`smartthings deviceprofiles:update ID`](#smartthings-deviceprofilesupdate-id)
 * [`smartthings devices [ID]`](#smartthings-devices-id)
@@ -116,6 +117,7 @@ Commands are organized in a hierarchy that maps the API hierarchy.
 * [`smartthings devices:commands ID`](#smartthings-devicescommands-id)
 * [`smartthings devices:components-status ID COMPONENTID`](#smartthings-devicescomponents-status-id-componentid)
 * [`smartthings devices:delete [ID]`](#smartthings-devicesdelete-id)
+* [`smartthings devices:presentation [ID]`](#smartthings-devicespresentation-id)
 * [`smartthings devices:status ID`](#smartthings-devicesstatus-id)
 * [`smartthings generate:java`](#smartthings-generatejava)
 * [`smartthings generate:node`](#smartthings-generatenode)
@@ -130,7 +132,7 @@ Commands are organized in a hierarchy that maps the API hierarchy.
 * [`smartthings locations:rooms:delete [IDORINDEX]`](#smartthings-locationsroomsdelete-idorindex)
 * [`smartthings locations:rooms:update [IDORINDEX]`](#smartthings-locationsroomsupdate-idorindex)
 * [`smartthings locations:update [ID]`](#smartthings-locationsupdate-id)
-* [`smartthings presentation VID`](#smartthings-presentation-vid)
+* [`smartthings presentation VID [MNMN]`](#smartthings-presentation-vid-mnmn)
 * [`smartthings presentation:device-config VID`](#smartthings-presentationdevice-config-vid)
 * [`smartthings presentation:device-config:create`](#smartthings-presentationdevice-configcreate)
 * [`smartthings presentation:device-config:generate ID`](#smartthings-presentationdevice-configgenerate-id)
@@ -776,6 +778,31 @@ EXAMPLES
 
 _See code: [dist/commands/deviceprofiles/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/deviceprofiles/delete.ts)_
 
+## `smartthings deviceprofiles:presentation [ID]`
+
+get the presentation associated with a device profile
+
+```
+USAGE
+  $ smartthings deviceprofiles:presentation [ID]
+
+ARGUMENTS
+  ID  device profile UUID or the number of the profile from list
+
+OPTIONS
+  -h, --help             show CLI help
+  -j, --json             use JSON format of input and/or output
+  -o, --output=output    specify output file
+  -p, --profile=profile  [default: default] configuration profile
+  -t, --token=token      the auth token to use
+  -y, --yaml             use YAML format of input and/or output
+  --compact              use compact table format with no lines between body rows
+  --expanded             use expanded table format with a line between each body row
+  --indent=indent        specify indentation for formatting JSON or YAML output
+```
+
+_See code: [dist/commands/deviceprofiles/presentation.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/deviceprofiles/presentation.ts)_
+
 ## `smartthings deviceprofiles:publish ID`
 
 publish a device profile (published profiles cannot be modified)
@@ -955,6 +982,31 @@ OPTIONS
 ```
 
 _See code: [dist/commands/devices/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/devices/delete.ts)_
+
+## `smartthings devices:presentation [ID]`
+
+get a device presentation
+
+```
+USAGE
+  $ smartthings devices:presentation [ID]
+
+ARGUMENTS
+  ID  the device id or number in the list
+
+OPTIONS
+  -h, --help             show CLI help
+  -j, --json             use JSON format of input and/or output
+  -o, --output=output    specify output file
+  -p, --profile=profile  [default: default] configuration profile
+  -t, --token=token      the auth token to use
+  -y, --yaml             use YAML format of input and/or output
+  --compact              use compact table format with no lines between body rows
+  --expanded             use expanded table format with a line between each body row
+  --indent=indent        specify indentation for formatting JSON or YAML output
+```
+
+_See code: [dist/commands/devices/presentation.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/devices/presentation.ts)_
 
 ## `smartthings devices:status ID`
 
@@ -1271,16 +1323,17 @@ OPTIONS
 
 _See code: [dist/commands/locations/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/locations/update.ts)_
 
-## `smartthings presentation VID`
+## `smartthings presentation VID [MNMN]`
 
 query device presentation by vid
 
 ```
 USAGE
-  $ smartthings presentation VID
+  $ smartthings presentation VID [MNMN]
 
 ARGUMENTS
-  VID  system generated identifier that corresponds to a device presentation
+  VID   system generated identifier that corresponds to a device presentation
+  MNMN  manufacturer ID. Defaults to SmartThingsCommunity
 
 OPTIONS
   -h, --help             show CLI help

--- a/packages/cli/src/commands/deviceprofiles/presentation.ts
+++ b/packages/cli/src/commands/deviceprofiles/presentation.ts
@@ -1,0 +1,44 @@
+import { DeviceProfile, PresentationDevicePresentation } from '@smartthings/core-sdk'
+
+import { ListingOutputAPICommand } from '@smartthings/cli-lib'
+
+import { buildTableOutput } from '../presentation'
+
+
+export default class ProfilePresentationCommand extends ListingOutputAPICommand<PresentationDevicePresentation, DeviceProfile> {
+	static description = 'get the presentation associated with a device profile'
+
+	static flags = ListingOutputAPICommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'device profile UUID or the number of the profile from list',
+	}]
+
+	primaryKeyName = 'id'
+	sortKeyName = 'name'
+
+	protected buildTableOutput(presentation: PresentationDevicePresentation): string {
+		return buildTableOutput(presentation, this.tableGenerator)
+	}
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(ProfilePresentationCommand	)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => { return this.client.deviceProfiles.list() },
+			async (id) => {
+				const profile = await this.client.deviceProfiles.get(id)
+				if (profile.metadata) {
+					return this.client.presentation.getPresentation(profile.metadata.vid, profile.metadata.mnmn)
+				} else {
+					this.logger.error('No presentation defined for device profile')
+					// eslint-disable-next-line no-process-exit
+					process.exit(1)
+				}
+			},
+		)
+	}
+}

--- a/packages/cli/src/commands/devices/presentation.ts
+++ b/packages/cli/src/commands/devices/presentation.ts
@@ -1,0 +1,37 @@
+import { Device, PresentationDevicePresentation } from '@smartthings/core-sdk'
+
+import { ListingOutputAPICommand } from '@smartthings/cli-lib'
+
+import { buildTableOutput } from '../presentation'
+
+
+export const tableFieldDefinitions = ['clientName', 'scope', 'redirectUris']
+
+export default class DevicePresentationCommand extends ListingOutputAPICommand<PresentationDevicePresentation, Device> {
+	static description = 'get a device presentation'
+
+	static flags = ListingOutputAPICommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'the device id or number in the list',
+	}]
+
+	primaryKeyName = 'deviceId'
+	sortKeyName = 'label'
+
+	protected buildTableOutput(presentation: PresentationDevicePresentation): string {
+		return buildTableOutput(presentation, this.tableGenerator)
+	}
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(DevicePresentationCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => this.client.devices.list(),
+			(id) => this.client.devices.getPresentation(id),
+		)
+	}
+}

--- a/packages/cli/src/commands/presentation.ts
+++ b/packages/cli/src/commands/presentation.ts
@@ -1,98 +1,108 @@
 import { PresentationDevicePresentation } from '@smartthings/core-sdk'
 
-import { OutputAPICommand } from '@smartthings/cli-lib'
+import {OutputAPICommand, TableGenerator} from '@smartthings/cli-lib'
 
+
+export function buildTableOutput(presentation: PresentationDevicePresentation, tableGenerator: TableGenerator): string {
+	const basicInfo = tableGenerator.buildTableFromItem(presentation, [
+		{ prop: 'vid', label: 'VID' }, { prop: 'mnmn', label: 'MNMN' }, 'iconUrl',
+	])
+
+	let dashboardStates = 'No dashboard states'
+	if (presentation.dashboard?.states && presentation.dashboard.states.length > 0) {
+		const subTable = tableGenerator.newOutputTable({ head: ['Label', 'Alternatives', 'Group'] })
+		for (const state of presentation.dashboard.states) {
+			const alternatives = state.alternatives?.length
+				? state.alternatives.length
+				: 'none'
+			subTable.push([
+				state.label,
+				alternatives,
+				state.group ? state.group : '',
+			])
+		}
+		dashboardStates = `Dashboard States\n${subTable.toString()}`
+	}
+
+	function buildDisplayTypeTable(items: { displayType: string }[]): string {
+		const subTable = tableGenerator.newOutputTable({ head: ['Display Type'] })
+		for (const item of items) {
+			subTable.push([item.displayType])
+		}
+		return subTable.toString()
+	}
+
+	function buildLabelDisplayTypeTable(items: { label: string; displayType: string }[]): string {
+		const subTable = tableGenerator.newOutputTable({ head: ['Label', 'Display Type'] })
+		for (const item of items) {
+			subTable.push([item.label, item.displayType])
+		}
+		return subTable.toString()
+	}
+
+	let dashboardActions = 'No dashboard actions'
+	if (presentation.dashboard?.actions?.length) {
+		dashboardActions = `Dashboard Actions\n${buildDisplayTypeTable(presentation.dashboard.actions)}`
+	}
+
+	let dashboardBasicPlus = 'No dashboard basic plus items'
+	if (presentation.dashboard?.basicPlus?.length) {
+		dashboardBasicPlus = `Dashboard Basic Plus\n${buildDisplayTypeTable(presentation.dashboard.basicPlus)}`
+	}
+
+	let detailViews = 'No detail views'
+	if (presentation.detailView?.length) {
+		const subTable = tableGenerator.newOutputTable({ head: ['Capability', 'Version', 'Component'] })
+		for (const detailView of presentation.detailView) {
+			subTable.push([
+				detailView.capability,
+				detailView.version ? detailView.version : 'none',
+				detailView.component,
+			])
+		}
+		detailViews = `Detail Views\n${subTable.toString()}`
+	}
+
+	let automationConditions = 'No automation conditions'
+	if (presentation.automation?.conditions?.length) {
+		automationConditions = `Automation Conditions\n${buildLabelDisplayTypeTable(presentation.automation.conditions)}`
+	}
+
+	let automationActions = 'No automation actions'
+	if (presentation.automation?.actions?.length) {
+		automationActions = `Automation Actions\n${buildLabelDisplayTypeTable(presentation.automation.actions)}`
+	}
+
+	return `Basic Information\n${basicInfo}\n\n` +
+		`${dashboardStates}\n\n` +
+		`${dashboardActions}\n\n` +
+		`${dashboardBasicPlus}\n\n` +
+		`${detailViews}\n\n` +
+		`${automationConditions}\n\n` +
+		`${automationActions}\n\n` +
+		'(Information is summarized, for full details use YAML or JSON flags.)'
+}
 
 export default class PresentationCommand extends OutputAPICommand<PresentationDevicePresentation> {
 	static description = 'query device presentation by vid'
 
 	static flags = OutputAPICommand.flags
 
-	static args = [{
-		name: 'vid',
-		description: 'system generated identifier that corresponds to a device presentation',
-		required: true,
-	}]
+	static args = [
+		{
+			name: 'vid',
+			description: 'system generated identifier that corresponds to a device presentation',
+			required: true,
+		},
+		{
+			name: 'mnmn',
+			description: 'manufacturer ID. Defaults to SmartThingsCommunity',
+			required: false,
+		},
+	]
 
 	protected buildTableOutput(presentation: PresentationDevicePresentation): string {
-		const tableGenerator = this.tableGenerator
-		const basicInfo = tableGenerator.buildTableFromItem(presentation, [
-			{ prop: 'vid', label: 'VID' }, { prop: 'mnmn', label: 'MNMN' }, 'iconUrl',
-		])
-
-		let dashboardStates = 'No dashboard states'
-		if (presentation.dashboard?.states && presentation.dashboard.states.length > 0) {
-			const subTable = tableGenerator.newOutputTable({ head: ['Label', 'Alternatives', 'Group'] })
-			for (const state of presentation.dashboard.states) {
-				const alternatives = state.alternatives?.length
-					? state.alternatives.length
-					: 'none'
-				subTable.push([
-					state.label,
-					alternatives,
-					state.group ? state.group : '',
-				])
-			}
-			dashboardStates = `Dashboard States\n${subTable.toString()}`
-		}
-
-		function buildDisplayTypeTable(items: { displayType: string }[]): string {
-			const subTable = tableGenerator.newOutputTable({ head: ['Display Type'] })
-			for (const item of items) {
-				subTable.push([item.displayType])
-			}
-			return subTable.toString()
-		}
-
-		function buildLabelDisplayTypeTable(items: { label: string; displayType: string }[]): string {
-			const subTable = tableGenerator.newOutputTable({ head: ['Label', 'Display Type'] })
-			for (const item of items) {
-				subTable.push([item.label, item.displayType])
-			}
-			return subTable.toString()
-		}
-
-		let dashboardActions = 'No dashboard actions'
-		if (presentation.dashboard?.actions?.length) {
-			dashboardActions = `Dashboard Actions\n${buildDisplayTypeTable(presentation.dashboard.actions)}`
-		}
-
-		let dashboardBasicPlus = 'No dashboard basic plus items'
-		if (presentation.dashboard?.basicPlus?.length) {
-			dashboardBasicPlus = `Dashboard Basic Plus\n${buildDisplayTypeTable(presentation.dashboard.basicPlus)}`
-		}
-
-		let detailViews = 'No detail views'
-		if (presentation.detailView?.length) {
-			const subTable = tableGenerator.newOutputTable({ head: ['Capability', 'Version', 'Component'] })
-			for (const detailView of presentation.detailView) {
-				subTable.push([
-					detailView.capability,
-					detailView.version ? detailView.version : 'none',
-					detailView.component,
-				])
-			}
-			detailViews = `Detail Views\n${subTable.toString()}`
-		}
-
-		let automationConditions = 'No automation conditions'
-		if (presentation.automation?.conditions?.length) {
-			automationConditions = `Automation Conditions\n${buildLabelDisplayTypeTable(presentation.automation.conditions)}`
-		}
-
-		let automationActions = 'No automation actions'
-		if (presentation.automation?.actions?.length) {
-			automationActions = `Automation Actions\n${buildLabelDisplayTypeTable(presentation.automation.actions)}`
-		}
-
-		return `Basic Information\n${basicInfo}\n\n` +
-			`${dashboardStates}\n\n` +
-			`${dashboardActions}\n\n` +
-			`${dashboardBasicPlus}\n\n` +
-			`${detailViews}\n\n` +
-			`${automationConditions}\n\n` +
-			`${automationActions}\n\n` +
-			'(Information is summarized, for full details use YAML or JSON flags.)'
+		return buildTableOutput(presentation, this.tableGenerator)
 	}
 
 	async run(): Promise<void> {
@@ -100,7 +110,7 @@ export default class PresentationCommand extends OutputAPICommand<PresentationDe
 		await super.setup(args, argv, flags)
 
 		this.processNormally(() => {
-			return this.client.presentation.getPresentation(args.vid)
+			return this.client.presentation.getPresentation(args.vid, args.mnmn)
 		})
 	}
 }


### PR DESCRIPTION
Fixes to CLI to address issues with device presentation commands and to align it with future direction of the API

* Corrected _presentation_ command arguments to correctly consist of a required `vid` and options `mnmn`
* Added  _devices:presentation_ command to display the presentation of a device
* Added _deviceprofiles:presentation_ command as a convenience to display the presentation of a profile
* Add -v flag to _deviceprofiles_ command to display `vid` and `mnmn` in the list table
