### PR TITLE
fix dry-run output bug

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -482,17 +482,18 @@ USAGE
   $ smartthings capabilities:create
 
 OPTIONS
-  -d, --dry-run          produce JSON but don't actually submit
-  -h, --help             show CLI help
-  -i, --input=input      specify input file
-  -j, --json             use JSON format of input and/or output
-  -o, --output=output    specify output file
-  -p, --profile=profile  [default: default] configuration profile
-  -t, --token=token      the auth token to use
-  -y, --yaml             use YAML format of input and/or output
-  --compact              use compact table format with no lines between body rows
-  --expanded             use expanded table format with a line between each body row
-  --indent=indent        specify indentation for formatting JSON or YAML output
+  -d, --dry-run              produce JSON but don't actually submit
+  -h, --help                 show CLI help
+  -i, --input=input          specify input file
+  -j, --json                 use JSON format of input and/or output
+  -n, --namespace=namespace  the namespace to create the capability under
+  -o, --output=output        specify output file
+  -p, --profile=profile      [default: default] configuration profile
+  -t, --token=token          the auth token to use
+  -y, --yaml                 use YAML format of input and/or output
+  --compact                  use compact table format with no lines between body rows
+  --expanded                 use expanded table format with a line between each body row
+  --indent=indent            specify indentation for formatting JSON or YAML output
 ```
 
 _See code: [dist/commands/capabilities/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/capabilities/create.ts)_
@@ -712,6 +713,7 @@ OPTIONS
   -o, --output=output    specify output file
   -p, --profile=profile  [default: default] configuration profile
   -t, --token=token      the auth token to use
+  -v, --verbose          include vid and mnmn in list output
   -y, --yaml             use YAML format of input and/or output
   --compact              use compact table format with no lines between body rows
   --expanded             use expanded table format with a line between each body row

--- a/packages/lib/src/io-command.ts
+++ b/packages/lib/src/io-command.ts
@@ -100,15 +100,15 @@ function formatFromFilename(filename: string): IOFormat {
  *   need to display a list to the user to choose from.
  */
 function writeOutputPrivate<T>(data: T, outputOptions: OutputOptions,
-		buildTableOutput: (data: T) => string, forceTableOutput?: boolean): void {
+		buildTableOutput?: (data: T) => string, forceTableOutput?: boolean): void {
 	let output: string
 
-	if (forceTableOutput) {
+	if (forceTableOutput && buildTableOutput) {
 		output = buildTableOutput(data)
-	} else if (outputOptions.format === IOFormat.JSON) {
-		output = JSON.stringify(data, null, outputOptions.indentLevel)
-	} else if (outputOptions.format === IOFormat.YAML) {
+	} else if (outputOptions.format === IOFormat.YAML ) {
 		output = yaml.safeDump(data, { indent: outputOptions.indentLevel })
+	} else if ((outputOptions.format === IOFormat.JSON) || !buildTableOutput) {
+		output = JSON.stringify(data, null, outputOptions.indentLevel)
 	} else {
 		output = buildTableOutput(data)
 	}
@@ -386,7 +386,7 @@ export abstract class InputOutputAPICommand<I, O> extends APICommand {
 	protected processNormally(executeCommand: (input: I) => Promise<O>): void {
 		if (this.flags['dry-run']) {
 			this.readInput().then(input => {
-				this.log(JSON.stringify(input, null, 4))
+				writeOutputPrivate(input, this.outputOptions)
 			}).catch(err => {
 				this.logger.error(`caught error ${err}`)
 				process.exit(1)


### PR DESCRIPTION
Fixed the dry-run output bug for the create commands. Users can now see their output in yaml via the yaml flag and save the output to a file via the output flag. 