### PR TITLE
Devices phase1 and selecting output commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,7 +16,6 @@ progress.
 
 <!-- toc -->
 * [Usage](#usage)
-* [Configuration](#configuration)
 * [Helpful Hints](#helpful-hints)
 * [Commands](#commands)
 * [Logging](#logging)
@@ -115,19 +114,20 @@ Commands are organized in a hierarchy that maps to the API hierarchy.
 * [`smartthings deviceprofiles:device-config [ID]`](#smartthings-deviceprofilesdevice-config-id)
 * [`smartthings deviceprofiles:presentation [ID]`](#smartthings-deviceprofilespresentation-id)
 * [`smartthings deviceprofiles:publish [ID]`](#smartthings-deviceprofilespublish-id)
+* [`smartthings deviceprofiles:update [ID]`](#smartthings-deviceprofilesupdate-id)
 * [`smartthings devices [ID]`](#smartthings-devices-id)
 * [`smartthings devices:capabilities-status ID COMPONENTID CAPABILITYID`](#smartthings-devicescapabilities-status-id-componentid-capabilityid)
 * [`smartthings devices:commands ID`](#smartthings-devicescommands-id)
 * [`smartthings devices:components-status ID COMPONENTID`](#smartthings-devicescomponents-status-id-componentid)
 * [`smartthings devices:delete [ID]`](#smartthings-devicesdelete-id)
 * [`smartthings devices:presentation [ID]`](#smartthings-devicespresentation-id)
-* [`smartthings devices:status ID`](#smartthings-devicesstatus-id)
+* [`smartthings devices:status [ID]`](#smartthings-devicesstatus-id)
 * [`smartthings generate:java`](#smartthings-generatejava)
 * [`smartthings generate:node`](#smartthings-generatenode)
 * [`smartthings help [COMMAND]`](#smartthings-help-command)
 * [`smartthings installedapps [ID]`](#smartthings-installedapps-id)
 * [`smartthings installedapps:delete [ID]`](#smartthings-installedappsdelete-id)
-* [`smartthings locations [ID]`](#smartthings-locations-id)
+* [`smartthings locations [IDORINDEX]`](#smartthings-locations-idorindex)
 * [`smartthings locations:create`](#smartthings-locationscreate)
 * [`smartthings locations:delete [ID]`](#smartthings-locationsdelete-id)
 * [`smartthings locations:rooms [IDORINDEX]`](#smartthings-locationsrooms-idorindex)
@@ -858,6 +858,32 @@ OPTIONS
 
 _See code: [dist/commands/deviceprofiles/publish.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/deviceprofiles/publish.ts)_
 
+## `smartthings deviceprofiles:update [ID]`
+
+update a device profile
+
+```
+USAGE
+  $ smartthings deviceprofiles:update [ID]
+
+ARGUMENTS
+  ID  device profile UUID or number in the list
+
+OPTIONS
+  -h, --help             show CLI help
+  -i, --input=input      specify input file
+  -j, --json             use JSON format of input and/or output
+  -o, --output=output    specify output file
+  -p, --profile=profile  [default: default] configuration profile
+  -t, --token=token      the auth token to use
+  -y, --yaml             use YAML format of input and/or output
+  --compact              use compact table format with no lines between body rows
+  --expanded             use expanded table format with a line between each body row
+  --indent=indent        specify indentation for formatting JSON or YAML output
+```
+
+_See code: [dist/commands/deviceprofiles/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/deviceprofiles/update.ts)_
+
 ## `smartthings devices [ID]`
 
 list all devices available in a user account or retrieve a single device
@@ -1007,21 +1033,27 @@ OPTIONS
 
 _See code: [dist/commands/devices/presentation.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/devices/presentation.ts)_
 
-## `smartthings devices:status ID`
+## `smartthings devices:status [ID]`
 
 get the current status of all of a device's component's attributes
 
 ```
 USAGE
-  $ smartthings devices:status ID
+  $ smartthings devices:status [ID]
 
 ARGUMENTS
   ID  the device id
 
 OPTIONS
   -h, --help             show CLI help
+  -j, --json             use JSON format of input and/or output
+  -o, --output=output    specify output file
   -p, --profile=profile  [default: default] configuration profile
   -t, --token=token      the auth token to use
+  -y, --yaml             use YAML format of input and/or output
+  --compact              use compact table format with no lines between body rows
+  --expanded             use expanded table format with a line between each body row
+  --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
 _See code: [dist/commands/devices/status.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/devices/status.ts)_
@@ -1118,16 +1150,16 @@ OPTIONS
 
 _See code: [dist/commands/installedapps/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/installedapps/delete.ts)_
 
-## `smartthings locations [ID]`
+## `smartthings locations [IDORINDEX]`
 
 get a specific Location
 
 ```
 USAGE
-  $ smartthings locations [ID]
+  $ smartthings locations [IDORINDEX]
 
 ARGUMENTS
-  ID  the location id or number in list
+  IDORINDEX  the location id or number in list
 
 OPTIONS
   -h, --help             show CLI help
@@ -1450,6 +1482,8 @@ OPTIONS
   --indent=indent              specify indentation for formatting JSON or YAML output
 ```
 
+_See code: [dist/commands/rules.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/rules.ts)_
+
 ## `smartthings rules:create`
 
 create a rule
@@ -1473,6 +1507,8 @@ OPTIONS
   --indent=indent              specify indentation for formatting JSON or YAML output
 ```
 
+_See code: [dist/commands/rules/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/rules/create.ts)_
+
 ## `smartthings rules:delete [ID]`
 
 delete a rule
@@ -1490,6 +1526,8 @@ OPTIONS
   -p, --profile=profile        [default: default] configuration profile
   -t, --token=token            the auth token to use
 ```
+
+_See code: [dist/commands/rules/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/rules/delete.ts)_
 
 ## `smartthings rules:update [ID]`
 
@@ -1515,6 +1553,8 @@ OPTIONS
   --expanded                   use expanded table format with a line between each body row
   --indent=indent              specify indentation for formatting JSON or YAML output
 ```
+
+_See code: [dist/commands/rules/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0/dist/commands/rules/update.ts)_
 
 ## `smartthings schema [ID]`
 

--- a/packages/cli/src/commands/apps/oauth.ts
+++ b/packages/cli/src/commands/apps/oauth.ts
@@ -1,14 +1,14 @@
 import { App, AppOAuth } from '@smartthings/core-sdk'
 
-import { ListingOutputAPICommand } from '@smartthings/cli-lib'
+import {SelectingOutputAPICommand} from '@smartthings/cli-lib'
 
 
 export const tableFieldDefinitions = ['clientName', 'scope', 'redirectUris']
 
-export default class AppOauthCommand extends ListingOutputAPICommand<AppOAuth, App> {
+export default class AppOauthCommand extends SelectingOutputAPICommand<AppOAuth, App> {
 	static description = 'get OAuth settings of the app'
 
-	static flags = ListingOutputAPICommand.flags
+	static flags = SelectingOutputAPICommand.flags
 
 	static args = [{
 		name: 'id',
@@ -17,6 +17,7 @@ export default class AppOauthCommand extends ListingOutputAPICommand<AppOAuth, A
 
 	primaryKeyName = 'appId'
 	sortKeyName = 'displayName'
+	acceptIndexId = true
 
 	protected tableFieldDefinitions = tableFieldDefinitions
 

--- a/packages/cli/src/commands/apps/settings.ts
+++ b/packages/cli/src/commands/apps/settings.ts
@@ -1,6 +1,6 @@
 import { App, AppSettings } from '@smartthings/core-sdk'
 
-import { APICommand, ListingOutputAPICommand } from '@smartthings/cli-lib'
+import {APICommand, SelectingOutputAPICommand} from '@smartthings/cli-lib'
 
 
 export function buildTableOutput(this: APICommand, appSettings: AppSettings): string {
@@ -13,10 +13,10 @@ export function buildTableOutput(this: APICommand, appSettings: AppSettings): st
 	return table.toString()
 }
 
-export default class AppSettingsCommand extends ListingOutputAPICommand<AppSettings, App> {
+export default class AppSettingsCommand extends SelectingOutputAPICommand<AppSettings, App> {
 	static description = 'get OAuth settings of the app'
 
-	static flags = ListingOutputAPICommand.flags
+	static flags = SelectingOutputAPICommand.flags
 
 	static args = [{
 		name: 'id',
@@ -25,6 +25,7 @@ export default class AppSettingsCommand extends ListingOutputAPICommand<AppSetti
 
 	primaryKeyName = 'appId'
 	sortKeyName = 'displayName'
+	acceptIndexId = true
 
 	protected buildTableOutput = buildTableOutput
 

--- a/packages/cli/src/commands/deviceprofiles/delete.ts
+++ b/packages/cli/src/commands/deviceprofiles/delete.ts
@@ -15,6 +15,7 @@ export default class DeviceProfileDeleteCommand extends SelectingAPICommand<Devi
 
 	primaryKeyName = 'id'
 	sortKeyName = 'name'
+	listTableFieldDefinitions = ['name', 'status', 'id']
 
 	static examples = [
 		'$ smartthings deviceprofiles:delete 63b8c91e-9686-4c43-9afb-fbd9f77e3bb0  # delete profile with this UUID',

--- a/packages/cli/src/commands/deviceprofiles/device-config.ts
+++ b/packages/cli/src/commands/deviceprofiles/device-config.ts
@@ -1,14 +1,14 @@
 import { DeviceProfile, PresentationDeviceConfig } from '@smartthings/core-sdk'
 
-import { ListingOutputAPICommand } from '@smartthings/cli-lib'
+import { SelectingOutputAPICommand } from '@smartthings/cli-lib'
 
 import { buildTableOutput } from '../presentation/device-config'
 
 
-export default class ProfilePresentationCommand extends ListingOutputAPICommand<PresentationDeviceConfig, DeviceProfile> {
+export default class ProfilePresentationCommand extends SelectingOutputAPICommand<PresentationDeviceConfig, DeviceProfile> {
 	static description = 'get the presentation associated with a device profile'
 
-	static flags = ListingOutputAPICommand.flags
+	static flags = SelectingOutputAPICommand.flags
 
 	static args = [{
 		name: 'id',
@@ -17,11 +17,10 @@ export default class ProfilePresentationCommand extends ListingOutputAPICommand<
 
 	primaryKeyName = 'id'
 	sortKeyName = 'name'
+	listTableFieldDefinitions = ['name', 'status', 'id']
+	acceptIndexId = true
 
-	protected buildTableOutput(presentation: PresentationDeviceConfig): string {
-		// @ts-ignore
-		return buildTableOutput(presentation, this.tableGenerator)
-	}
+	protected buildTableOutput = buildTableOutput
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(ProfilePresentationCommand	)

--- a/packages/cli/src/commands/deviceprofiles/presentation.ts
+++ b/packages/cli/src/commands/deviceprofiles/presentation.ts
@@ -1,14 +1,14 @@
 import { DeviceProfile, PresentationDevicePresentation } from '@smartthings/core-sdk'
 
-import { ListingOutputAPICommand } from '@smartthings/cli-lib'
+import {SelectingOutputAPICommand} from '@smartthings/cli-lib'
 
 import { buildTableOutput } from '../presentation'
 
 
-export default class ProfilePresentationCommand extends ListingOutputAPICommand<PresentationDevicePresentation, DeviceProfile> {
+export default class ProfilePresentationCommand extends SelectingOutputAPICommand<PresentationDevicePresentation, DeviceProfile> {
 	static description = 'get the presentation associated with a device profile'
 
-	static flags = ListingOutputAPICommand.flags
+	static flags = SelectingOutputAPICommand.flags
 
 	static args = [{
 		name: 'id',
@@ -17,6 +17,8 @@ export default class ProfilePresentationCommand extends ListingOutputAPICommand<
 
 	primaryKeyName = 'id'
 	sortKeyName = 'name'
+	listTableFieldDefinitions = ['name', 'status', 'id']
+	acceptIndexId = true
 
 	protected buildTableOutput(presentation: PresentationDevicePresentation): string {
 		return buildTableOutput(presentation, this.tableGenerator)

--- a/packages/cli/src/commands/deviceprofiles/publish.ts
+++ b/packages/cli/src/commands/deviceprofiles/publish.ts
@@ -17,6 +17,7 @@ export default class DeviceProfilePublishCommand extends SelectingOutputAPIComma
 
 	primaryKeyName = 'id'
 	sortKeyName = 'name'
+	listTableFieldDefinitions = ['name', 'status', 'id']
 
 	protected buildTableOutput = buildTableOutput
 

--- a/packages/cli/src/commands/deviceprofiles/update.ts
+++ b/packages/cli/src/commands/deviceprofiles/update.ts
@@ -30,6 +30,7 @@ export default class DeviceProfileUpdateCommand extends SelectingInputOutputAPIC
 
 	primaryKeyName = 'id'
 	sortKeyName = 'name'
+	listTableFieldDefinitions = ['name', 'status', 'id']
 
 	protected buildTableOutput = buildTableOutput
 

--- a/packages/cli/src/commands/devices/health.ts
+++ b/packages/cli/src/commands/devices/health.ts
@@ -1,0 +1,32 @@
+import { Device, DeviceHealth } from '@smartthings/core-sdk'
+
+import {SelectingOutputAPICommand} from '@smartthings/cli-lib'
+
+
+export default class DeviceHealthCommand extends SelectingOutputAPICommand<DeviceHealth, Device> {
+	static description = 'get the current health status of a device'
+
+	static flags = SelectingOutputAPICommand.flags
+
+	static args = [{
+		name: 'id',
+		description: 'the device id',
+	}]
+
+	primaryKeyName = 'deviceId'
+	sortKeyName = 'label'
+	listTableFieldDefinitions = ['label', 'name', 'type', 'deviceId']
+	tableFieldDefinitions = ['deviceId', 'state', 'lastUpdatedDate']
+	acceptIndexId = true
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(DeviceHealthCommand)
+		await super.setup(args, argv, flags)
+
+		this.processNormally(
+			args.id,
+			() => this.client.devices.list(),
+			(id) => this.client.devices.getHealth(id),
+		)
+	}
+}

--- a/packages/cli/src/commands/devices/presentation.ts
+++ b/packages/cli/src/commands/devices/presentation.ts
@@ -1,16 +1,16 @@
 import { Device, PresentationDevicePresentation } from '@smartthings/core-sdk'
 
-import { ListingOutputAPICommand } from '@smartthings/cli-lib'
+import {SelectingOutputAPICommand} from '@smartthings/cli-lib'
 
 import { buildTableOutput } from '../presentation'
 
 
 export const tableFieldDefinitions = ['clientName', 'scope', 'redirectUris']
 
-export default class DevicePresentationCommand extends ListingOutputAPICommand<PresentationDevicePresentation, Device> {
+export default class DevicePresentationCommand extends SelectingOutputAPICommand<PresentationDevicePresentation, Device> {
 	static description = 'get a device presentation'
 
-	static flags = ListingOutputAPICommand.flags
+	static flags = SelectingOutputAPICommand.flags
 
 	static args = [{
 		name: 'id',
@@ -19,6 +19,7 @@ export default class DevicePresentationCommand extends ListingOutputAPICommand<P
 
 	primaryKeyName = 'deviceId'
 	sortKeyName = 'label'
+	acceptIndexId = true
 
 	protected buildTableOutput(presentation: PresentationDevicePresentation): string {
 		return buildTableOutput(presentation, this.tableGenerator)

--- a/packages/cli/src/commands/devices/status.ts
+++ b/packages/cli/src/commands/devices/status.ts
@@ -1,23 +1,31 @@
-import { APICommand } from '@smartthings/cli-lib'
+import { Device, DeviceStatus } from '@smartthings/core-sdk'
+
+import {SelectingOutputAPICommand} from '@smartthings/cli-lib'
 
 
-export default class DevicesStatus extends APICommand {
+export default class DeviceStatusCommand extends SelectingOutputAPICommand<DeviceStatus, Device> {
 	static description = "get the current status of all of a device's component's attributes"
 
-	static flags = APICommand.flags
+	static flags = SelectingOutputAPICommand.flags
 
 	static args = [{
 		name: 'id',
 		description: 'the device id',
-		required: true,
 	}]
 
+	primaryKeyName = 'deviceId'
+	sortKeyName = 'label'
+	listTableFieldDefinitions = ['label', 'name', 'type', 'deviceId']
+	acceptIndexId = true
+
 	async run(): Promise<void> {
-		const { args, argv, flags } = this.parse(DevicesStatus)
+		const { args, argv, flags } = this.parse(DeviceStatusCommand)
 		await super.setup(args, argv, flags)
 
-		this.client.devices.getStatus(args.id).then(async status => {
-			this.log(JSON.stringify(status, null, 4))
-		})
+		this.processNormally(
+			args.id,
+			() => this.client.devices.list(),
+			(id) => this.client.devices.getStatus(id),
+		)
 	}
 }

--- a/packages/cli/src/commands/devices/status.ts
+++ b/packages/cli/src/commands/devices/status.ts
@@ -3,6 +3,14 @@ import { Device, DeviceStatus } from '@smartthings/core-sdk'
 import {APICommand, SelectingOutputAPICommand} from '@smartthings/cli-lib'
 
 
+function prettyPrintAttribute(value: unknown): string {
+	let result = JSON.stringify(value)
+	if (result.length > 50) {
+		result = JSON.stringify(value, null, 2)
+	}
+	return result
+}
+
 export function buildTableOutput(this: APICommand, data: DeviceStatus): string {
 	let output = ''
 	if (data.components) {
@@ -18,7 +26,7 @@ export function buildTableOutput(this: APICommand, data: DeviceStatus): string {
 						capabilityName,
 						attributeName,
 						attribute.value !== null ?
-							`${JSON.stringify(attribute.value)}${attribute.unit ? ' ' + attribute.unit : ''}` : ''])
+							`${prettyPrintAttribute(attribute.value)}${attribute.unit ? ' ' + attribute.unit : ''}` : ''])
 				}
 			}
 			output += table.toString()

--- a/packages/cli/src/commands/devices/status.ts
+++ b/packages/cli/src/commands/devices/status.ts
@@ -1,7 +1,32 @@
 import { Device, DeviceStatus } from '@smartthings/core-sdk'
 
-import {SelectingOutputAPICommand} from '@smartthings/cli-lib'
+import {APICommand, SelectingOutputAPICommand} from '@smartthings/cli-lib'
 
+
+export function buildTableOutput(this: APICommand, data: DeviceStatus): string {
+	let output = ''
+	if (data.components) {
+		for (const componentId of Object.keys(data.components)) {
+			const table = this.tableGenerator.newOutputTable({head: ['Capability', 'Attribute','Value']})
+			output += `\n${componentId} component\n`
+			const component = data.components[componentId]
+			for (const capabilityName of Object.keys(component)) {
+				const capability = component[capabilityName]
+				for (const attributeName of Object.keys(capability)) {
+					const attribute = capability[attributeName]
+					table.push([
+						capabilityName,
+						attributeName,
+						attribute.value !== null ?
+							`${JSON.stringify(attribute.value)}${attribute.unit ? ' ' + attribute.unit : ''}` : ''])
+				}
+			}
+			output += table.toString()
+			output += '\n'
+		}
+	}
+	return output
+}
 
 export default class DeviceStatusCommand extends SelectingOutputAPICommand<DeviceStatus, Device> {
 	static description = "get the current status of all of a device's component's attributes"
@@ -12,6 +37,8 @@ export default class DeviceStatusCommand extends SelectingOutputAPICommand<Devic
 		name: 'id',
 		description: 'the device id',
 	}]
+
+	protected buildTableOutput = buildTableOutput
 
 	primaryKeyName = 'deviceId'
 	sortKeyName = 'label'

--- a/packages/lib/src/io-command.ts
+++ b/packages/lib/src/io-command.ts
@@ -445,30 +445,6 @@ applyMixins(ListingOutputAPICommandBase, [Outputable, Outputting, Listing], { me
 
 export abstract class ListingOutputAPICommand<O, L> extends ListingOutputAPICommandBase<string, O, L> {
 	protected translateToId = stringTranslateToId
-	// protected async translateToId(idOrIndex: string,
-	// 		listFunction: ListCallback<L>): Promise<string> {
-	// 	if (!idOrIndex.match(validIndex)) {
-	// 		// idOrIndex isn't a valid index so has to be an id (or bad)
-	// 		return idOrIndex
-	// 	}
-	//
-	// 	const index = Number.parseInt(idOrIndex)
-	//
-	// 	const items = this.sort(await listFunction())
-	// 	const matchingItem: L = items[index - 1]
-	// 	if (!(this.primaryKeyName in matchingItem)) {
-	// 		throw Error(`did not find key ${this.primaryKeyName} in data`)
-	// 	}
-	// 	// @ts-ignore
-	// 	const pk = matchingItem[this.primaryKeyName]
-	// 	if (typeof pk === 'string') {
-	// 		return pk
-	// 	}
-	//
-	// 	throw Error(`invalid type ${typeof pk} for primary key`  +
-	// 		` ${this.primaryKeyName} in ${JSON.stringify(matchingItem)}`)
-	// }
-
 	static flags = ListingOutputAPICommandBase.flags
 }
 


### PR DESCRIPTION
Started bringing device commands up to current practices but ran into issues with multiple, non-ID arguments that I decided to defer to a second PR.

Also switched a number of commands that display non-definition data for objects such as `apps:oauth` from `ListingOutputAPICommand ` to `SelectingOutputAPICommand` for consistency between commands that accept indexes on the command line (because they don't modify anything) and those that don't. Added an argument check to display a descriptive error message when an index is provided for commands that don't support it (because they modify data) rather than just letting the command fail with a 403, which can be confusing.