### PR TITLE
chore: include publishConfig for scoped packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,9 @@
 		"/oclif.manifest.json",
 		"!*/__tests__"
 	],
+	"publishConfig": {
+		"access": "public"
+	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/SmartThingsCommunity/smartthings-cli.git"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -13,6 +13,9 @@
 		"README.md",
 		"!*/__tests__"
 	],
+	"publishConfig": {
+		"access": "public"
+	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/SmartThingsCommunity/smartthings-cli.git",

--- a/packages/testlib/package.json
+++ b/packages/testlib/package.json
@@ -13,6 +13,9 @@
 		"README.md",
 		"!*/__tests__"
 	],
+	"publishConfig": {
+		"access": "public"
+	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/SmartThingsCommunity/smartthings-cli.git",


### PR DESCRIPTION
* add publishConfig to scoped packages as required by npm (private by default)

See https://github.com/lerna/lerna/issues/1821#issuecomment-551393580 and https://github.com/lerna/lerna/tree/master/commands/publish#publishconfigaccess