### PR TITLE
chore: disable Windows CI runner

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # add/remove versions as we move support forward
         node-version: [12.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
* disable `windows-latest` temporarily while we look into why builds are failing on it