### PR TITLE
make cliConfig truly global

### DIFF
--- a/packages/lib/src/cli-config.ts
+++ b/packages/lib/src/cli-config.ts
@@ -69,4 +69,10 @@ export class CLIConfig {
 	}
 }
 
-export const cliConfig = new CLIConfig()
+/* eslint-disable @typescript-eslint/no-explicit-any */
+if (!('_cliConfig' in (global as any))) {
+	(global as any)._cliConfig = new CLIConfig()
+}
+
+export const cliConfig = (global as any)._cliConfig
+/* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
This is my attempt at making the `cliConfig` truly global so the same object is used in plugins as well as the core commands.