### PR TITLE
fix: make logManager and credentials work across with plugins

### DIFF
--- a/packages/lib/src/cli-config.ts
+++ b/packages/lib/src/cli-config.ts
@@ -74,5 +74,5 @@ if (!('_cliConfig' in (global as any))) {
 	(global as any)._cliConfig = new CLIConfig()
 }
 
-export const cliConfig = (global as any)._cliConfig
+export const cliConfig: CLIConfig = (global as any)._cliConfig
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/packages/lib/src/logger.ts
+++ b/packages/lib/src/logger.ts
@@ -87,4 +87,10 @@ export class LogManager {
 	}
 }
 
-export const logManager: LogManager = new LogManager()
+/* eslint-disable @typescript-eslint/no-explicit-any */
+if (!('_logManager' in (global as any))) {
+	(global as any)._logManager = new LogManager()
+}
+
+export const logManager: LogManager = (global as any)._logManager
+/* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
I found a couple more places where things worked differently when the module was linked vs. downloaded from npm. This fixes those.