### PR TITLE
fix: corrected processing of command line input into command line id

### DIFF
--- a/packages/cli/src/commands/capabilities/delete.ts
+++ b/packages/cli/src/commands/capabilities/delete.ts
@@ -28,7 +28,8 @@ export default class CapabilitiesDeleteCommand extends SelectingAPICommandBase<C
 		const { args, argv, flags } = this.parse(CapabilitiesDeleteCommand)
 		await super.setup(args, argv, flags)
 
-		this.processNormally({ id: args.id, version: args.version },
+		const optionalId = args.id ? { id: args.id, version: args.version ?? 1 } : undefined
+		this.processNormally(optionalId,
 			async () => this.getCustomByNamespace(),
 			async (id) => { this.client.capabilities.delete(id.id, id.version) },
 			'capability {{id}} deleted')


### PR DESCRIPTION
Fixed a bug where we were passing an empty id to `processNormally` instead of no id when no id was specified on the command line.