### PR TITLE
fix: Update to accommodate switch from vid to presentationId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4458,9 +4458,9 @@
 			}
 		},
 		"@smartthings/core-sdk": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-0.6.0.tgz",
-			"integrity": "sha512-lfkNFfTK0b7IpSHRwUW3J2pXPx4jQtgOWsHBSt/9F3nfUHETEOHnBLzCaaVkvBCU/3a6YlAX8DgB/B9fI6PUbg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-1.1.0.tgz",
+			"integrity": "sha512-gs2GtQ2mrglwjzS23Z1XhmPgpfTgXcAnzHPNW7uYhaGo13oYwS5g8JkcKPuz4Ux6PK02Eeh3mpjWMn7Dg6pQ7A==",
 			"requires": {
 				"async-mutex": "^0.2.1",
 				"axios": "^0.19.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"dependencies": {
 		"@oclif/command": "^1.5.19",
 		"@oclif/config": "^1.15.1",
-		"@smartthings/core-sdk": "^0.6.0",
+		"@smartthings/core-sdk": "^1.1.0",
 		"js-yaml": "^3.13.1",
 		"log4js": "^6.3.0",
 		"tslib": "^1.11.1"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -147,8 +147,8 @@ that maps to that hierarchy.
 * [`smartthings plugins:link PLUGIN`](#smartthings-pluginslink-plugin)
 * [`smartthings plugins:uninstall PLUGIN...`](#smartthings-pluginsuninstall-plugin)
 * [`smartthings plugins:update`](#smartthings-pluginsupdate)
-* [`smartthings presentation VID [MNMN]`](#smartthings-presentation-vid-mnmn)
-* [`smartthings presentation:device-config VID`](#smartthings-presentationdevice-config-vid)
+* [`smartthings presentation PRESENTATIONID [MANUFACTURERNAME]`](#smartthings-presentation-presentationid-manufacturername)
+* [`smartthings presentation:device-config PRESENTATIONID`](#smartthings-presentationdevice-config-presentationid)
 * [`smartthings presentation:device-config:create`](#smartthings-presentationdevice-configcreate)
 * [`smartthings presentation:device-config:generate ID`](#smartthings-presentationdevice-configgenerate-id)
 * [`smartthings rules [IDORINDEX]`](#smartthings-rules-idorindex)
@@ -718,7 +718,7 @@ OPTIONS
   -o, --output=output    specify output file
   -p, --profile=profile  [default: default] configuration profile
   -t, --token=token      the auth token to use
-  -v, --verbose          include vid and mnmn in list output
+  -v, --verbose          include presentationId and manufacturerName in list output
   -y, --yaml             use YAML format of input and/or output
   --compact              use compact table format with no lines between body rows
   --expanded             use expanded table format with a line between each body row
@@ -1737,17 +1737,17 @@ OPTIONS
 
 _See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v1.9.0/src/commands/plugins/update.ts)_
 
-## `smartthings presentation VID [MNMN]`
+## `smartthings presentation PRESENTATIONID [MANUFACTURERNAME]`
 
 query device presentation by vid
 
 ```
 USAGE
-  $ smartthings presentation VID [MNMN]
+  $ smartthings presentation PRESENTATIONID [MANUFACTURERNAME]
 
 ARGUMENTS
-  VID   system generated identifier that corresponds to a device presentation
-  MNMN  manufacturer ID. Defaults to SmartThingsCommunity
+  PRESENTATIONID    system generated identifier that corresponds to a device presentation
+  MANUFACTURERNAME  manufacturer name. Defaults to SmartThingsCommunity
 
 OPTIONS
   -h, --help             show CLI help
@@ -1763,16 +1763,16 @@ OPTIONS
 
 _See code: [dist/commands/presentation.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.10/dist/commands/presentation.ts)_
 
-## `smartthings presentation:device-config VID`
+## `smartthings presentation:device-config PRESENTATIONID`
 
-query device config by vid
+query device config by presentationId
 
 ```
 USAGE
-  $ smartthings presentation:device-config VID
+  $ smartthings presentation:device-config PRESENTATIONID
 
 ARGUMENTS
-  VID  system generated identifier that corresponds to a device presentation
+  PRESENTATIONID  system generated identifier that corresponds to a device presentation
 
 OPTIONS
   -h, --help             show CLI help

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,7 +59,7 @@
 		"@oclif/plugin-not-found": "^1.2.3",
 		"@oclif/plugin-plugins": "^1.9.0",
 		"@smartthings/cli-lib": "^0.0.0-pre.10",
-		"@smartthings/core-sdk": "^0.6.0",
+		"@smartthings/core-sdk": "^1.1.0",
 		"aws-sdk": "^2.690.0",
 		"generator-smartthings": "^1.5.0",
 		"inquirer": "^7.3.3",

--- a/packages/cli/src/commands/deviceprofiles.ts
+++ b/packages/cli/src/commands/deviceprofiles.ts
@@ -14,8 +14,8 @@ export function buildTableOutput(this: APICommand, data: DeviceProfile): string 
 	table.push(['Id', data.id])
 	table.push(['Device Type', data.metadata?.deviceType ?? ''])
 	table.push(['OCF Device Type', data.metadata?.ocfDeviceType ?? ''])
-	table.push(['mnmn', data.metadata?.mnmn ?? ''])
-	table.push(['vid', data.metadata?.vid ?? ''])
+	table.push(['Manufacturer Name', data.metadata?.mnmn ?? ''])
+	table.push(['Presentation ID', data.metadata?.vid ?? ''])
 	table.push(['Status', data.status])
 	return table.toString()
 }
@@ -26,7 +26,7 @@ export default class DeviceProfilesList extends ListingOutputAPICommand<DevicePr
 	static flags = {
 		...ListingOutputAPICommand.flags,
 		verbose: flags.boolean({
-			description: 'include vid and mnmn in list output',
+			description: 'include presentationId and manufacturerName in list output',
 			char: 'v',
 		}),
 	}
@@ -60,8 +60,8 @@ export default class DeviceProfilesList extends ListingOutputAPICommand<DevicePr
 		await super.setup(args, argv, flags)
 
 		if (this.flags.verbose) {
-			this.listTableFieldDefinitions.push({ label: 'vid', value: (item) => item.metadata ? item.metadata.vid : '' })
-			this.listTableFieldDefinitions.push({ label: 'mnmn', value: (item) => item.metadata ? item.metadata.mnmn : '' })
+			this.listTableFieldDefinitions.push({ label: 'Presentation ID', value: (item) => item.metadata ? item.metadata.vid : '' })
+			this.listTableFieldDefinitions.push({ label: 'Manufacturer Name', value: (item) => item.metadata ? item.metadata.mnmn : '' })
 		}
 
 		this.processNormally(

--- a/packages/cli/src/commands/deviceprofiles/create.ts
+++ b/packages/cli/src/commands/deviceprofiles/create.ts
@@ -97,8 +97,8 @@ export async function createWithDefaultConfig(client: SmartThingsClient, data: D
 	if (!deviceProfile.metadata) {
 		deviceProfile.metadata = {}
 	}
-	deviceProfile.metadata.vid = deviceConfig.vid
-	deviceProfile.metadata.mnmn = deviceConfig.mnmn
+	deviceProfile.metadata.vid = deviceConfig.presentationId
+	deviceProfile.metadata.mnmn = deviceConfig.manufacturerName
 
 	// Update the profile with the vid and mnmn
 	deviceProfile = await client.deviceProfiles.update(profileId, deviceProfile)

--- a/packages/cli/src/commands/deviceprofiles/update.ts
+++ b/packages/cli/src/commands/deviceprofiles/update.ts
@@ -13,8 +13,8 @@ export function buildTableOutput(this: APICommand, data: DeviceProfile): string 
 	table.push(['Id', data.id])
 	table.push(['Device Type', data.metadata?.deviceType ?? ''])
 	table.push(['OCF Device Type', data.metadata?.ocfDeviceType ?? ''])
-	table.push(['mnmn', data.metadata?.mnmn ?? ''])
-	table.push(['vid', data.metadata?.vid ?? ''])
+	table.push(['Manufacturer Name', data.metadata?.mnmn ?? ''])
+	table.push(['Presentation ID', data.metadata?.vid ?? ''])
 	table.push(['Status', data.status])
 	return table.toString()
 }

--- a/packages/cli/src/commands/deviceprofiles/view.ts
+++ b/packages/cli/src/commands/deviceprofiles/view.ts
@@ -39,8 +39,8 @@ export function buildTableOutput(this: APICommand, data: DeviceDefinition): stri
 	table.push(['Id', data.id])
 	table.push(['Device Type', data.metadata?.deviceType ?? ''])
 	table.push(['OCF Device Type', data.metadata?.ocfDeviceType ?? ''])
-	table.push(['mnmn', data.metadata?.mnmn ?? ''])
-	table.push(['vid', data.metadata?.vid ?? ''])
+	table.push(['Manufacturer Name', data.metadata?.mnmn ?? ''])
+	table.push(['Presentation ID', data.metadata?.vid ?? ''])
 	table.push(['Status', data.status])
 	if (data.view) {
 		if (data.view.dashboard) {
@@ -68,8 +68,8 @@ export function buildTableOutput(this: APICommand, data: DeviceDefinition): stri
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function prunePresentation(view: { [key: string]: any }): void {
-	delete view.mnmn
-	delete view.vid
+	delete view.manufacturerName
+	delete view.presentationId
 	delete view.type
 	if (view.dpInfo === null) {
 		delete view.dpInfo

--- a/packages/cli/src/commands/deviceprofiles/view/create.ts
+++ b/packages/cli/src/commands/deviceprofiles/view/create.ts
@@ -48,8 +48,8 @@ export default class DeviceDefCreateCommand extends InputOutputAPICommand<Device
 		if (!data.metadata) {
 			data.metadata = {}
 		}
-		data.metadata.vid = deviceConfig.vid
-		data.metadata.mnmn = deviceConfig.mnmn
+		data.metadata.vid = deviceConfig.presentationId
+		data.metadata.mnmn = deviceConfig.manufacturerName
 		delete data.view
 
 		// Create the profile

--- a/packages/cli/src/commands/deviceprofiles/view/update.ts
+++ b/packages/cli/src/commands/deviceprofiles/view/update.ts
@@ -73,8 +73,8 @@ export default class CapabilitiesUpdate extends SelectingInputOutputAPICommand<D
 				if (!profileData.metadata) {
 					profileData.metadata = {}
 				}
-				profileData.metadata.vid = presentation.vid
-				profileData.metadata.mnmn = presentation.mnmn
+				profileData.metadata.vid = presentation.presentationId
+				profileData.metadata.mnmn = presentation.manufacturerName
 				const profile = await this.client.deviceProfiles.update(id, cleanupRequest(profileData))
 
 				return {...profile, presentation: prunePresentationValues(presentation)}

--- a/packages/cli/src/commands/presentation.ts
+++ b/packages/cli/src/commands/presentation.ts
@@ -5,7 +5,7 @@ import {OutputAPICommand, TableGenerator} from '@smartthings/cli-lib'
 
 export function buildTableOutput(presentation: PresentationDevicePresentation, tableGenerator: TableGenerator): string {
 	const basicInfo = tableGenerator.buildTableFromItem(presentation, [
-		{ prop: 'vid', label: 'VID' }, { prop: 'mnmn', label: 'MNMN' }, 'iconUrl',
+		{ prop: 'presentationId', label: 'Presentation ID' }, { prop: 'manufacturerName', label: 'Manufacturer Name' }, 'iconUrl',
 	])
 
 	let dashboardStates = 'No dashboard states'
@@ -90,13 +90,13 @@ export default class PresentationCommand extends OutputAPICommand<PresentationDe
 
 	static args = [
 		{
-			name: 'vid',
+			name: 'presentationId',
 			description: 'system generated identifier that corresponds to a device presentation',
 			required: true,
 		},
 		{
-			name: 'mnmn',
-			description: 'manufacturer ID. Defaults to SmartThingsCommunity',
+			name: 'manufacturerName',
+			description: 'manufacturer name. Defaults to SmartThingsCommunity',
 			required: false,
 		},
 	]
@@ -110,7 +110,7 @@ export default class PresentationCommand extends OutputAPICommand<PresentationDe
 		await super.setup(args, argv, flags)
 
 		this.processNormally(() => {
-			return this.client.presentation.getPresentation(args.vid, args.mnmn)
+			return this.client.presentation.getPresentation(args.presentationId, args.manufacturerName)
 		})
 	}
 }

--- a/packages/cli/src/commands/presentation/device-config.ts
+++ b/packages/cli/src/commands/presentation/device-config.ts
@@ -7,8 +7,8 @@ export function buildTableOutput(this: APICommand, deviceConfig: PresentationDev
 	const tableGenerator = this.tableGenerator
 	// This could use more advanced methods of tableGenerator.
 	const table = tableGenerator.newOutputTable()
-	table.push(['VID', deviceConfig.vid])
-	table.push(['MNMN', deviceConfig.mnmn])
+	table.push(['Presentation ID', deviceConfig.presentationId])
+	table.push(['Manufacturer Name', deviceConfig.manufacturerName])
 	if (deviceConfig.type) {
 		table.push(['Type', deviceConfig.type])
 	}
@@ -77,12 +77,12 @@ export function buildTableOutput(this: APICommand, deviceConfig: PresentationDev
 }
 
 export default class Devices extends OutputAPICommand<PresentationDeviceConfig> {
-	static description = 'query device config by vid'
+	static description = 'query device config by presentationId'
 
 	static flags = OutputAPICommand.flags
 
 	static args = [{
-		name: 'vid',
+		name: 'presentationId',
 		description: 'system generated identifier that corresponds to a device presentation',
 		required: true,
 	}]
@@ -94,7 +94,7 @@ export default class Devices extends OutputAPICommand<PresentationDeviceConfig> 
 		await super.setup(args, argv, flags)
 
 		this.processNormally(() => {
-			return this.client.presentation.get(args.vid)
+			return this.client.presentation.get(args.presentationId)
 		})
 	}
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -22,7 +22,7 @@
 		"directory": "packages/testlib"
 	},
 	"dependencies": {
-		"@smartthings/core-sdk": "^0.6.0",
+		"@smartthings/core-sdk": "^1.1.0",
 		"axios": "^0.19.2",
 		"cli-table": "^0.3.1",
 		"express": "^4.17.1",


### PR DESCRIPTION
Note that although there are some code changes here to use `presentationId` and `manufacturerName` in the device config object there is actually no functional change to the CLI at this time.  Also long as the API still accepts `vid` and `mnmn` they will continue to work in device config bodies. With this change, however, the CLI will be ready for whenever the API stops supporting the old names. The rest of these changes here are argument naming and documentation changes.