### PR TITLE
feat: use separate file for logging config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,6 @@
 {
 	"name": "root",
 	"private": true,
-	"dependencies": {
-		"@oclif/command": "^1.5.19",
-		"@oclif/config": "^1.15.1",
-		"@smartthings/core-sdk": "^1.1.2",
-		"js-yaml": "^3.13.1",
-		"log4js": "^6.3.0",
-		"tslib": "^1.11.1"
-	},
 	"devDependencies": {
 		"@oclif/dev-cli": "^1.22.2",
 		"@types/jest": "^26.0.9",

--- a/packages/cli/doc/configuration.md
+++ b/packages/cli/doc/configuration.md
@@ -51,12 +51,11 @@ using it).
 
 The CLI uses [log4js](https://log4js-node.github.io/log4js-node/) for logging.
 
-Logging is configured using the `logging` key in the config file. The value of
-this key is passed directly to log4js so any valid log4js configuration can
-be used here. The following categories are used in the CLI:
+Logging is configured using a YAML file called `logging.yaml` in the same
+location as the config file mentioned above. The contents of this file are
+passed directly to log4js so any valid log4js configuration can be included
+here. The following categories are used in the CLI:
 
 * rest-client - This category is used for the SDK that interfaces with the API.
   Turn this on to see detailed information for HTTP calls are made to SmartThings.
 * cli - This is the generic logger used by the CLI.
-
-There are other categories and more may be added later.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,7 +59,7 @@
 		"@oclif/plugin-not-found": "^1.2.3",
 		"@oclif/plugin-plugins": "^1.9.0",
 		"@smartthings/cli-lib": "^0.0.0-pre.10",
-		"@smartthings/core-sdk": "^1.1.0",
+		"@smartthings/core-sdk": "^1.1.2",
 		"aws-sdk": "^2.690.0",
 		"generator-smartthings": "^1.5.0",
 		"inquirer": "^7.3.3",

--- a/packages/cli/src/hooks/init/init-config.ts
+++ b/packages/cli/src/hooks/init/init-config.ts
@@ -1,34 +1,12 @@
-import { Configuration } from 'log4js'
 import { Hook } from '@oclif/config'
 
-import { cliConfig, logManager, LoginAuthenticator } from '@smartthings/cli-lib'
+import { LoginAuthenticator, cliConfig, loadLoggingConfig, logManager } from '@smartthings/cli-lib'
 
 
 const hook: Hook<'init'> = async function (opts) {
 	cliConfig.init(`${opts.config.configDir}/config.yaml`)
 	LoginAuthenticator.init(`${opts.config.configDir}/credentials.json`)
-
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const config: { [name: string]: any } = cliConfig.loadConfig()
-	let logConfig: Configuration
-	if ('logging' in config) {
-		logConfig = config['logging']
-	} else {
-		logConfig = {
-			appenders: {
-				smartthings: { type: 'file', filename: 'smartthings.log' },
-				stderr: { type: 'stderr' },
-				errors: { type: 'logLevelFilter', appender: 'stderr', level: 'error' },
-			},
-			categories: {
-				default: { appenders: ['smartthings', 'errors'], level: 'warn' },
-				'rest-client': { appenders: ['smartthings', 'errors'], level: 'warn' },
-				cli: { appenders: ['smartthings', 'errors'], level: 'warn' },
-			},
-		}
-	}
-
-	logManager.init(logConfig)
+	logManager.init(loadLoggingConfig(`${opts.config.configDir}/logging.yaml`))
 }
 
 export default hook

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -22,7 +22,7 @@
 		"directory": "packages/testlib"
 	},
 	"dependencies": {
-		"@smartthings/core-sdk": "^1.1.0",
+		"@smartthings/core-sdk": "^1.1.2",
 		"axios": "^0.19.2",
 		"cli-table": "^0.3.1",
 		"express": "^4.17.1",

--- a/packages/lib/src/__tests__/logger.test.ts
+++ b/packages/lib/src/__tests__/logger.test.ts
@@ -2,11 +2,13 @@ import { LoggingEvent } from 'log4js'
 
 import { Logger } from '@smartthings/core-sdk'
 
-import { logManager } from '../logger'
+import { loadLoggingConfig, logManager } from '../logger'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const recording = require('log4js/lib/appenders/recording')
 
+
+const resourcesDir = './src/__tests__/resources'
 
 describe('logger', () => {
 	function setupLogManager(level: string): void {
@@ -31,6 +33,43 @@ describe('logger', () => {
 	afterEach(() => {
 		recording.erase()
 		jest.clearAllMocks()
+	})
+
+	describe('loadLoggingConfig', () => {
+		it('loads log file correctly', function() {
+			const loggingConfig = loadLoggingConfig(`${resourcesDir}/good-logging.yaml`)
+			expect(loggingConfig).toEqual({ appenders: { stdout: { type: 'stdout' } } })
+		})
+
+		it('returns default for missing file', function() {
+			const defaultLoggingConfig = {
+				appenders: {
+					smartthings: { type: 'file', filename: 'smartthings.log' },
+					stderr: { type: 'stderr' },
+					errors: { type: 'logLevelFilter', appender: 'stderr', level: 'error' },
+				},
+				categories: {
+					default: { appenders: ['smartthings', 'errors'], level: 'warn' },
+					'rest-client': { appenders: ['smartthings', 'errors'], level: 'warn' },
+					cli: { appenders: ['smartthings', 'errors'], level: 'warn' },
+				},
+			}
+
+			const loggingConfig = loadLoggingConfig(`${resourcesDir}/does-not-exists.yaml`)
+			expect(loggingConfig).toEqual(defaultLoggingConfig)
+		})
+
+		it('throws exception for empty file', function() {
+			// We can re-use the files for the config test because we're just
+			// looking for invalid JSON.
+			expect(() => loadLoggingConfig(`${resourcesDir}/empty-config.yaml`)).toThrow()
+		})
+
+		it('throws exception for empty file', function() {
+			// We can re-use the files for the config test because we're just
+			// looking for invalid JSON.
+			expect(() => loadLoggingConfig(`${resourcesDir}/bad-config.yaml`)).toThrow()
+		})
 	})
 
 	describe('logManager', () => {

--- a/packages/lib/src/__tests__/resources/good-logging.yaml
+++ b/packages/lib/src/__tests__/resources/good-logging.yaml
@@ -1,0 +1,3 @@
+appenders:
+  stdout:
+    type: stdout

--- a/packages/lib/src/cli-config.ts
+++ b/packages/lib/src/cli-config.ts
@@ -1,5 +1,4 @@
 import fs from 'fs'
-
 import yaml from 'js-yaml'
 
 

--- a/packages/lib/src/logger.ts
+++ b/packages/lib/src/logger.ts
@@ -1,4 +1,6 @@
-import { configure, Configuration, Logger, Level } from 'log4js'
+import fs from 'fs'
+import yaml from 'js-yaml'
+import { configure, Configuration as LoggingConfig, Logger, Level } from 'log4js'
 
 import { Logger as APILogger } from '@smartthings/core-sdk'
 
@@ -67,7 +69,7 @@ export class LogManager {
 		this.loggersByName = {}
 	}
 
-	init(config: Configuration): void {
+	init(config: LoggingConfig): void {
 		this.getLog4jsLogger = configure(config).getLogger
 	}
 
@@ -84,6 +86,34 @@ export class LogManager {
 		this.loggersByName[name] = logger
 		return logger
 	}
+}
+
+const defaultLoggingConfig: LoggingConfig = {
+	appenders: {
+		smartthings: { type: 'file', filename: 'smartthings.log' },
+		stderr: { type: 'stderr' },
+		errors: { type: 'logLevelFilter', appender: 'stderr', level: 'error' },
+	},
+	categories: {
+		default: { appenders: ['smartthings', 'errors'], level: 'warn' },
+		'rest-client': { appenders: ['smartthings', 'errors'], level: 'warn' },
+		cli: { appenders: ['smartthings', 'errors'], level: 'warn' },
+	},
+}
+
+
+const loggingDocsLink = 'https://github.com/SmartThingsCommunity/' +
+	'smartthings-cli/blob/master/packages/cli/doc/configuration.md#logging'
+export function loadLoggingConfig(filename: string): LoggingConfig {
+	if (!fs.existsSync(filename)) {
+		return defaultLoggingConfig
+	}
+
+	const parsed = yaml.safeLoad(fs.readFileSync(filename, 'utf-8'))
+	if (parsed && typeof parsed === 'object') {
+		return parsed as LoggingConfig
+	}
+	throw new Error(`invalid or unreadable logging config file format; see ${loggingDocsLink}`)
 }
 
 if (!('_logManager' in (global as { _logManager?: LogManager }))) {


### PR DESCRIPTION
* use separate logging.xml file for logging configuration instead of reading key from config.yaml file
* removed plain dependencies from main package.json (Lerna doesn't use these anyway) so we don't have to maintain them
* fixed dependency versions for core SDK (they all match now)