### PR TITLE
fix: fix rules lookup without location id and functional refactor

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -216,7 +216,7 @@ OPTIONS
   --type=type                      filter results by appType, WEBHOOK_SMART_APP, LAMBDA_SMART_APP, API_ONLY
 ```
 
-_See code: [dist/commands/apps.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/apps.ts)_
+_See code: [dist/commands/apps.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/apps.ts)_
 
 ## `smartthings apps:authorize ARN`
 
@@ -248,7 +248,7 @@ EXAMPLES
   It requires your machine to be configured to run the AWS CLI
 ```
 
-_See code: [dist/commands/apps/authorize.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/apps/authorize.ts)_
+_See code: [dist/commands/apps/authorize.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/apps/authorize.ts)_
 
 ## `smartthings apps:create`
 
@@ -275,7 +275,7 @@ OPTIONS
   --statement-id=statement-id  use this statement id instead of the default when authorizing lambda functions
 ```
 
-_See code: [dist/commands/apps/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/apps/create.ts)_
+_See code: [dist/commands/apps/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/apps/create.ts)_
 
 ## `smartthings apps:delete [ID]`
 
@@ -294,7 +294,7 @@ OPTIONS
   -t, --token=token      the auth token to use
 ```
 
-_See code: [dist/commands/apps/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/apps/delete.ts)_
+_See code: [dist/commands/apps/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/apps/delete.ts)_
 
 ## `smartthings apps:oauth [ID]`
 
@@ -319,7 +319,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/apps/oauth.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/apps/oauth.ts)_
+_See code: [dist/commands/apps/oauth.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/apps/oauth.ts)_
 
 ## `smartthings apps:oauth:generate [ID]`
 
@@ -345,7 +345,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/apps/oauth/generate.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/apps/oauth/generate.ts)_
+_See code: [dist/commands/apps/oauth/generate.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/apps/oauth/generate.ts)_
 
 ## `smartthings apps:oauth:update [ID]`
 
@@ -371,7 +371,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/apps/oauth/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/apps/oauth/update.ts)_
+_See code: [dist/commands/apps/oauth/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/apps/oauth/update.ts)_
 
 ## `smartthings apps:register [ID]`
 
@@ -390,7 +390,7 @@ OPTIONS
   -t, --token=token      the auth token to use
 ```
 
-_See code: [dist/commands/apps/register.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/apps/register.ts)_
+_See code: [dist/commands/apps/register.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/apps/register.ts)_
 
 ## `smartthings apps:settings [ID]`
 
@@ -415,7 +415,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/apps/settings.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/apps/settings.ts)_
+_See code: [dist/commands/apps/settings.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/apps/settings.ts)_
 
 ## `smartthings apps:settings:update [ID]`
 
@@ -441,7 +441,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/apps/settings/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/apps/settings/update.ts)_
+_See code: [dist/commands/apps/settings/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/apps/settings/update.ts)_
 
 ## `smartthings apps:update [ID]`
 
@@ -470,7 +470,7 @@ OPTIONS
   --statement-id=statement-id  use this statement id instead of the default when authorizing lambda functions
 ```
 
-_See code: [dist/commands/apps/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/apps/update.ts)_
+_See code: [dist/commands/apps/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/apps/update.ts)_
 
 ## `smartthings autocomplete [SHELL]`
 
@@ -521,7 +521,7 @@ OPTIONS
   --indent=indent            specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/capabilities.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/capabilities.ts)_
+_See code: [dist/commands/capabilities.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/capabilities.ts)_
 
 ## `smartthings capabilities:create`
 
@@ -546,7 +546,7 @@ OPTIONS
   --indent=indent            specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/capabilities/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/capabilities/create.ts)_
+_See code: [dist/commands/capabilities/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/capabilities/create.ts)_
 
 ## `smartthings capabilities:delete [ID] [VERSION]`
 
@@ -566,7 +566,7 @@ OPTIONS
   -t, --token=token      the auth token to use
 ```
 
-_See code: [dist/commands/capabilities/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/capabilities/delete.ts)_
+_See code: [dist/commands/capabilities/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/capabilities/delete.ts)_
 
 ## `smartthings capabilities:namespaces`
 
@@ -588,7 +588,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/capabilities/namespaces.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/capabilities/namespaces.ts)_
+_See code: [dist/commands/capabilities/namespaces.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/capabilities/namespaces.ts)_
 
 ## `smartthings capabilities:presentation [ID] [VERSION]`
 
@@ -615,7 +615,7 @@ OPTIONS
   --indent=indent            specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/capabilities/presentation.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/capabilities/presentation.ts)_
+_See code: [dist/commands/capabilities/presentation.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/capabilities/presentation.ts)_
 
 ## `smartthings capabilities:presentation:create [ID] [VERSION]`
 
@@ -642,7 +642,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/capabilities/presentation/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/capabilities/presentation/create.ts)_
+_See code: [dist/commands/capabilities/presentation/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/capabilities/presentation/create.ts)_
 
 ## `smartthings capabilities:presentation:update [ID] [VERSION]`
 
@@ -669,7 +669,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/capabilities/presentation/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/capabilities/presentation/update.ts)_
+_See code: [dist/commands/capabilities/presentation/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/capabilities/presentation/update.ts)_
 
 ## `smartthings capabilities:translations [ID] [VERSION] [TAG]`
 
@@ -754,7 +754,7 @@ EXAMPLES
   └──────────────────────────────────────┴───────────────────────┴──────────────────────────────────────────────────┘
 ```
 
-_See code: [dist/commands/capabilities/translations.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/capabilities/translations.ts)_
+_See code: [dist/commands/capabilities/translations.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/capabilities/translations.ts)_
 
 ## `smartthings capabilities:translations:upsert [ID] [VERSION]`
 
@@ -829,7 +829,7 @@ EXAMPLES
            label: Output Modulation
 ```
 
-_See code: [dist/commands/capabilities/translations/upsert.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/capabilities/translations/upsert.ts)_
+_See code: [dist/commands/capabilities/translations/upsert.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/capabilities/translations/upsert.ts)_
 
 ## `smartthings capabilities:update [ID] [VERSION]`
 
@@ -856,7 +856,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/capabilities/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/capabilities/update.ts)_
+_See code: [dist/commands/capabilities/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/capabilities/update.ts)_
 
 ## `smartthings config [NAME]`
 
@@ -874,7 +874,6 @@ OPTIONS
   -j, --json             use JSON format of input and/or output
   -o, --output=output    specify output file
   -p, --profile=profile  [default: default] configuration profile
-  -t, --token=token      the auth token to use
   -v, --verbose          Include additional data in table output
   -y, --yaml             use YAML format of input and/or output
   --compact              use compact table format with no lines between body rows
@@ -882,7 +881,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/config.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/config.ts)_
+_See code: [dist/commands/config.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/config.ts)_
 
 ## `smartthings deviceprofiles [ID]`
 
@@ -919,7 +918,7 @@ EXAMPLES
   $ smartthings deviceprofiles 4 -j -o profile.json # write the profile to the file "profile.json"
 ```
 
-_See code: [dist/commands/deviceprofiles.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/deviceprofiles.ts)_
+_See code: [dist/commands/deviceprofiles.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/deviceprofiles.ts)_
 
 ## `smartthings deviceprofiles:create`
 
@@ -953,7 +952,7 @@ EXAMPLES
   $ smartthings deviceprofiles:create                      # create a device profile with interactive dialog
 ```
 
-_See code: [dist/commands/deviceprofiles/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/deviceprofiles/create.ts)_
+_See code: [dist/commands/deviceprofiles/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/deviceprofiles/create.ts)_
 
 ## `smartthings deviceprofiles:delete [ID]`
 
@@ -976,7 +975,7 @@ EXAMPLES
   $ smartthings deviceprofiles:delete 5                                     # delete the 5th profile in the list
 ```
 
-_See code: [dist/commands/deviceprofiles/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/deviceprofiles/delete.ts)_
+_See code: [dist/commands/deviceprofiles/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/deviceprofiles/delete.ts)_
 
 ## `smartthings deviceprofiles:device-config [ID]`
 
@@ -1001,7 +1000,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/deviceprofiles/device-config.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/deviceprofiles/device-config.ts)_
+_See code: [dist/commands/deviceprofiles/device-config.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/deviceprofiles/device-config.ts)_
 
 ## `smartthings deviceprofiles:presentation [ID]`
 
@@ -1026,7 +1025,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/deviceprofiles/presentation.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/deviceprofiles/presentation.ts)_
+_See code: [dist/commands/deviceprofiles/presentation.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/deviceprofiles/presentation.ts)_
 
 ## `smartthings deviceprofiles:publish [ID]`
 
@@ -1051,7 +1050,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/deviceprofiles/publish.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/deviceprofiles/publish.ts)_
+_See code: [dist/commands/deviceprofiles/publish.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/deviceprofiles/publish.ts)_
 
 ## `smartthings deviceprofiles:translations [ID] [TAG]`
 
@@ -1116,7 +1115,7 @@ EXAMPLES
   └───────────┴────────────┴───────────────────────────────┘
 ```
 
-_See code: [dist/commands/deviceprofiles/translations.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/deviceprofiles/translations.ts)_
+_See code: [dist/commands/deviceprofiles/translations.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/deviceprofiles/translations.ts)_
 
 ## `smartthings deviceprofiles:translations:delete [ID] [TAG]`
 
@@ -1157,7 +1156,7 @@ EXAMPLES
   Device profile "3acbf2fc-6be2-4be0-aeb5-44759cbd66c2" translation "en" deleted
 ```
 
-_See code: [dist/commands/deviceprofiles/translations/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/deviceprofiles/translations/delete.ts)_
+_See code: [dist/commands/deviceprofiles/translations/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/deviceprofiles/translations/delete.ts)_
 
 ## `smartthings deviceprofiles:translations:upsert [ID]`
 
@@ -1217,7 +1216,7 @@ EXAMPLES
        description: Switchable outlet 1 power
 ```
 
-_See code: [dist/commands/deviceprofiles/translations/upsert.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/deviceprofiles/translations/upsert.ts)_
+_See code: [dist/commands/deviceprofiles/translations/upsert.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/deviceprofiles/translations/upsert.ts)_
 
 ## `smartthings deviceprofiles:update [ID]`
 
@@ -1243,7 +1242,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/deviceprofiles/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/deviceprofiles/update.ts)_
+_See code: [dist/commands/deviceprofiles/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/deviceprofiles/update.ts)_
 
 ## `smartthings deviceprofiles:view [ID]`
 
@@ -1268,7 +1267,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/deviceprofiles/view.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/deviceprofiles/view.ts)_
+_See code: [dist/commands/deviceprofiles/view.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/deviceprofiles/view.ts)_
 
 ## `smartthings deviceprofiles:view:create`
 
@@ -1319,7 +1318,7 @@ EXAMPLES
          - capability: switch
 ```
 
-_See code: [dist/commands/deviceprofiles/view/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/deviceprofiles/view/create.ts)_
+_See code: [dist/commands/deviceprofiles/view/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/deviceprofiles/view/create.ts)_
 
 ## `smartthings deviceprofiles:view:update [ID]`
 
@@ -1375,7 +1374,7 @@ EXAMPLES
          - capability: switch
 ```
 
-_See code: [dist/commands/deviceprofiles/view/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/deviceprofiles/view/update.ts)_
+_See code: [dist/commands/deviceprofiles/view/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/deviceprofiles/view/update.ts)_
 
 ## `smartthings devices [ID]`
 
@@ -1421,7 +1420,7 @@ OPTIONS
   --indent=indent                          specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/devices.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/devices.ts)_
+_See code: [dist/commands/devices.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/devices.ts)_
 
 ## `smartthings devices:capability-status [ID] [COMPONENT] [CAPABILITY]`
 
@@ -1448,7 +1447,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/devices/capability-status.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/devices/capability-status.ts)_
+_See code: [dist/commands/devices/capability-status.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/devices/capability-status.ts)_
 
 ## `smartthings devices:commands [ID] [COMMAND]`
 
@@ -1475,7 +1474,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/devices/commands.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/devices/commands.ts)_
+_See code: [dist/commands/devices/commands.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/devices/commands.ts)_
 
 ## `smartthings devices:component-status [ID] [COMPONENT]`
 
@@ -1501,7 +1500,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/devices/component-status.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/devices/component-status.ts)_
+_See code: [dist/commands/devices/component-status.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/devices/component-status.ts)_
 
 ## `smartthings devices:delete [ID]`
 
@@ -1520,7 +1519,7 @@ OPTIONS
   -t, --token=token      the auth token to use
 ```
 
-_See code: [dist/commands/devices/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/devices/delete.ts)_
+_See code: [dist/commands/devices/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/devices/delete.ts)_
 
 ## `smartthings devices:health [ID]`
 
@@ -1545,7 +1544,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/devices/health.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/devices/health.ts)_
+_See code: [dist/commands/devices/health.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/devices/health.ts)_
 
 ## `smartthings devices:presentation [ID]`
 
@@ -1570,7 +1569,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/devices/presentation.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/devices/presentation.ts)_
+_See code: [dist/commands/devices/presentation.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/devices/presentation.ts)_
 
 ## `smartthings devices:rename [ID] [LABEL]`
 
@@ -1596,7 +1595,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/devices/rename.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/devices/rename.ts)_
+_See code: [dist/commands/devices/rename.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/devices/rename.ts)_
 
 ## `smartthings devices:status [ID]`
 
@@ -1621,7 +1620,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/devices/status.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/devices/status.ts)_
+_See code: [dist/commands/devices/status.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/devices/status.ts)_
 
 ## `smartthings devices:update [ID]`
 
@@ -1647,7 +1646,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/devices/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/devices/update.ts)_
+_See code: [dist/commands/devices/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/devices/update.ts)_
 
 ## `smartthings generate:java`
 
@@ -1662,7 +1661,7 @@ OPTIONS
   -p, --profile=profile  [default: default] configuration profile
 ```
 
-_See code: [dist/commands/generate/java.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/generate/java.ts)_
+_See code: [dist/commands/generate/java.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/generate/java.ts)_
 
 ## `smartthings generate:node`
 
@@ -1677,7 +1676,7 @@ OPTIONS
   -p, --profile=profile  [default: default] configuration profile
 ```
 
-_See code: [dist/commands/generate/node.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/generate/node.ts)_
+_See code: [dist/commands/generate/node.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/generate/node.ts)_
 
 ## `smartthings help [COMMAND]`
 
@@ -1720,7 +1719,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/installedapps.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/installedapps.ts)_
+_See code: [dist/commands/installedapps.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/installedapps.ts)_
 
 ## `smartthings installedapps:delete [ID]`
 
@@ -1739,7 +1738,7 @@ OPTIONS
   -t, --token=token      the auth token to use
 ```
 
-_See code: [dist/commands/installedapps/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/installedapps/delete.ts)_
+_See code: [dist/commands/installedapps/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/installedapps/delete.ts)_
 
 ## `smartthings installedapps:rename [ID] [NAME]`
 
@@ -1765,7 +1764,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/installedapps/rename.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/installedapps/rename.ts)_
+_See code: [dist/commands/installedapps/rename.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/installedapps/rename.ts)_
 
 ## `smartthings locations [IDORINDEX]`
 
@@ -1790,7 +1789,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/locations.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/locations.ts)_
+_See code: [dist/commands/locations.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/locations.ts)_
 
 ## `smartthings locations:create`
 
@@ -1814,7 +1813,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/locations/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/locations/create.ts)_
+_See code: [dist/commands/locations/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/locations/create.ts)_
 
 ## `smartthings locations:delete [ID]`
 
@@ -1833,7 +1832,7 @@ OPTIONS
   -t, --token=token      the auth token to use
 ```
 
-_See code: [dist/commands/locations/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/locations/delete.ts)_
+_See code: [dist/commands/locations/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/locations/delete.ts)_
 
 ## `smartthings locations:rooms [IDORINDEX]`
 
@@ -1862,7 +1861,7 @@ ALIASES
   $ smartthings rooms
 ```
 
-_See code: [dist/commands/locations/rooms.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/locations/rooms.ts)_
+_See code: [dist/commands/locations/rooms.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/locations/rooms.ts)_
 
 ## `smartthings locations:rooms:create`
 
@@ -1890,7 +1889,7 @@ ALIASES
   $ smartthings rooms:create
 ```
 
-_See code: [dist/commands/locations/rooms/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/locations/rooms/create.ts)_
+_See code: [dist/commands/locations/rooms/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/locations/rooms/create.ts)_
 
 ## `smartthings locations:rooms:delete [ID]`
 
@@ -1913,7 +1912,7 @@ ALIASES
   $ smartthings rooms:delete
 ```
 
-_See code: [dist/commands/locations/rooms/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/locations/rooms/delete.ts)_
+_See code: [dist/commands/locations/rooms/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/locations/rooms/delete.ts)_
 
 ## `smartthings locations:rooms:update [ID]`
 
@@ -1943,7 +1942,7 @@ ALIASES
   $ smartthings rooms:update
 ```
 
-_See code: [dist/commands/locations/rooms/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/locations/rooms/update.ts)_
+_See code: [dist/commands/locations/rooms/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/locations/rooms/update.ts)_
 
 ## `smartthings locations:update [ID]`
 
@@ -1969,7 +1968,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/locations/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/locations/update.ts)_
+_See code: [dist/commands/locations/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/locations/update.ts)_
 
 ## `smartthings plugins`
 
@@ -2112,7 +2111,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/presentation.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/presentation.ts)_
+_See code: [dist/commands/presentation.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/presentation.ts)_
 
 ## `smartthings presentation:device-config PRESENTATIONID`
 
@@ -2137,7 +2136,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/presentation/device-config.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/presentation/device-config.ts)_
+_See code: [dist/commands/presentation/device-config.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/presentation/device-config.ts)_
 
 ## `smartthings presentation:device-config:create`
 
@@ -2161,7 +2160,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/presentation/device-config/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/presentation/device-config/create.ts)_
+_See code: [dist/commands/presentation/device-config/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/presentation/device-config/create.ts)_
 
 ## `smartthings presentation:device-config:generate ID`
 
@@ -2190,7 +2189,7 @@ OPTIONS
                                  integrations
 ```
 
-_See code: [dist/commands/presentation/device-config/generate.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/presentation/device-config/generate.ts)_
+_See code: [dist/commands/presentation/device-config/generate.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/presentation/device-config/generate.ts)_
 
 ## `smartthings rules [IDORINDEX]`
 
@@ -2216,7 +2215,7 @@ OPTIONS
   --indent=indent              specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/rules.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/rules.ts)_
+_See code: [dist/commands/rules.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/rules.ts)_
 
 ## `smartthings rules:create`
 
@@ -2241,7 +2240,7 @@ OPTIONS
   --indent=indent              specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/rules/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/rules/create.ts)_
+_See code: [dist/commands/rules/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/rules/create.ts)_
 
 ## `smartthings rules:delete [ID]`
 
@@ -2261,7 +2260,7 @@ OPTIONS
   -t, --token=token            the auth token to use
 ```
 
-_See code: [dist/commands/rules/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/rules/delete.ts)_
+_See code: [dist/commands/rules/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/rules/delete.ts)_
 
 ## `smartthings rules:update [ID]`
 
@@ -2288,7 +2287,7 @@ OPTIONS
   --indent=indent              specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/rules/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/rules/update.ts)_
+_See code: [dist/commands/rules/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/rules/update.ts)_
 
 ## `smartthings schema [ID]`
 
@@ -2314,7 +2313,7 @@ OPTIONS
   --indent=indent        specify indentation for formatting JSON or YAML output
 ```
 
-_See code: [dist/commands/schema.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/schema.ts)_
+_See code: [dist/commands/schema.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/schema.ts)_
 
 ## `smartthings schema:authorize ARN`
 
@@ -2346,7 +2345,7 @@ EXAMPLES
   It requires your machine to be configured to run the AWS CLI
 ```
 
-_See code: [dist/commands/schema/authorize.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/schema/authorize.ts)_
+_See code: [dist/commands/schema/authorize.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/schema/authorize.ts)_
 
 ## `smartthings schema:create`
 
@@ -2373,7 +2372,7 @@ OPTIONS
   --statement-id=statement-id  use this statement id instead of the default when authorizing lambda functions
 ```
 
-_See code: [dist/commands/schema/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/schema/create.ts)_
+_See code: [dist/commands/schema/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/schema/create.ts)_
 
 ## `smartthings schema:delete [ID]`
 
@@ -2392,7 +2391,7 @@ OPTIONS
   -t, --token=token      the auth token to use
 ```
 
-_See code: [dist/commands/schema/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/schema/delete.ts)_
+_See code: [dist/commands/schema/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/schema/delete.ts)_
 
 ## `smartthings schema:update [ID]`
 
@@ -2421,7 +2420,7 @@ OPTIONS
   --statement-id=statement-id  use this statement id instead of the default when authorizing lambda functions
 ```
 
-_See code: [dist/commands/schema/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.14/dist/commands/schema/update.ts)_
+_See code: [dist/commands/schema/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.15/dist/commands/schema/update.ts)_
 <!-- commandsstop -->
 
 # Configuration and Logging

--- a/packages/cli/src/commands/apps.ts
+++ b/packages/cli/src/commands/apps.ts
@@ -2,7 +2,7 @@ import { flags } from '@oclif/command'
 
 import { App, AppType, AppClassification, AppListOptions } from '@smartthings/core-sdk'
 
-import { ListingOutputAPICommand, TableFieldDefinition } from '@smartthings/cli-lib'
+import { APICommand, outputListing, TableFieldDefinition } from '@smartthings/cli-lib'
 
 
 const isWebhookSmartApp = (app: App): boolean => !!app.webhookSmartApp
@@ -35,11 +35,12 @@ export const tableFieldDefinitions: TableFieldDefinition<App>[] = [
 	{ prop: 'installMetadata.certified', include: app => app.installMetadata?.certified !== undefined },
 ]
 
-export default class AppsList extends ListingOutputAPICommand<App, App> {
+export default class AppsList extends APICommand {
 	static description = 'get a specific app or a list of apps'
 
 	static flags = {
-		...ListingOutputAPICommand.flags,
+		...APICommand.flags,
+		...outputListing.flags,
 		type: flags.string({
 			description: 'filter results by appType, WEBHOOK_SMART_APP, LAMBDA_SMART_APP, API_ONLY',
 			multiple: false,
@@ -67,8 +68,8 @@ export default class AppsList extends ListingOutputAPICommand<App, App> {
 	primaryKeyName = 'appId'
 	sortKeyName = 'displayName'
 
-	protected tableFieldDefinitions = tableFieldDefinitions
-	protected listTableFieldDefinitions = ['displayName', 'appType', 'appId']
+	tableFieldDefinitions = tableFieldDefinitions
+	listTableFieldDefinitions = ['displayName', 'appType', 'appId']
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(AppsList)
@@ -117,6 +118,6 @@ export default class AppsList extends ListingOutputAPICommand<App, App> {
 			return this.client.apps.list(appListOptions)
 		}
 
-		await this.processNormally(args.id, listApps, id => this.client.apps.get(id))
+		await outputListing(this, args.id, listApps, id => this.client.apps.get(id))
 	}
 }

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,8 +1,8 @@
-import fs from 'fs'
 import yaml from 'js-yaml'
 import { flags } from '@oclif/command'
 
-import { cliConfig, IOFormat, ListingOutputAPICommand, TableFieldDefinition } from '@smartthings/cli-lib'
+import { buildOutputFormatter, calculateOutputFormat, cliConfig, IOFormat, outputItem, outputList, outputListing,
+	SmartThingsCommand, stringTranslateToId, TableFieldDefinition, writeOutput } from '@smartthings/cli-lib'
 
 
 function reservedKey(key: string): boolean {
@@ -24,21 +24,18 @@ export class ConfigItem {
 	constructor(key: string, data: ConfigData, profileName: string) {
 		this.name = key
 		this.active = reservedKey(key) ? 'N/A' : key === profileName ? 'true' : ''
-		this.token = data.token || ''
-		this.apiUrl = data.clientIdProvider?.baseURL || ''
+		this.token = data?.token ?? ''
+		this.apiUrl = data?.clientIdProvider?.baseURL ?? ''
 		this.data = data
 	}
-
 }
 
-// TODO: make non-API commands listable as well so we don't have to extend
-// APICommand here (or anywhere else we need to do non-API commands that list
-// things)
-export default class ConfigCommand extends ListingOutputAPICommand<ConfigItem, ConfigItem> {
+export default class ConfigCommand extends SmartThingsCommand {
 	static description = 'list config file entries'
 
 	static flags = {
-		...ListingOutputAPICommand.flags,
+		...SmartThingsCommand.flags,
+		...outputListing.flags,
 		verbose: flags.boolean({
 			description: 'Include additional data in table output',
 			char: 'v',
@@ -53,60 +50,50 @@ export default class ConfigCommand extends ListingOutputAPICommand<ConfigItem, C
 	primaryKeyName = 'name'
 	sortKeyName = 'name'
 
-	protected listTableFieldDefinitions: TableFieldDefinition<ConfigItem>[] = [
+	listTableFieldDefinitions: TableFieldDefinition<ConfigItem>[] = [
 		'name',
 		{ label: 'Active', value: (item) => reservedKey(item.name) ? 'N/A' : item.active ? 'true' : '' },
 	]
 
-	protected tableFieldDefinitions: TableFieldDefinition<ConfigItem>[] = [
+	tableFieldDefinitions: TableFieldDefinition<ConfigItem>[] = [
 		...this.listTableFieldDefinitions,
 		{ label: 'Definition', value: (item) => yaml.safeDump(item.data) },
 	]
-
-	protected buildListTableOutput(sortedList: ConfigItem[]): string {
-		if (this.flags.verbose) {
-			this.listTableFieldDefinitions.push('token')
-			if (this.flags.verbose && !!sortedList.find(it => it.data.clientIdProvider?.baseURL)) {
-				this.listTableFieldDefinitions.push('apiUrl')
-			}
-		}
-
-		return super.buildListTableOutput(sortedList)
-	}
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(ConfigCommand)
 		await super.setup(args, argv, flags)
 
-		const outputOptions = this.outputOptions
-		if (!args.name && outputOptions.format === IOFormat.JSON || outputOptions.format === IOFormat.YAML) {
-			const data = cliConfig.getRawConfigData()
-			const output = outputOptions.format === IOFormat.JSON ?
-				JSON.stringify(data, null, outputOptions.indentLevel) :
-				yaml.safeDump(data, { indent: outputOptions.indentLevel })
+		if (this.flags.verbose) {
+			this.listTableFieldDefinitions.push('token')
+		}
 
-			if (this.outputOptions.filename) {
-				fs.writeFileSync(this.outputOptions.filename, output)
-			} else {
-				process.stdout.write(output)
-				if (!output.endsWith('\n')) {
-					process.stdout.write('\n')
-				}
+		const getConfig = async (name: string): Promise<ConfigItem> => {
+			const config = cliConfig.getRawConfigData()
+			return new ConfigItem(name, config[name], this.profileName)
+		}
+		const listConfigs = async (): Promise<ConfigItem[]> => {
+			const config = cliConfig.getRawConfigData()
+			const list = Object.keys(config).map(it => {
+				return new ConfigItem(it, config[it], this.profileName)
+			})
+			if (this.flags.verbose && !!list.find(it => it.data?.clientIdProvider?.baseURL)) {
+				this.listTableFieldDefinitions.push('apiUrl')
 			}
+			return list
+		}
+
+		if (args.name) {
+			const id = await stringTranslateToId(this, args.name, listConfigs)
+			await outputItem(this, () => getConfig(id))
 		} else {
-			await this.processNormally(
-				args.name,
-				async () => {
-					const config = cliConfig.getRawConfigData()
-					return Object.keys(config).map(it => {
-						return new ConfigItem(it, config[it], this.profileName)
-					})
-				},
-				async (name) => {
-					const config = cliConfig.getRawConfigData()
-					return new ConfigItem(name, config[name], this.profileName)
-				},
-			)
+			const outputFormat = calculateOutputFormat(this)
+			if (outputFormat === IOFormat.COMMON) {
+				await outputList(this, listConfigs, true)
+			} else {
+				const outputFormatter = buildOutputFormatter(this)
+				await writeOutput(outputFormatter(cliConfig.getRawConfigData()), this.flags.output)
+			}
 		}
 	}
 }

--- a/packages/cli/src/commands/deviceprofiles.ts
+++ b/packages/cli/src/commands/deviceprofiles.ts
@@ -1,6 +1,6 @@
 import { DeviceProfile } from '@smartthings/core-sdk'
 
-import {APICommand, ListingOutputAPICommand, TableFieldDefinition} from '@smartthings/cli-lib'
+import {APICommand, outputListing, TableFieldDefinition} from '@smartthings/cli-lib'
 
 import { flags } from '@oclif/command'
 
@@ -20,11 +20,12 @@ export function buildTableOutput(this: APICommand, data: DeviceProfile): string 
 	return table.toString()
 }
 
-export default class DeviceProfilesList extends ListingOutputAPICommand<DeviceProfile, DeviceProfile> {
+export default class DeviceProfilesList extends APICommand {
 	static description = 'list all device profiles available in a user account or retrieve a single profile'
 
 	static flags = {
-		...ListingOutputAPICommand.flags,
+		...APICommand.flags,
+		...outputListing.flags,
 		verbose: flags.boolean({
 			description: 'include presentationId and manufacturerName in list output',
 			char: 'v',
@@ -50,10 +51,9 @@ export default class DeviceProfilesList extends ListingOutputAPICommand<DevicePr
 	primaryKeyName = 'id'
 	sortKeyName = 'name'
 
+	listTableFieldDefinitions: TableFieldDefinition<DeviceProfile>[] = ['name', 'status', 'id']
 
-	protected listTableFieldDefinitions: TableFieldDefinition<DeviceProfile>[] = ['name', 'status', 'id']
-
-	protected buildTableOutput = buildTableOutput
+	buildTableOutput = buildTableOutput
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(DeviceProfilesList)
@@ -64,8 +64,7 @@ export default class DeviceProfilesList extends ListingOutputAPICommand<DevicePr
 			this.listTableFieldDefinitions.push({ label: 'Manufacturer Name', value: (item) => item.metadata ? item.metadata.mnmn : '' })
 		}
 
-		await this.processNormally(
-			args.id,
+		await outputListing(this, args.id,
 			() => { return this.client.deviceProfiles.list() },
 			(id) => { return this.client.deviceProfiles.get(id) },
 		)

--- a/packages/cli/src/commands/devices.ts
+++ b/packages/cli/src/commands/devices.ts
@@ -2,7 +2,7 @@ import { flags } from '@oclif/command'
 
 import { Device, DeviceListOptions } from '@smartthings/core-sdk'
 
-import { APICommand, ListingOutputAPICommand, withLocationsAndRooms } from '@smartthings/cli-lib'
+import { APICommand, outputListing, withLocationsAndRooms } from '@smartthings/cli-lib'
 
 
 export type DeviceWithLocation = Device & { location?: string }
@@ -27,11 +27,12 @@ export function buildTableOutput(this: APICommand, data: Device & { profileId?: 
 	return table.toString()
 }
 
-export default class DevicesCommand extends ListingOutputAPICommand<Device, DeviceWithLocation> {
+export default class DevicesCommand extends APICommand {
 	static description = 'list all devices available in a user account or retrieve a single device'
 
 	static flags = {
-		...ListingOutputAPICommand.flags,
+		...APICommand.flags,
+		...outputListing.flags,
 		'location-id': flags.string({
 			char: 'l',
 			description: 'filter results by location',
@@ -70,9 +71,9 @@ export default class DevicesCommand extends ListingOutputAPICommand<Device, Devi
 
 	primaryKeyName = 'deviceId'
 	sortKeyName = 'label'
-	protected listTableFieldDefinitions = ['label', 'name', 'type', 'deviceId']
+	listTableFieldDefinitions = ['label', 'name', 'type', 'deviceId']
 
-	protected buildTableOutput = buildTableOutput
+	buildTableOutput = buildTableOutput
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(DevicesCommand)
@@ -90,7 +91,7 @@ export default class DevicesCommand extends ListingOutputAPICommand<Device, Devi
 			installedAppId: flags['installed-app-id'],
 		}
 
-		await this.processNormally(
+		await outputListing(this,
 			args.id,
 			async () => {
 				const devices = await this.client.devices.list(deviceListOptions)
@@ -99,7 +100,7 @@ export default class DevicesCommand extends ListingOutputAPICommand<Device, Devi
 				}
 				return devices
 			},
-			(id) => {return this.client.devices.get(id) },
+			id => this.client.devices.get(id),
 		)
 	}
 }

--- a/packages/cli/src/commands/locations/rooms.ts
+++ b/packages/cli/src/commands/locations/rooms.ts
@@ -1,7 +1,7 @@
 import { flags } from '@oclif/command'
 import { LocationItem, Room } from '@smartthings/core-sdk'
 
-import { APICommand, ListingOutputAPICommand } from '@smartthings/cli-lib'
+import { APICommand, outputListing } from '@smartthings/cli-lib'
 
 
 export const tableFieldDefinitions = ['name', 'locationId', 'roomId']
@@ -32,15 +32,16 @@ export type RoomWithLocation = Room & {
 	locationName?: string
 }
 
-export default class RoomsCommand extends ListingOutputAPICommand<Room, RoomWithLocation> {
+export default class RoomsCommand extends APICommand {
 	static description = 'get a specific room'
 
 	static flags = {
-		...ListingOutputAPICommand.flags,
+		...APICommand.flags,
 		locationId: flags.string({
 			char: 'l',
 			description: 'a specific locationId to query',
 		}),
+		...outputListing.flags,
 	}
 
 	static args = [{
@@ -55,18 +56,18 @@ export default class RoomsCommand extends ListingOutputAPICommand<Room, RoomWith
 
 	protected getRoomsByLocation = getRoomsByLocation
 
-	protected listTableFieldDefinitions = tableFieldDefinitions
-	protected tableFieldDefinitions = tableFieldDefinitions
+	listTableFieldDefinitions = tableFieldDefinitions
+	tableFieldDefinitions = tableFieldDefinitions
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(RoomsCommand)
 		await super.setup(args, argv, flags)
 
 		const roomsPromise = this.getRoomsByLocation(flags.locationId)
-		await this.processNormally(
+		await outputListing(this,
 			args.idOrIndex,
 			() => roomsPromise,
-			async (id) => {
+			async id => {
 				const room = (await roomsPromise).find(room => room.roomId === id)
 				if (!room) {
 					throw Error(`could not find room with id ${id}`)

--- a/packages/cli/src/commands/rules/create.ts
+++ b/packages/cli/src/commands/rules/create.ts
@@ -1,8 +1,10 @@
 import { flags } from '@oclif/command'
+
 import { Rule, RuleRequest } from '@smartthings/core-sdk'
 
-import { tableFieldDefinitions } from '../rules'
 import { InputOutputAPICommand } from '@smartthings/cli-lib'
+
+import { tableFieldDefinitions } from '../rules'
 
 
 export default class RulesCreate extends InputOutputAPICommand<RuleRequest, Rule> {
@@ -10,9 +12,10 @@ export default class RulesCreate extends InputOutputAPICommand<RuleRequest, Rule
 
 	static flags = {
 		...InputOutputAPICommand.flags,
-		locationid: flags.string({
+		'location-id': flags.string({
 			char: 'l',
 			description: 'a specific location to query',
+			required: true, // TODO: ask user if not specified instead of making this required
 		}),
 	}
 
@@ -23,7 +26,7 @@ export default class RulesCreate extends InputOutputAPICommand<RuleRequest, Rule
 		await super.setup(args, argv, flags)
 
 		this.processNormally(rule => {
-			return this.client.rules.create(rule, flags.locationid)
+			return this.client.rules.create(rule, flags['location-id'])
 		})
 	}
 }

--- a/packages/lib/src/__tests__/format.test.ts
+++ b/packages/lib/src/__tests__/format.test.ts
@@ -70,6 +70,30 @@ describe('format', () => {
 			expect(commonFormatter(item)).toBe('common output')
 			expect(command.buildTableOutput).toHaveBeenCalledTimes(1)
 		})
+
+		it('uses buildTableOutput when both specified', async () => {
+			const command = {
+				...baseCommand,
+				tableFieldDefinitions: [],
+				buildTableOutput: jest.fn(),
+			}
+
+			await formatAndWriteItem<SimpleType>(command, item, IOFormat.JSON)
+
+			expect(itemTableFormatterSpy).toHaveBeenCalledTimes(0)
+			expect(buildOutputFormatterSpy).toHaveBeenCalledTimes(1)
+			expect(buildOutputFormatterSpy).toHaveBeenCalledWith(command, IOFormat.JSON, expect.anything())
+			expect(outputFormatter).toHaveBeenCalledTimes(1)
+			expect(outputFormatter).toHaveBeenCalledWith(item)
+			expect(writeOutputSpy).toHaveBeenCalledTimes(1)
+			expect(writeOutputSpy).toHaveBeenCalledWith('output', 'output.yaml')
+
+			// Call the OutputFormatter that was build to ensure it uses `buildTableOutput`
+			const commonFormatter: output.OutputFormatter<SimpleType> = buildOutputFormatterSpy.mock.calls[0][2] as never
+			command.buildTableOutput.mockReturnValue('common output')
+			expect(commonFormatter(item)).toBe('common output')
+			expect(command.buildTableOutput).toHaveBeenCalledTimes(1)
+		})
 	})
 
 	describe('formatAndWriteList', () => {
@@ -164,6 +188,30 @@ describe('format', () => {
 		it('uses buildListTableOutput when specified', async () => {
 			const command = {
 				...baseCommand,
+				buildListTableOutput: jest.fn(),
+			}
+
+			await formatAndWriteList<SimpleType>(command, list, true)
+
+			expect(listTableFormatterSpy).toHaveBeenCalledTimes(0)
+			expect(buildOutputFormatterSpy).toHaveBeenCalledTimes(1)
+			expect(buildOutputFormatterSpy).toHaveBeenCalledWith(command, undefined, expect.anything())
+			expect(outputFormatter).toHaveBeenCalledTimes(1)
+			expect(outputFormatter).toHaveBeenCalledWith(list)
+			expect(writeOutputSpy).toHaveBeenCalledTimes(1)
+			expect(writeOutputSpy).toHaveBeenCalledWith('output', 'output.yaml')
+
+			// Call the OutputFormatter that was build to ensure it uses `buildTableOutput`
+			const commonFormatter: output.OutputFormatter<SimpleType[]> = buildOutputFormatterSpy.mock.calls[0][2] as never
+			command.buildListTableOutput.mockReturnValue('common output')
+			expect(commonFormatter(list)).toBe('common output')
+			expect(command.buildListTableOutput).toHaveBeenCalledTimes(1)
+		})
+
+		it('uses buildListTableOutput when both specified', async () => {
+			const command = {
+				...baseCommand,
+				listTableFieldDefinitions: [],
 				buildListTableOutput: jest.fn(),
 			}
 

--- a/packages/lib/src/__tests__/output.test.ts
+++ b/packages/lib/src/__tests__/output.test.ts
@@ -1,7 +1,8 @@
 import * as ioUtil from '../io-util'
-import { itemTableFormatter, jsonFormatter, listTableFormatter, sort, writeOutput, yamlFormatter } from '../output'
+import { calculateOutputFormat, itemTableFormatter, jsonFormatter, listTableFormatter, sort, writeOutput, yamlFormatter } from '../output'
 import { DefaultTableGenerator, TableGenerator } from '../table-generator'
 
+import { buildMockCommand } from './test-lib/mock-command'
 import { SimpleType } from './test-lib/simple-type'
 
 
@@ -21,6 +22,42 @@ describe('sort', () => {
 		const input: SimpleType[] = [ st('xyz'), st('abc'), st('ABC') ]
 		const result = sort(input, 'str')
 		expect(result).toEqual([st('abc'), st('ABC'), st('xyz')])
+	})
+})
+
+describe('calculateOutputFormat', () => {
+	it('returns json when specified', () => {
+		const command = buildMockCommand({ json: true })
+
+		expect(calculateOutputFormat(command)).toBe(ioUtil.IOFormat.JSON)
+	})
+
+	it('uses yaml when specified', () => {
+		const command = buildMockCommand({ yaml: true })
+
+		expect(calculateOutputFormat(command)).toBe(ioUtil.IOFormat.YAML)
+	})
+
+	it('gets format using formatFromFilename with output file when not specified', () => {
+		const command = buildMockCommand({ output: 'fn.json' })
+		const formatFromFilenameSpy = jest.spyOn(ioUtil, 'formatFromFilename').mockReturnValue(ioUtil.IOFormat.JSON)
+
+		expect(calculateOutputFormat(command)).toBe(ioUtil.IOFormat.JSON)
+
+		expect(formatFromFilenameSpy).toHaveBeenCalledTimes(1)
+		expect(formatFromFilenameSpy).toHaveBeenCalledWith('fn.json')
+	})
+
+	it('defaults to specified default format', () => {
+		const command = buildMockCommand()
+
+		expect(calculateOutputFormat(command, ioUtil.IOFormat.YAML)).toBe(ioUtil.IOFormat.YAML)
+	})
+
+	it('falls back to common with no other default specified', () => {
+		const command = buildMockCommand()
+
+		expect(calculateOutputFormat(command)).toBe(ioUtil.IOFormat.COMMON)
 	})
 })
 

--- a/packages/lib/src/format.ts
+++ b/packages/lib/src/format.ts
@@ -25,9 +25,9 @@ export type CommonListOutputProducer<L> = TableCommonListOutputProducer<L> | Cus
 
 export async function formatAndWriteItem<O>(command: SmartThingsCommandInterface & CommonOutputProducer<O>, item: O,
 		defaultIOFormat?: IOFormat): Promise<void> {
-	const commonFormatter = 'tableFieldDefinitions' in command
-		? itemTableFormatter<O>(command.tableGenerator, command.tableFieldDefinitions)
-		: (data: O) => command.buildTableOutput(data)
+	const commonFormatter = 'buildTableOutput' in command
+		? (data: O) => command.buildTableOutput(data)
+		: itemTableFormatter<O>(command.tableGenerator, command.tableFieldDefinitions)
 	const outputFormatter = buildOutputFormatter(command, defaultIOFormat, commonFormatter)
 	await writeOutput(outputFormatter(item), command.flags.output)
 }
@@ -38,10 +38,10 @@ export async function formatAndWriteList<L>(command: SmartThingsCommandInterface
 	if (list.length === 0) {
 		const pluralName = command.pluralItemName ?? (command.itemName ? `${command.itemName}s` : 'items')
 		commonFormatter = () => `no ${pluralName} found`
-	} else if ('listTableFieldDefinitions' in command) {
-		commonFormatter = listTableFormatter<L>(command.tableGenerator, command.listTableFieldDefinitions, includeIndex)
 	} else if ('buildListTableOutput' in command) {
 		commonFormatter = data => command.buildListTableOutput(data)
+	} else if ('listTableFieldDefinitions' in command) {
+		commonFormatter = listTableFormatter<L>(command.tableGenerator, command.listTableFieldDefinitions, includeIndex)
 	} else {
 		commonFormatter = listTableFormatter<L>(command.tableGenerator, [command.sortKeyName, command.primaryKeyName], includeIndex)
 	}

--- a/packages/lib/src/output-builder.ts
+++ b/packages/lib/src/output-builder.ts
@@ -1,23 +1,14 @@
 import { flags } from '@oclif/command'
 
 import { commonIOFlags } from './input'
-import { formatFromFilename, IOFormat } from './io-util'
-import { jsonFormatter, OutputFormatter, yamlFormatter } from './output'
+import { IOFormat } from './io-util'
+import { calculateOutputFormat, jsonFormatter, OutputFormatter, yamlFormatter } from './output'
 import { SmartThingsCommandInterface } from './smartthings-command'
 
 
 export function buildOutputFormatter<T>(command: SmartThingsCommandInterface,
 		inputFormat?: IOFormat, commonOutputFormatter?: OutputFormatter<T>): OutputFormatter<T> {
-	let outputFormat = IOFormat.COMMON
-	if (command.flags.json) {
-		outputFormat = IOFormat.JSON
-	} else if (command.flags.yaml) {
-		outputFormat = IOFormat.YAML
-	} else if (command.flags.output) {
-		outputFormat = formatFromFilename(command.flags.output)
-	} else if (inputFormat) {
-		outputFormat = inputFormat
-	}
+	const outputFormat = calculateOutputFormat(command, inputFormat)
 
 	const indent: number | undefined = command.flags.indent || command.profileConfig.indent
 	if (outputFormat === IOFormat.COMMON && commonOutputFormatter) {

--- a/packages/lib/src/output.ts
+++ b/packages/lib/src/output.ts
@@ -1,6 +1,7 @@
 import yaml from 'js-yaml'
 
-import { writeFile } from './io-util'
+import { formatFromFilename, IOFormat, writeFile } from './io-util'
+import { SmartThingsCommandInterface } from './smartthings-command'
 import { TableFieldDefinition, TableGenerator } from './table-generator'
 
 
@@ -16,6 +17,18 @@ export function sort<L>(list: L[], keyName: string): L[] {
 	})
 }
 
+export function calculateOutputFormat(command: SmartThingsCommandInterface, defaultIOFormat?: IOFormat): IOFormat {
+	if (command.flags.json) {
+		return IOFormat.JSON
+	} else if (command.flags.yaml) {
+		return IOFormat.YAML
+	} else if (command.flags.output) {
+		return formatFromFilename(command.flags.output)
+	} else if (defaultIOFormat) {
+		return defaultIOFormat
+	}
+	return IOFormat.COMMON
+}
 
 export type OutputFormatter<T> = (data: T) => string
 


### PR DESCRIPTION
* Updated several `ListingOutputAPICommand` commands to use the new `outputListing` functional style.
    * Notably un-updated is the `schema` command. I need to figure out how to create a schema app so I can test it first.
    * The `config` command no longer has a dependency on `APICommand` which is good since it's not an API command. 😄 
* Fixed `rules` command when looking up a rule by id or index without specifying a location id.
* Commands now use `build(List)TableOutput` before checking the `(listT|t)ableFieldDefinitions`. I didn't actually end up using this but they should be checked in this order since a complex `build(List)TableOutput` method could make use of table field definitions and there is no reason we shouldn't be able to use the default names.
* Moved logic for determining output format into a function so we could use it in the `config` command. (This made tests nicer too.)
* Updated unit tests for library refactors.
* Refactored rules commands to remove duplication.
* Fixed camel case `locationId` in rules command to be kebab case.
* Marked `location-id` flag in `rules:create` command required since it is. We should make it not required and ask the user for the location if it's not specified at some point.