### PR TITLE
feat: Added support for specifying a language header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10383,6 +10383,11 @@
 				"p-is-promise": "^3.0.0"
 			}
 		},
+		"invert-kv": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-3.0.1.tgz",
+			"integrity": "sha512-CYdFeFexxhv/Bcny+Q0BfOV+ltRlJcd4BBZBYFX/O0u4npJrgZtIcjokegtiSMAvlMTJ+Koq0GBCc//3bueQxw=="
+		},
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -12306,6 +12311,14 @@
 				"set-getter": "^0.1.0"
 			}
 		},
+		"lcid": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-3.1.1.tgz",
+			"integrity": "sha512-M6T051+5QCGLBQb8id3hdvIW8+zeFV2FyBGFS9IEK5H9Wt4MueD4bW1eWikpHgZp+5xR3l5c8pZUkQsIA0BFZg==",
+			"requires": {
+				"invert-kv": "^3.0.0"
+			}
+		},
 		"lerna": {
 			"version": "3.22.1",
 			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.22.1.tgz",
@@ -12600,6 +12613,14 @@
 				"tmpl": "1.0.x"
 			}
 		},
+		"map-age-cleaner": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+			"requires": {
+				"p-defer": "^1.0.0"
+			}
+		},
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -12623,6 +12644,28 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+		},
+		"mem": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-5.1.1.tgz",
+			"integrity": "sha512-qvwipnozMohxLXG1pOqoLiZKNkC4r4qqRucSoDwXowsNGDSULiqFTRUF05vcZWnwJSG22qTsynQhxbaMtnX9gw==",
+			"requires": {
+				"map-age-cleaner": "^0.1.3",
+				"mimic-fn": "^2.1.0",
+				"p-is-promise": "^2.1.0"
+			},
+			"dependencies": {
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+				},
+				"p-is-promise": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+					"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
+				}
+			}
 		},
 		"mem-fs": {
 			"version": "1.2.0",
@@ -13867,6 +13910,16 @@
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 			"dev": true
 		},
+		"os-locale": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-5.0.0.tgz",
+			"integrity": "sha512-tqZcNEDAIZKBEPnHPlVDvKrp7NzgLi7jRmhKiUoa2NUmhl13FtkAGLUVR+ZsYvApBQdBfYm43A4tXXQ4IrYLBA==",
+			"requires": {
+				"execa": "^4.0.0",
+				"lcid": "^3.0.0",
+				"mem": "^5.0.0"
+			}
+		},
 		"os-name": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -13897,6 +13950,11 @@
 			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
 			"integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
 			"dev": true
+		},
+		"p-defer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
 		},
 		"p-each-series": {
 			"version": "2.2.0",

--- a/packages/cli/src/commands/deviceprofiles/presentation.ts
+++ b/packages/cli/src/commands/deviceprofiles/presentation.ts
@@ -15,6 +15,17 @@ export default class ProfilePresentationCommand extends SelectingOutputAPIComman
 		description: 'device profile UUID or the number of the profile from list',
 	}]
 
+	static examples = [
+		'$ smartthings deviceprofiles:presentation fd4adb7f-4a23-4134-9b39-05ed889a03cf',
+		'$ smartthings deviceprofiles:presentation fd4adb7f-4a23-4134-9b39-05ed889a03cf --language=ko',
+		'$ smartthings deviceprofiles:presentation fd4adb7f-4a23-4134-9b39-05ed889a03cf --language=NONE',
+		'',
+		'Specifying only the presentationId defaults to the "SmartThingsCommunity" manufacturer',
+		'name and the language set for the computer\'s operating system. The language can be',
+		'overridden by specifying an ISO language code. If "NONE" is specified for the language',
+		'flag then no language header is specified in the API request',
+	]
+
 	primaryKeyName = 'id'
 	sortKeyName = 'name'
 	listTableFieldDefinitions = ['name', 'status', 'id']

--- a/packages/cli/src/commands/presentation.ts
+++ b/packages/cli/src/commands/presentation.ts
@@ -101,6 +101,18 @@ export default class PresentationCommand extends OutputAPICommand<PresentationDe
 		},
 	]
 
+	static examples = [
+		'$ smartthings presentation fd4adb7f-4a23-4134-9b39-05ed889a03cf',
+		'$ smartthings presentation 4ea31e30-2aba-41c7-a3ec-8f97423d565a SmartThings',
+		'$ smartthings presentation fd4adb7f-4a23-4134-9b39-05ed889a03cf --language=ko',
+		'$ smartthings presentation fd4adb7f-4a23-4134-9b39-05ed889a03cf --language=NONE',
+		'',
+		'Specifying only the presentationId defaults to the "SmartThingsCommunity" manufacturer',
+		'name and the language set for the computer\'s operating system. The language can be',
+		'overridden by specifying an ISO language code. If "NONE" is specified for the language',
+		'flag then no language header is specified in the API request',
+	]
+
 	protected buildTableOutput(presentation: PresentationDevicePresentation): string {
 		return buildTableOutput(presentation, this.tableGenerator)
 	}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -32,6 +32,7 @@
 		"lodash": "^4.17.19",
 		"log4js": "^6.3.0",
 		"open": "^7.0.3",
+		"os-locale": "^5.0.0",
 		"qs": "^6.9.3"
 	},
 	"devDependencies": {

--- a/packages/lib/src/api-command.ts
+++ b/packages/lib/src/api-command.ts
@@ -1,4 +1,5 @@
 import { flags } from '@oclif/command'
+import osLocale from 'os-locale'
 
 import { SmartThingsClient } from '@smartthings/core-sdk'
 import { BearerTokenAuthenticator } from '@smartthings/core-sdk'
@@ -19,6 +20,9 @@ export abstract class APICommand extends SmartThingsCommand {
 			char: 't',
 			description: 'the auth token to use',
 			env: 'SMARTTHINGS_TOKEN',
+		}),
+		language: flags.string({
+			description: 'ISO language code or "NONE" to not specify a language. Defaults to the OS locale',
 		}),
 	}
 
@@ -49,10 +53,15 @@ export abstract class APICommand extends SmartThingsCommand {
 
 		const logger = logManager.getLogger('rest-client')
 
+		const headers = flags.language ?
+			(flags.language === 'NONE' ? undefined : {'Accept-Language': flags.language}) :
+			{'Accept-Language': await osLocale()}
+
 		const authenticator = this.token
 			? new BearerTokenAuthenticator(this.token)
 			: new LoginAuthenticator(this.profileName, this.clientIdProvider)
+
 		this._client = new SmartThingsClient(authenticator,
-			{ urlProvider: this.clientIdProvider, logger })
+			{ urlProvider: this.clientIdProvider, logger, headers })
 	}
 }


### PR DESCRIPTION
Implemented a change to pass an `Accept-Language` header in API requests so that endpoints such as `/presentation` will only return one translation rather than all of them. 

By default the language is obtained from the operating system of the computer running the command. There is also a new `language` flag that overrides that value. The flag accepts an ISO language code such as `ko`. If the reserved values `NONE` is passed as the language flag than no  `Accept-Language` is sent. In the case of `/presentation` that returns all available translations.