### PR TITLE
refactor: convert last listing commands to functional API, other minor misc clean-up

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -232,7 +232,6 @@ ARGUMENTS
 OPTIONS
   -h, --help                   show CLI help
   -p, --profile=profile        [default: default] configuration profile
-  -t, --token=token            the auth token to use
   --principal=principal        use this principal instead of the default when authorizing lambda functions
   --statement-id=statement-id  use this statement id instead of the default when authorizing lambda functions
 
@@ -2329,12 +2328,11 @@ ARGUMENTS
 OPTIONS
   -h, --help                   show CLI help
   -p, --profile=profile        [default: default] configuration profile
-  -t, --token=token            the auth token to use
   --principal=principal        use this principal instead of the default when authorizing lambda functions
   --statement-id=statement-id  use this statement id instead of the default when authorizing lambda functions
 
 EXAMPLES
-  $ smartthings apps:authorize arn:aws:lambda:us-east-1:1234567890:function:your-test-app
+  $ smartthings schema:authorize arn:aws:lambda:us-east-1:1234567890:function:your-test-app
 
   Note that this command is the same as running the following with the AWS CLI:
 

--- a/packages/cli/src/commands/apps.ts
+++ b/packages/cli/src/commands/apps.ts
@@ -35,7 +35,7 @@ export const tableFieldDefinitions: TableFieldDefinition<App>[] = [
 	{ prop: 'installMetadata.certified', include: app => app.installMetadata?.certified !== undefined },
 ]
 
-export default class AppsList extends APICommand {
+export default class AppsCommand extends APICommand {
 	static description = 'get a specific app or a list of apps'
 
 	static flags = {
@@ -72,7 +72,7 @@ export default class AppsList extends APICommand {
 	listTableFieldDefinitions = ['displayName', 'appType', 'appId']
 
 	async run(): Promise<void> {
-		const { args, argv, flags } = this.parse(AppsList)
+		const { args, argv, flags } = this.parse(AppsCommand)
 		await super.setup(args, argv, flags)
 
 		if (flags.verbose) {

--- a/packages/cli/src/commands/apps/authorize.ts
+++ b/packages/cli/src/commands/apps/authorize.ts
@@ -1,13 +1,13 @@
-import { APICommand } from '@smartthings/cli-lib'
+import { SmartThingsCommand } from '@smartthings/cli-lib'
 import { addPermission } from '../../lib/aws-utils'
 import { lambdaAuthFlags } from '../../lib/common-flags'
 
 
-export default class AppAuthorize extends APICommand {
+export default class AppsAuthorizeCommand extends SmartThingsCommand {
 	static description = 'authorize calls to your AWS Lambda function from SmartThings'
 
 	static flags = {
-		...APICommand.flags,
+		...SmartThingsCommand.flags,
 		...lambdaAuthFlags,
 	}
 
@@ -32,7 +32,7 @@ export default class AppAuthorize extends APICommand {
 	]
 
 	async run(): Promise<void> {
-		const { args, argv, flags } = this.parse(AppAuthorize)
+		const { args, argv, flags } = this.parse(AppsAuthorizeCommand)
 		await super.setup(args, argv, flags)
 
 		addPermission(args.arn, flags.principal, flags['statement-id']).then(async (message) => {

--- a/packages/cli/src/commands/capabilities.ts
+++ b/packages/cli/src/commands/capabilities.ts
@@ -3,7 +3,7 @@ import { flags } from '@oclif/command'
 
 import { Capability, CapabilityArgument, CapabilitySummary, CapabilityJSONSchema, CapabilityNamespace } from '@smartthings/core-sdk'
 
-import { APICommand, ListCallback, ListingOutputCommand, outputGenericListing, sort } from '@smartthings/cli-lib'
+import { APICommand, ListCallback, outputGenericListing, sort } from '@smartthings/cli-lib'
 
 
 export const capabilityIdInputArgs = [
@@ -219,7 +219,7 @@ export async function getIdFromUser(this: APICommand, items: (CapabilitySummaryW
 	return { 'id': inputId, 'version': 1 }
 }
 
-export async function translateToId(this: ListingOutputCommand<Capability, CapabilitySummaryWithNamespace>,  idOrIndex: string | CapabilityId,
+export async function translateToId(sortKeyName: string,  idOrIndex: string | CapabilityId,
 		listFunction: ListCallback<CapabilitySummaryWithNamespace>): Promise<CapabilityId> {
 	if (typeof idOrIndex !== 'string') {
 		return idOrIndex
@@ -233,7 +233,7 @@ export async function translateToId(this: ListingOutputCommand<Capability, Capab
 		return { id: idOrIndex, version: 1 }
 	}
 
-	const items = sort(await listFunction(), this.sortKeyName)
+	const items = sort(await listFunction(), sortKeyName)
 	const matchingItem: CapabilitySummaryWithNamespace = items[index - 1]
 	return { id: matchingItem.id, version: matchingItem.version }
 }
@@ -262,7 +262,6 @@ export default class CapabilitiesCommand extends APICommand {
 	listTableFieldDefinitions = ['id', 'version', 'status']
 
 	buildTableOutput = buildTableOutput
-	translateToId = translateToId
 
 	private getCustomByNamespace = getCustomByNamespace
 	private getStandard = getStandard
@@ -275,6 +274,6 @@ export default class CapabilitiesCommand extends APICommand {
 		await outputGenericListing<CapabilityId, Capability, CapabilitySummaryWithNamespace>(this, idOrIndex,
 			() => flags.standard ? this.getStandard() : this.getCustomByNamespace(flags.namespace),
 			id =>  this.client.capabilities.get(id.id, id.version),
-			(idOrIndex, listFunction) => this.translateToId(idOrIndex, listFunction))
+			(idOrIndex, listFunction) => translateToId(this.sortKeyName, idOrIndex, listFunction))
 	}
 }

--- a/packages/cli/src/commands/capabilities/namespaces.ts
+++ b/packages/cli/src/commands/capabilities/namespaces.ts
@@ -3,7 +3,7 @@ import { APICommand, outputList } from '@smartthings/cli-lib'
 import { CapabilityNamespace } from '@smartthings/core-sdk'
 
 
-export default class CapabilitiesListNamespaces extends APICommand {
+export default class CapabilitiesListNamespacesCommand extends APICommand {
 	static description = 'list all capability namespaces currently available in a user account'
 
 	static flags = {
@@ -16,7 +16,7 @@ export default class CapabilitiesListNamespaces extends APICommand {
 	primaryKeyName = 'name'
 
 	async run(): Promise<void> {
-		const { args, argv, flags } = this.parse(CapabilitiesListNamespaces)
+		const { args, argv, flags } = this.parse(CapabilitiesListNamespacesCommand)
 		await super.setup(args, argv, flags)
 
 		await outputList<CapabilityNamespace>(this,

--- a/packages/cli/src/commands/capabilities/presentation.ts
+++ b/packages/cli/src/commands/capabilities/presentation.ts
@@ -2,10 +2,9 @@ import { flags } from '@oclif/command'
 
 import { CapabilityPresentation } from '@smartthings/core-sdk'
 
-import { APICommand, ListingOutputAPICommandBase } from '@smartthings/cli-lib'
+import { APICommand, outputGenericListing } from '@smartthings/cli-lib'
 
-import { capabilityIdOrIndexInputArgs, getCustomByNamespace, translateToId,
-	CapabilityId, CapabilitySummaryWithNamespace } from '../capabilities'
+import { CapabilityId, capabilityIdOrIndexInputArgs, getCustomByNamespace, translateToId } from '../capabilities'
 
 
 export function buildTableOutput(this: APICommand, presentation: CapabilityPresentation): string {
@@ -70,11 +69,12 @@ export function buildTableOutput(this: APICommand, presentation: CapabilityPrese
 		'(Information is summarized, for full details use YAML or JSON flags.)'
 }
 
-export default class PresentationsCommand extends ListingOutputAPICommandBase<CapabilityId, CapabilityPresentation, CapabilitySummaryWithNamespace> {
+export default class PresentationsCommand extends APICommand {
 	static description = 'get presentation information for a specific capability'
 
 	static flags = {
-		...ListingOutputAPICommandBase.flags,
+		...APICommand.flags,
+		...outputGenericListing.flags,
 		namespace: flags.string({
 			char: 'n',
 			description: 'a specific namespace to query; will use all by default',
@@ -86,10 +86,9 @@ export default class PresentationsCommand extends ListingOutputAPICommandBase<Ca
 	primaryKeyName = 'id'
 	sortKeyName = 'id'
 
-	protected listTableFieldDefinitions = ['id', 'version', 'status']
+	listTableFieldDefinitions = ['id', 'version', 'status']
 
-	protected buildTableOutput = buildTableOutput
-	protected translateToId = translateToId
+	buildTableOutput = buildTableOutput
 
 	private getCustomByNamespace = getCustomByNamespace
 
@@ -100,9 +99,9 @@ export default class PresentationsCommand extends ListingOutputAPICommandBase<Ca
 		const idOrIndex = args.version
 			? { id: args.id, version: args.version }
 			: args.id
-		await this.processNormally(
-			idOrIndex,
+		await outputGenericListing(this, idOrIndex,
 			() => this.getCustomByNamespace(flags.namespace),
-			(id) =>  this.client.capabilities.getPresentation(id.id, id.version))
+			(id: CapabilityId) =>  this.client.capabilities.getPresentation(id.id, id.version),
+			(idOrIndex, listFunction) => translateToId(this.sortKeyName, idOrIndex, listFunction))
 	}
 }

--- a/packages/cli/src/commands/capabilities/translations.ts
+++ b/packages/cli/src/commands/capabilities/translations.ts
@@ -1,11 +1,10 @@
 import { flags } from '@oclif/command'
 
-import {CapabilityLocalization, LocaleReference} from '@smartthings/core-sdk'
+import { CapabilityLocalization, LocaleReference } from '@smartthings/core-sdk'
 
-import { APICommand, NestedListingOutputAPICommandBase, stringTranslateToNestedId } from '@smartthings/cli-lib'
+import { APICommand, ListCallback, NestedListingOutputAPICommandBase, stringTranslateToNestedId } from '@smartthings/cli-lib'
 
-import { capabilityIdOrIndexInputArgs, getCustomByNamespace, translateToId,
-	CapabilityId, CapabilitySummaryWithNamespace } from '../capabilities'
+import { CapabilityId, capabilityIdOrIndexInputArgs, CapabilitySummaryWithNamespace, getCustomByNamespace, translateToId } from '../capabilities'
 
 
 export function buildTableOutput(this: APICommand, data: CapabilityLocalization): string {
@@ -123,7 +122,8 @@ export default class CapabilityTranslationsCommand extends NestedListingOutputAP
 	protected nestedListTableFieldDefinition = ['tag']
 
 	protected buildTableOutput = buildTableOutput
-	protected translateToId = translateToId
+	// TODO: clean this up once all of the commands that use the imported `translateToId` function have been converted to the functional API
+	protected translateToId = (idOrIndex: string | CapabilityId, listFunction: ListCallback<CapabilitySummaryWithNamespace>): Promise<CapabilityId> => translateToId(this.sortKeyName, idOrIndex, listFunction)
 	protected translateToNestedId = stringTranslateToNestedId
 
 	private getCustomByNamespace = getCustomByNamespace

--- a/packages/cli/src/commands/deviceprofiles.ts
+++ b/packages/cli/src/commands/deviceprofiles.ts
@@ -20,7 +20,7 @@ export function buildTableOutput(this: APICommand, data: DeviceProfile): string 
 	return table.toString()
 }
 
-export default class DeviceProfilesList extends APICommand {
+export default class DeviceProfilesCommand extends APICommand {
 	static description = 'list all device profiles available in a user account or retrieve a single profile'
 
 	static flags = {
@@ -56,7 +56,7 @@ export default class DeviceProfilesList extends APICommand {
 	buildTableOutput = buildTableOutput
 
 	async run(): Promise<void> {
-		const { args, argv, flags } = this.parse(DeviceProfilesList)
+		const { args, argv, flags } = this.parse(DeviceProfilesCommand)
 		await super.setup(args, argv, flags)
 
 		if (this.flags.verbose) {

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -1,13 +1,16 @@
-import { SchemaApp } from '@smartthings/core-sdk'
-import { ListingOutputAPICommand } from '@smartthings/cli-lib'
 import { flags } from '@oclif/command'
 
+import { SchemaApp } from '@smartthings/core-sdk'
 
-export default class SchemaList extends ListingOutputAPICommand<SchemaApp, SchemaApp> {
+import { APICommand, outputListing } from '@smartthings/cli-lib'
+
+
+export default class SchemaCommand extends APICommand {
 	static description = 'list all ST Schema Apps currently available in a user account'
 
 	static flags = {
-		...ListingOutputAPICommand.flags,
+		...APICommand.flags,
+		...outputListing.flags,
 		verbose: flags.boolean({
 			description: 'include ARN in output',
 			char: 'v',
@@ -19,7 +22,7 @@ export default class SchemaList extends ListingOutputAPICommand<SchemaApp, Schem
 		description: 'the schema connector id',
 	}]
 
-	protected tableFieldDefinitions = [
+	tableFieldDefinitions = [
 		'appName', 'partnerName', 'endpointAppId', 'schemaType', 'hostingType',
 		'stClientId', 'oAuthAuthorizationUrl', 'oAuthTokenUrl', 'oAuthClientId',
 		'oAuthClientSecret', 'icon', 'icon2x', 'icon3x',
@@ -33,32 +36,27 @@ export default class SchemaList extends ListingOutputAPICommand<SchemaApp, Schem
 	primaryKeyName = 'endpointAppId'
 	sortKeyName = 'appName'
 
-	protected listTableFieldDefinitions = ['appName', 'endpointAppId', 'hostingType']
+	listTableFieldDefinitions = ['appName', 'endpointAppId', 'hostingType']
 
 	async run(): Promise<void> {
-		const { args, argv, flags } = this.parse(SchemaList)
+		const { args, argv, flags } = this.parse(SchemaCommand)
 		await super.setup(args, argv, flags)
 
 		if (flags.verbose) {
 			this.listTableFieldDefinitions.push('ARN/URL')
 		}
 
-		await this.processNormally(
-			args.id,
+		await outputListing<SchemaApp, SchemaApp>(this, args.id,
 			async () => {
-				const items: SchemaApp[] = await this.client.schema.list()
+				const items = await this.client.schema.list()
 				return items.map(item => {
 					return {
-						appName: item.appName,
-						endpointAppId: item.endpointAppId,
-						hostingType: item.hostingType,
+						...item,
 						'ARN/URL': item.hostingType === 'lambda' ? item.lambdaArn : item.webhookUrl,
 					}
 				})
 			},
-			(id) => {
-				return this.client.schema.get(id)
-			},
+			id => this.client.schema.get(id),
 		)
 	}
 }

--- a/packages/cli/src/commands/schema/authorize.ts
+++ b/packages/cli/src/commands/schema/authorize.ts
@@ -1,13 +1,14 @@
-import { APICommand } from '@smartthings/cli-lib'
+import { SmartThingsCommand } from '@smartthings/cli-lib'
+
 import { addPermission } from '../../lib/aws-utils'
 import { lambdaAuthFlags } from '../../lib/common-flags'
 
 
-export default class SchemaAppAuthorize extends APICommand {
+export default class SchemaAppAuthorizeCommand extends SmartThingsCommand {
 	static description = 'authorize calls to your ST Schema Lambda function from SmartThings'
 
 	static flags = {
-		...APICommand.flags,
+		...SmartThingsCommand.flags,
 		...lambdaAuthFlags,
 	}
 	static args = [
@@ -19,7 +20,7 @@ export default class SchemaAppAuthorize extends APICommand {
 	]
 
 	static examples = [
-		'$ smartthings apps:authorize arn:aws:lambda:us-east-1:1234567890:function:your-test-app',
+		'$ smartthings schema:authorize arn:aws:lambda:us-east-1:1234567890:function:your-test-app',
 		'',
 		'Note that this command is the same as running the following with the AWS CLI:',
 		'',
@@ -31,7 +32,7 @@ export default class SchemaAppAuthorize extends APICommand {
 	]
 
 	async run(): Promise<void> {
-		const { args, argv, flags } = this.parse(SchemaAppAuthorize)
+		const { args, argv, flags } = this.parse(SchemaAppAuthorizeCommand)
 		await super.setup(args, argv, flags)
 
 		addPermission(args.arn, flags.principal, flags['statement-id']).then(async (message) => {

--- a/packages/lib/src/io-command.ts
+++ b/packages/lib/src/io-command.ts
@@ -459,55 +459,6 @@ export interface InputOutputAPICommand<I, O> extends Inputting<I>, Outputting<O>
 applyMixins(InputOutputAPICommand, [Inputting, Outputable, Outputting], { mergeFunctions: true })
 
 /**
- * Use this as your base when you need to be able to list or get a single
- * resource.
- *
- * This class accepts the identifier type as the ID generic input. In most
- * cases, your id will be a simple string and you can use
- * ListingOutputAPICommand which is a little simpler.
- */
-export abstract class ListingOutputAPICommandBase<ID, O, L> extends APICommand {
-	protected abstract translateToId(idOrIndex: ID | string,
-		listFunction: ListCallback<L>): Promise<ID>
-
-	protected async processNormally(idOrIndex: ID | string | undefined,
-			listFunction: ListCallback<L>,
-			getFunction: LookupCallback<ID, O>): Promise<void> {
-		try {
-			if (idOrIndex) {
-				const id: ID = await this.translateToId(idOrIndex, listFunction)
-				const item = await getFunction(id)
-				this.writeOutput(item)
-			} else {
-				const list = this.sort(await listFunction())
-				writeOutputPrivate(list, this.outputOptions, this.buildListTableOutput.bind(this))
-			}
-		} catch (err) {
-			this.logger.error(`caught error ${err}`)
-			process.exit(1)
-		}
-	}
-
-	static flags = outputFlags
-}
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export interface ListingOutputAPICommandBase<ID, O, L> extends Outputting<O>, Listing<L> {}
-applyMixins(ListingOutputAPICommandBase, [Outputable, Outputting, Listing], { mergeFunctions: true })
-
-/**
- * Use this as your base when you need to be able to list or get a single
- * resource. In other words, this is the base for most GET commands.
- *
- * This class is used for commands where the identifier is a simple string.
- * If you need a more complex identifier type, you can use
- * ListingOutputAPICommandBase.
- */
-export abstract class ListingOutputAPICommand<O, L> extends ListingOutputAPICommandBase<string, O, L> {
-	protected translateToId = oldStringTranslateToId
-	static flags = ListingOutputAPICommandBase.flags
-}
-
-/**
  * This class is used for command like "delete" that require a specific resource
  * to act on.
  *


### PR DESCRIPTION
<!-- Describe your pull request. -->

* Removed last use of `ListingOutputAPICommandBase` and `ListingOutputAPICommand` and then removed them.
* Renamed several command classes to use the suffix `Command`. I only did this to only commands that have already been converted to the new functional style and plan to do the rest as I convert them.
* Updated commands that don't use the API (`schema:authorize` and `apps:authorize` to directly use `SmartThingsCommand` instead of `APICommand` which removed some unused flags from their help.
* minor doc fix in `schema` command example

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [X] My code follows the code style of this project (`lerna run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
