### PR TITLE
feat: Added commands to list, show, and delete installed ST schema instances

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -157,6 +157,8 @@ that maps to that hierarchy.
 * [`smartthings installedapps [ID]`](#smartthings-installedapps-id)
 * [`smartthings installedapps:delete [ID]`](#smartthings-installedappsdelete-id)
 * [`smartthings installedapps:rename [ID] [NAME]`](#smartthings-installedappsrename-id-name)
+* [`smartthings installedschema [ID]`](#smartthings-installedschema-id)
+* [`smartthings installedschema:delete [ID]`](#smartthings-installedschemadelete-id)
 * [`smartthings locations [IDORINDEX]`](#smartthings-locations-idorindex)
 * [`smartthings locations:create`](#smartthings-locationscreate)
 * [`smartthings locations:delete [ID]`](#smartthings-locationsdelete-id)
@@ -1759,17 +1761,18 @@ ARGUMENTS
   ID  the app id
 
 OPTIONS
-  -h, --help             show CLI help
-  -j, --json             use JSON format of input and/or output
-  -o, --output=output    specify output file
-  -p, --profile=profile  [default: default] configuration profile
-  -t, --token=token      the auth token to use
-  -v, --verbose          include location name in output
-  -y, --yaml             use YAML format of input and/or output
-  --compact              use compact table format with no lines between body rows
-  --expanded             use expanded table format with a line between each body row
-  --indent=indent        specify indentation for formatting JSON or YAML output
-  --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+  -h, --help                     show CLI help
+  -j, --json                     use JSON format of input and/or output
+  -l, --location-id=location-id  filter results by location
+  -o, --output=output            specify output file
+  -p, --profile=profile          [default: default] configuration profile
+  -t, --token=token              the auth token to use
+  -v, --verbose                  include location name in output
+  -y, --yaml                     use YAML format of input and/or output
+  --compact                      use compact table format with no lines between body rows
+  --expanded                     use expanded table format with a line between each body row
+  --indent=indent                specify indentation for formatting JSON or YAML output
+  --language=language            ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
 _See code: [dist/commands/installedapps.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.17/dist/commands/installedapps.ts)_
@@ -1786,10 +1789,12 @@ ARGUMENTS
   ID  installed app UUID
 
 OPTIONS
-  -h, --help             show CLI help
-  -p, --profile=profile  [default: default] configuration profile
-  -t, --token=token      the auth token to use
-  --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+  -h, --help                     show CLI help
+  -l, --location-id=location-id  filter results by location
+  -p, --profile=profile          [default: default] configuration profile
+  -t, --token=token              the auth token to use
+  -v, --verbose                  include location name in output
+  --language=language            ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
 _See code: [dist/commands/installedapps/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.17/dist/commands/installedapps/delete.ts)_
@@ -1807,19 +1812,71 @@ ARGUMENTS
   NAME  the new installed app name
 
 OPTIONS
-  -h, --help             show CLI help
-  -j, --json             use JSON format of input and/or output
-  -o, --output=output    specify output file
-  -p, --profile=profile  [default: default] configuration profile
-  -t, --token=token      the auth token to use
-  -y, --yaml             use YAML format of input and/or output
-  --compact              use compact table format with no lines between body rows
-  --expanded             use expanded table format with a line between each body row
-  --indent=indent        specify indentation for formatting JSON or YAML output
-  --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+  -h, --help                     show CLI help
+  -j, --json                     use JSON format of input and/or output
+  -l, --location-id=location-id  filter results by location
+  -o, --output=output            specify output file
+  -p, --profile=profile          [default: default] configuration profile
+  -t, --token=token              the auth token to use
+  -v, --verbose                  include location name in output
+  -y, --yaml                     use YAML format of input and/or output
+  --compact                      use compact table format with no lines between body rows
+  --expanded                     use expanded table format with a line between each body row
+  --indent=indent                specify indentation for formatting JSON or YAML output
+  --language=language            ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 ```
 
 _See code: [dist/commands/installedapps/rename.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.17/dist/commands/installedapps/rename.ts)_
+
+## `smartthings installedschema [ID]`
+
+get a specific schema connector instance or a list of instances
+
+```
+USAGE
+  $ smartthings installedschema [ID]
+
+ARGUMENTS
+  ID  the isa id
+
+OPTIONS
+  -h, --help                     show CLI help
+  -j, --json                     use JSON format of input and/or output
+  -l, --location-id=location-id  filter results by location
+  -o, --output=output            specify output file
+  -p, --profile=profile          [default: default] configuration profile
+  -t, --token=token              the auth token to use
+  -v, --verbose                  include location name in output
+  -y, --yaml                     use YAML format of input and/or output
+  --compact                      use compact table format with no lines between body rows
+  --expanded                     use expanded table format with a line between each body row
+  --indent=indent                specify indentation for formatting JSON or YAML output
+  --language=language            ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+```
+
+_See code: [dist/commands/installedschema.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.17/dist/commands/installedschema.ts)_
+
+## `smartthings installedschema:delete [ID]`
+
+delete the installed schema connector instance
+
+```
+USAGE
+  $ smartthings installedschema:delete [ID]
+
+ARGUMENTS
+  ID  installed schema conntector UUID
+
+OPTIONS
+  -h, --help                     show CLI help
+  -l, --location-id=location-id  filter results by location
+  -p, --profile=profile          [default: default] configuration profile
+  -t, --token=token              the auth token to use
+  -v, --verbose                  include location name in output
+  --language=language            ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+```
+
+_See code: [dist/commands/installedschema/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v0.0.0-pre.17/dist/commands/installedschema/delete.ts)_
 
 ## `smartthings locations [IDORINDEX]`
 

--- a/packages/cli/src/commands/installedapps.ts
+++ b/packages/cli/src/commands/installedapps.ts
@@ -1,6 +1,6 @@
 import { flags } from '@oclif/command'
 
-import { InstalledApp } from '@smartthings/core-sdk'
+import { InstalledApp, InstalledAppListOptions } from '@smartthings/core-sdk'
 
 import { APICommand, outputListing, TableFieldDefinition, withLocations } from '@smartthings/cli-lib'
 
@@ -24,6 +24,11 @@ export default class InstalledAppsCommand extends APICommand {
 	static flags = {
 		...APICommand.flags,
 		...outputListing.flags,
+		'location-id': flags.string({
+			char: 'l',
+			description: 'filter results by location',
+			multiple: true,
+		}),
 		verbose: flags.boolean({
 			description: 'include location name in output',
 			char: 'v',
@@ -48,11 +53,15 @@ export default class InstalledAppsCommand extends APICommand {
 			this.listTableFieldDefinitions.splice(3, 0, 'location')
 		}
 
+		const listOptions: InstalledAppListOptions = {
+			locationId: flags['location-id'],
+		}
+
 		await outputListing<InstalledApp, InstalledAppWithLocation>(this,
 			args.id,
 			async () => {
-				const apps = await this.client.installedApps.list()
-				if (flags.verbose) {
+				const apps = await this.client.installedApps.list(listOptions)
+				if (this.flags.verbose) {
 					return await withLocations(this.client, apps)
 				}
 				return apps

--- a/packages/cli/src/commands/installedschema.ts
+++ b/packages/cli/src/commands/installedschema.ts
@@ -1,0 +1,78 @@
+import _ from 'lodash'
+
+import { flags } from '@oclif/command'
+
+import { InstalledSchemaApp, SmartThingsClient } from '@smartthings/core-sdk'
+
+import { APICommand, outputListing, TableFieldDefinition, withLocations } from '@smartthings/cli-lib'
+
+
+export type InstalledSchemaAppWithLocation = InstalledSchemaApp & { location?: string }
+
+export const listTableFieldDefinitions = ['appName', 'partnerName', 'partnerSTConnection', 'isaId']
+export const tableFieldDefinitions: TableFieldDefinition<InstalledSchemaApp>[] = [
+	'appName', 'isaId', 'partnerName', 'partnerSTConnection', 'locationId',
+	'icon', 'icon2x', 'icon3x',
+]
+
+export async function installedSchemaInstances(client: SmartThingsClient, locationIds: string[], verbose: boolean): Promise<InstalledSchemaAppWithLocation[]> {
+	if (!locationIds) {
+		locationIds = (await client.locations.list()).map(it => it.locationId)
+	}
+
+	const isas = _.flatten(await Promise.all(locationIds.map(async (locationId) => {
+		try {
+			return (await client.schema.installedApps(locationId))
+		} catch(e) {
+			return []
+		}
+	})))
+
+	if (verbose) {
+		return await withLocations(client, isas)
+	}
+	return isas
+}
+
+export default class InstalledSchemaAppsCommand extends APICommand {
+	static description = 'get a specific schema connector instance or a list of instances'
+
+	static flags = {
+		...APICommand.flags,
+		...outputListing.flags,
+		'location-id': flags.string({
+			char: 'l',
+			description: 'filter results by location',
+			multiple: true,
+		}),
+		verbose: flags.boolean({
+			description: 'include location name in output',
+			char: 'v',
+		}),
+	}
+
+	static args = [{
+		name: 'id',
+		description: 'the isa id',
+	}]
+
+	primaryKeyName = 'isaId'
+	sortKeyName = 'appName'
+	listTableFieldDefinitions = listTableFieldDefinitions
+	tableFieldDefinitions = tableFieldDefinitions
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(InstalledSchemaAppsCommand)
+		await super.setup(args, argv, flags)
+
+		if (this.flags.verbose) {
+			this.listTableFieldDefinitions.splice(3, 0, 'location')
+		}
+
+		await outputListing<InstalledSchemaApp, InstalledSchemaAppWithLocation>(this,
+			args.id,
+			() => installedSchemaInstances(this.client, flags['location-id'], flags.verbose),
+			id => this.client.schema.getInstalledApp(id),
+		)
+	}
+}

--- a/packages/cli/src/commands/installedschema/delete.ts
+++ b/packages/cli/src/commands/installedschema/delete.ts
@@ -1,0 +1,47 @@
+import { flags } from '@oclif/command'
+
+import { InstalledSchemaApp } from '@smartthings/core-sdk'
+
+import {selectAndActOn, APICommand} from '@smartthings/cli-lib'
+
+import { installedSchemaInstances } from '../installedschema'
+
+
+export default class InstalledSchemaAppDeleteCommand extends APICommand {
+	static description = 'delete the installed schema connector instance'
+
+	static flags = {
+		...APICommand.flags,
+		'location-id': flags.string({
+			char: 'l',
+			description: 'filter results by location',
+			multiple: true,
+		}),
+		verbose: flags.boolean({
+			description: 'include location name in output',
+			char: 'v',
+		}),
+	}
+	static args = [{
+		name: 'id',
+		description: 'installed schema connector UUID',
+	}]
+
+	primaryKeyName = 'isaId'
+	sortKeyName = 'appName'
+	listTableFieldDefinitions = ['appName', 'partnerName', 'partnerSTConnection', 'isaId']
+
+	async run(): Promise<void> {
+		const { args, argv, flags } = this.parse(InstalledSchemaAppDeleteCommand)
+		await super.setup(args, argv, flags)
+
+		if (this.flags.verbose) {
+			this.listTableFieldDefinitions.splice(3, 0, 'location')
+		}
+
+		await selectAndActOn<InstalledSchemaApp>(this, args.id,
+			() => installedSchemaInstances(this.client, flags['location-id'], flags.verbose),
+			async id => { await this.client.schema.deleteInstalledApp(id) },
+			'installed schema app {{id}} deleted')
+	}
+}


### PR DESCRIPTION
Added commands to list, show, and delete installed ST schema connector instances. Also updated installed app delete and rename commands to accept location and verbose flags since location is important context for identifying instances that
often have the same names. 

<!-- Describe your pull request. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`lerna run lint` produces no warnings/errors)
- [x] Any required documentation has been added
- [ ] I have added tests to cover my changes
