### PR TITLE
refactor: convert and remove NestedListingOutputAPICommand commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -725,6 +725,14 @@ EXAMPLES
   │ 1 │ custom1.outputModulation    │ 1       │ proposed │
   │ 2 │ custom1.outputVoltage       │ 1       │ proposed │
   └───┴─────────────────────────────┴─────────┴──────────┘
+  ? Select a capability. 1
+  ┌───┬─────┐
+  │ # │ Tag │
+  ├───┼─────┤
+  │ 1 │ en  │
+  │ 2 │ ko  │
+  └───┴─────┘
+
   outputModulation (master)$ st capabilities:translations -v
   ┌───┬─────────────────────────────┬─────────┬──────────┬────────────┐
   │ # │ Id                          │ Version │ Status   │ Locales    │
@@ -732,9 +740,17 @@ EXAMPLES
   │ 1 │ custom1.outputModulation    │ 1       │ proposed │ ko, en, es │
   │ 2 │ custom1.outputVoltage       │ 1       │ proposed │ en         │
   └───┴─────────────────────────────┴─────────┴──────────┴────────────┘
+  ? Select a capability. 1
+  ┌───┬─────┐
+  │ # │ Tag │
+  ├───┼─────┤
+  │ 1 │ en  │
+  │ 1 │ es  │
+  │ 2 │ ko  │
+  └───┴─────┘
 
-  outputModulation (master)$ st capabilities:translations 1
-  outputModulation (master)$ st capabilities:translations custom1.outputModulation
+  $ smartthings capabilities:translations 1
+  $ smartthings capabilities:translations custom1.outputModulation
   ┌───┬─────┐
   │ # │ Tag │
   ├───┼─────┤
@@ -1123,6 +1139,13 @@ EXAMPLES
   │  1 │ Test Switch         │ DEVELOPMENT │ 58e73d0c-b5a5-4814-b344-c10f4ff357bb │
   │  2 │ Two Channel Outlet  │ DEVELOPMENT │ 3acbf2fc-6be2-4be0-aeb5-44759cbd66c2 │
   └────┴─────────────────────┴─────────────┴──────────────────────────────────────┘
+  ? Select a Device Profile. 2
+  ┌───┬─────┐
+  │ # │ Tag │
+  ├───┼─────┤
+  │ 1 │ en  │
+  │ 2 │ es  │
+  └───┴─────┘
 
   $ smartthings deviceprofiles:translations -v
   ┌────┬─────────────────────┬─────────────┬──────────────────────────────────────┬─────────┐
@@ -1131,6 +1154,13 @@ EXAMPLES
   │  1 │ Test Switch         │ DEVELOPMENT │ 58e73d0c-b5a5-4814-b344-c10f4ff357bb │         │
   │  2 │ Two Channel Outlet  │ DEVELOPMENT │ 3acbf2fc-6be2-4be0-aeb5-44759cbd66c2 │ en, es  │
   └────┴─────────────────────┴─────────────┴──────────────────────────────────────┴─────────┘
+  ? Select a Device Profile. 2
+  ┌───┬─────┐
+  │ # │ Tag │
+  ├───┼─────┤
+  │ 1 │ en  │
+  │ 2 │ es  │
+  └───┴─────┘
 
   $ smartthings deviceprofiles:translations 2
   $ smartthings deviceprofiles:translations 3acbf2fc-6be2-4be0-aeb5-c10f4ff357bb

--- a/packages/cli/src/commands/capabilities.ts
+++ b/packages/cli/src/commands/capabilities.ts
@@ -214,7 +214,7 @@ export async function getIdFromUser(fieldInfo: Sorting, list: CapabilitySummaryW
 	return { 'id': inputId, 'version': 1 }
 }
 
-export async function translateToId(sortKeyName: string,  idOrIndex: string | CapabilityId,
+export async function translateToId(sortKeyName: string, idOrIndex: string | CapabilityId,
 		listFunction: ListCallback<CapabilitySummaryWithNamespace>): Promise<CapabilityId> {
 	if (typeof idOrIndex !== 'string') {
 		return idOrIndex

--- a/packages/cli/src/commands/capabilities/create.ts
+++ b/packages/cli/src/commands/capabilities/create.ts
@@ -26,7 +26,7 @@ const enum Type {
 const attributeAndCommandNamePattern = /^[a-z][a-zA-Z]{0,35}$/
 function commandOrAttributeNameValidator(input: string): boolean | string {
 	return !!attributeAndCommandNamePattern.exec(input)
-		|| 'Invalid attribute name;  only letters are allowed and must start with a lowercase letter, max length 36'
+		|| 'Invalid attribute name; only letters are allowed and must start with a lowercase letter, max length 36'
 }
 
 export default class CapabilitiesCreate extends InputOutputAPICommand<CapabilityCreate, Capability> {

--- a/packages/cli/src/commands/capabilities/translations/upsert.ts
+++ b/packages/cli/src/commands/capabilities/translations/upsert.ts
@@ -70,7 +70,7 @@ export default class CapabilityTranslationsUpsertCommand extends SelectingInputO
 
 	protected listTableFieldDefinitions = ['id', 'version']
 
-	protected buildTableOutput = buildTableOutput
+	protected buildTableOutput = (data: CapabilityLocalization): string => buildTableOutput(this.tableGenerator, data)
 	protected getIdFromUser: (items: CapabilitySummaryWithNamespace[]) => Promise<CapabilityId> = items => getIdFromUser(this, items)
 
 	async run(): Promise<void> {

--- a/packages/cli/src/commands/deviceprofiles/translations/upsert.ts
+++ b/packages/cli/src/commands/deviceprofiles/translations/upsert.ts
@@ -56,7 +56,7 @@ export default class DeviceProfileTranslationsUpsertCommand extends SelectingInp
 
 	protected listTableFieldDefinitions = ['name', 'status', 'id']
 
-	protected buildTableOutput = buildTableOutput
+	protected buildTableOutput = (data: DeviceProfileTranslations): string => buildTableOutput(this.tableGenerator, data)
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(DeviceProfileTranslationsUpsertCommand)

--- a/packages/lib/src/command-util.ts
+++ b/packages/lib/src/command-util.ts
@@ -42,7 +42,7 @@ export async function stringTranslateToId<L>(config: Sorting & Naming, idOrIndex
 		return pk
 	}
 
-	throw Error(`invalid type ${typeof pk} for primary key`  +
+	throw Error(`invalid type ${typeof pk} for primary key` +
 		` ${primaryKeyName} in ${JSON.stringify(matchingItem)}`)
 }
 
@@ -73,7 +73,7 @@ export function convertToId<L>(itemIdOrIndex: string, primaryKeyName: string, so
 		if (typeof pk === 'string') {
 			return pk
 		}
-		throw Error(`invalid type ${typeof pk} for primary key`  +
+		throw Error(`invalid type ${typeof pk} for primary key` +
 			` ${primaryKeyName} in ${JSON.stringify(sortedList[index - 1])}`)
 	}
 	return false


### PR DESCRIPTION
<!-- Describe your pull request. -->

## Types of Changes

Updated commands that used `Nested*APICommand` classes to new functional API and removed them.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [X] My code follows the code style of this project (`lerna run lint` produces no warnings/errors)
- [X] Any required documentation has been added
- [ ] I have added tests to cover my changes
