### PR TITLE
refactor: convert commands using SelectingOutputAPICommand to functional API

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1027,7 +1027,7 @@ USAGE
   $ smartthings deviceprofiles:device-config [ID]
 
 ARGUMENTS
-  ID  device profile UUID or the number of the profile from list
+  ID  device profile id or the number in list
 
 OPTIONS
   -h, --help             show CLI help
@@ -1057,14 +1057,8 @@ ARGUMENTS
 
 OPTIONS
   -h, --help             show CLI help
-  -j, --json             use JSON format of input and/or output
-  -o, --output=output    specify output file
   -p, --profile=profile  [default: default] configuration profile
   -t, --token=token      the auth token to use
-  -y, --yaml             use YAML format of input and/or output
-  --compact              use compact table format with no lines between body rows
-  --expanded             use expanded table format with a line between each body row
-  --indent=indent        specify indentation for formatting JSON or YAML output
   --language=language    ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 
 EXAMPLES
@@ -1089,7 +1083,7 @@ USAGE
   $ smartthings deviceprofiles:publish [ID]
 
 ARGUMENTS
-  ID  Device profile UUID or number in the list
+  ID  device profile id
 
 OPTIONS
   -h, --help             show CLI help
@@ -1318,14 +1312,14 @@ _See code: [dist/commands/deviceprofiles/update.ts](https://github.com/SmartThin
 
 ## `smartthings deviceprofiles:view [ID]`
 
-Show device profile and device configuration in a single, consolidated view
+show device profile and device configuration in a single, consolidated view
 
 ```
 USAGE
   $ smartthings deviceprofiles:view [ID]
 
 ARGUMENTS
-  ID  Device profile UUID or the number from list
+  ID  device profile UUID or the number from list
 
 OPTIONS
   -h, --help             show CLI help
@@ -1344,7 +1338,7 @@ _See code: [dist/commands/deviceprofiles/view.ts](https://github.com/SmartThings
 
 ## `smartthings deviceprofiles:view:create`
 
-Create a new device profile and device configuration.
+create a new device profile and device configuration
 
 ```
 USAGE
@@ -1366,7 +1360,7 @@ OPTIONS
 
 DESCRIPTION
   Creates a new device profile and device configuration. Unlike deviceprofiles:create,
-  this command accepts a consolidated object that can include a device configration 
+  this command accepts a consolidated object that can include a device configuration
   in a property named "view".
 
 EXAMPLES
@@ -1396,14 +1390,14 @@ _See code: [dist/commands/deviceprofiles/view/create.ts](https://github.com/Smar
 
 ## `smartthings deviceprofiles:view:update [ID]`
 
-Update a device profile and configuration.
+update a device profile and configuration
 
 ```
 USAGE
   $ smartthings deviceprofiles:view:update [ID]
 
 ARGUMENTS
-  ID  Device profile UUID or the number from list
+  ID  device profile UUID or the number from list
 
 OPTIONS
   -h, --help             show CLI help
@@ -1421,7 +1415,7 @@ OPTIONS
 DESCRIPTION
   Updates a device profile and device configuration and sets the vid of the profile
   to the vid of the updated configuration. Unlike deviceprofiles:update this
-  command accepts a consolidated object that can include a device configration
+  command accepts a consolidated object that can include a device configuration
   in a property named "view".
 
 EXAMPLES
@@ -1502,7 +1496,7 @@ _See code: [dist/commands/devices.ts](https://github.com/SmartThingsCommunity/sm
 
 ## `smartthings devices:capability-status [ID] [COMPONENT] [CAPABILITY]`
 
-get the current status of all of a device capabilities's attributes
+get the current status of all of a device capability's attributes
 
 ```
 USAGE

--- a/packages/cli/src/commands/apps/settings.ts
+++ b/packages/cli/src/commands/apps/settings.ts
@@ -1,10 +1,14 @@
 import { App, AppSettings } from '@smartthings/core-sdk'
 
-import {APICommand, SelectingOutputAPICommand} from '@smartthings/cli-lib'
+import { APICommand, outputItem, outputListing, selectFromList, stringTranslateToId, TableGenerator } from '@smartthings/cli-lib'
 
 
-export function buildTableOutput(this: APICommand, appSettings: AppSettings): string {
-	const table = this.tableGenerator.newOutputTable()
+export function buildTableOutput(tableGenerator: TableGenerator, appSettings: AppSettings): string {
+	if (!appSettings.settings || Object.keys(appSettings.settings).length === 0) {
+		return 'No application settings.'
+	}
+
+	const table = tableGenerator.newOutputTable({ head: ['Key', 'Value'] })
 	if (appSettings.settings) {
 		for (const key of Object.keys(appSettings.settings)) {
 			table.push([key, appSettings.settings[key]])
@@ -13,30 +17,33 @@ export function buildTableOutput(this: APICommand, appSettings: AppSettings): st
 	return table.toString()
 }
 
-export default class AppSettingsCommand extends SelectingOutputAPICommand<AppSettings, App> {
+export default class AppSettingsCommand extends APICommand {
 	static description = 'get OAuth settings of the app'
 
-	static flags = SelectingOutputAPICommand.flags
+	static flags = {
+		...APICommand.flags,
+		...outputListing.flags,
+	}
 
 	static args = [{
 		name: 'id',
 		description: 'the app id',
 	}]
 
-	primaryKeyName = 'appId'
-	sortKeyName = 'displayName'
-	acceptIndexId = true
-
-	protected buildTableOutput = buildTableOutput
-
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(AppSettingsCommand)
 		await super.setup(args, argv, flags)
 
-		await this.processNormally(
-			args.id,
-			() => { return this.client.apps.list() },
-			(id) => { return this.client.apps.getSettings(id) },
-		)
+		const config = {
+			primaryKeyName: 'appId',
+			sortKeyName: 'displayName',
+		}
+		const listApps = (): Promise<App[]> => this.client.apps.list()
+
+		const preselectedId = await stringTranslateToId(config, args.id, listApps)
+		const id = await selectFromList(this, config, preselectedId, listApps, 'Select an app.')
+		await outputItem(this,
+			{ buildTableOutput: data => buildTableOutput(this.tableGenerator, data) },
+			() => this.client.apps.getSettings(id))
 	}
 }

--- a/packages/cli/src/commands/apps/settings/update.ts
+++ b/packages/cli/src/commands/apps/settings/update.ts
@@ -18,7 +18,7 @@ export default class AppSettingsUpdateCommand extends SelectingInputOutputAPICom
 	primaryKeyName = 'appId'
 	sortKeyName = 'displayName'
 
-	protected buildTableOutput = buildTableOutput
+	protected buildTableOutput = (data: AppSettings): string => buildTableOutput(this.tableGenerator, data)
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(AppSettingsUpdateCommand)

--- a/packages/cli/src/commands/deviceprofiles/delete.ts
+++ b/packages/cli/src/commands/deviceprofiles/delete.ts
@@ -1,4 +1,6 @@
-import { APICommand, selectFromList } from '@smartthings/cli-lib'
+import { APICommand } from '@smartthings/cli-lib'
+
+import { chooseDeviceProfile } from '../deviceprofiles'
 
 
 export default class DeviceProfileDeleteCommand extends APICommand {
@@ -20,14 +22,7 @@ export default class DeviceProfileDeleteCommand extends APICommand {
 		const { args, argv, flags } = this.parse(DeviceProfileDeleteCommand)
 		await super.setup(args, argv, flags)
 
-		const config = {
-			primaryKeyName: 'id',
-			sortKeyName: 'name',
-			listTableFieldDefinitions: ['name', 'status', 'id'],
-		}
-		const id = await selectFromList(this, config, args.id,
-			() => this.client.deviceProfiles.list(),
-			'Select a device profile to delete.')
+		const id = await chooseDeviceProfile(this, args.id)
 		await this.client.deviceProfiles.delete(id)
 		this.log(`Device profile ${id} deleted.`)
 	}

--- a/packages/cli/src/commands/deviceprofiles/translations/delete.ts
+++ b/packages/cli/src/commands/deviceprofiles/translations/delete.ts
@@ -1,4 +1,5 @@
 import { APICommand, selectFromList } from '@smartthings/cli-lib'
+import { chooseDeviceProfile } from '../../deviceprofiles'
 
 
 export default class DeviceProfileTranslationsDeleteCommand extends APICommand {
@@ -43,15 +44,7 @@ export default class DeviceProfileTranslationsDeleteCommand extends APICommand {
 		const { args, argv, flags } = this.parse(DeviceProfileTranslationsDeleteCommand)
 		await super.setup(args, argv, flags)
 
-
-		const deviceProfileSelectConfig = {
-			primaryKeyName: 'id',
-			sortKeyName: 'name',
-			listTableFieldDefinitions: ['name', 'status', 'id'],
-		}
-		const deviceProfileId = await selectFromList(this, deviceProfileSelectConfig, args.id,
-			() => this.client.deviceProfiles.list(),
-			'Select a device profile:')
+		const deviceProfileId = await chooseDeviceProfile(this, args.id)
 
 		const localeTagSelectConfig = {
 			primaryKeyName: 'tag',

--- a/packages/cli/src/commands/deviceprofiles/view/create.ts
+++ b/packages/cli/src/commands/deviceprofiles/view/create.ts
@@ -1,12 +1,13 @@
 import { InputOutputAPICommand } from '@smartthings/cli-lib'
-import {cleanupRequest, createWithDefaultConfig} from '../create'
+
+import { cleanupRequest, createWithDefaultConfig } from '../create'
 import { buildTableOutput, prunePresentationValues, augmentPresentationValues, DeviceDefinition, DeviceDefinitionRequest } from '../view'
 
 
 export default class DeviceDefCreateCommand extends InputOutputAPICommand<DeviceDefinitionRequest, DeviceDefinition> {
-	static description = 'Create a new device profile and device configuration.\n' +
+	static description = 'create a new device profile and device configuration\n' +
 		'Creates a new device profile and device configuration. Unlike deviceprofiles:create,\n' +
-		'this command accepts a consolidated object that can include a device configration \n' +
+		'this command accepts a consolidated object that can include a device configuration\n' +
 		'in a property named "view".'
 
 	static flags = InputOutputAPICommand.flags
@@ -34,7 +35,7 @@ export default class DeviceDefCreateCommand extends InputOutputAPICommand<Device
 		'      - capability: switch  ',
 	]
 
-	protected buildTableOutput = buildTableOutput
+	protected buildTableOutput = (data: DeviceDefinition): string => buildTableOutput(this.tableGenerator, data)
 
 	private async createWithCustomConfig(data: DeviceDefinitionRequest): Promise<DeviceDefinition> {
 		if (!data.view) {
@@ -56,7 +57,7 @@ export default class DeviceDefCreateCommand extends InputOutputAPICommand<Device
 		const profile = await this.client.deviceProfiles.create(cleanupRequest(data))
 
 		// Return the composite object
-		return {...profile, view: prunePresentationValues(deviceConfig)}
+		return { ...profile, view: prunePresentationValues(deviceConfig) }
 	}
 
 
@@ -69,7 +70,7 @@ export default class DeviceDefCreateCommand extends InputOutputAPICommand<Device
 				return this.createWithCustomConfig(data)
 			}
 			const profileAndConfig = await createWithDefaultConfig(this.client, data)
-			return {...profileAndConfig.deviceProfile, view: prunePresentationValues(profileAndConfig.deviceConfig)}
+			return { ...profileAndConfig.deviceProfile, view: prunePresentationValues(profileAndConfig.deviceConfig) }
 		})
 	}
 }

--- a/packages/cli/src/commands/deviceprofiles/view/update.ts
+++ b/packages/cli/src/commands/deviceprofiles/view/update.ts
@@ -1,15 +1,17 @@
+import { DeviceProfile } from '@smartthings/core-sdk'
+
 import { SelectingInputOutputAPICommand } from '@smartthings/cli-lib'
 
 import { generateDefaultConfig } from '../create'
 import { cleanupRequest } from '../update'
-import { buildTableOutput, DeviceDefinition, DeviceDefinitionRequest, prunePresentationValues, augmentPresentationValues } from '../view'
+import { augmentPresentationValues, buildTableOutput, DeviceDefinition, DeviceDefinitionRequest, prunePresentationValues } from '../view'
 
 
 export default class CapabilitiesUpdate extends SelectingInputOutputAPICommand<DeviceDefinitionRequest, DeviceDefinition, DeviceDefinition> {
-	static description = 'Update a device profile and configuration.\n' +
+	static description = 'update a device profile and configuration\n' +
 		'Updates a device profile and device configuration and sets the vid of the profile\n' +
 		'to the vid of the updated configuration. Unlike deviceprofiles:update this\n' +
-		'command accepts a consolidated object that can include a device configration\n' +
+		'command accepts a consolidated object that can include a device configuration\n' +
 		'in a property named "view".'
 
 	static examples = [
@@ -41,7 +43,7 @@ export default class CapabilitiesUpdate extends SelectingInputOutputAPICommand<D
 
 	static args = [{
 		name: 'id',
-		description: 'Device profile UUID or the number from list',
+		description: 'device profile UUID or the number from list',
 	}]
 
 	primaryKeyName = 'id'
@@ -49,14 +51,14 @@ export default class CapabilitiesUpdate extends SelectingInputOutputAPICommand<D
 
 	protected listTableFieldDefinitions = ['name', 'status', 'id']
 
-	protected buildTableOutput = buildTableOutput
+	protected buildTableOutput = (data: DeviceProfile): string => buildTableOutput(this.tableGenerator, data)
 
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(CapabilitiesUpdate)
 		await super.setup(args, argv, flags)
 
 		await this.processNormally(args.id,
-			() => { return this.client.deviceProfiles.list() },
+			() => this.client.deviceProfiles.list(),
 			async (id, data) => {
 				const profileData = data
 				let presentationData = data.view

--- a/packages/cli/src/commands/devices.ts
+++ b/packages/cli/src/commands/devices.ts
@@ -2,7 +2,7 @@ import { flags } from '@oclif/command'
 
 import { Device, DeviceListOptions } from '@smartthings/core-sdk'
 
-import { APICommand, outputListing, TableGenerator, withLocationsAndRooms } from '@smartthings/cli-lib'
+import { APICommand, outputListing, selectFromList, stringTranslateToId, TableGenerator, withLocationsAndRooms } from '@smartthings/cli-lib'
 
 
 export type DeviceWithLocation = Device & { location?: string }
@@ -27,6 +27,17 @@ export function buildTableOutput(tableGenerator: TableGenerator, data: Device & 
 	return table.toString()
 }
 
+export async function chooseDevice(command: APICommand, deviceFromArg?: string): Promise<string> {
+	const config = {
+		itemName: 'device',
+		primaryKeyName: 'deviceId',
+		sortKeyName: 'label',
+		listTableFieldDefinitions: ['label', 'name', 'type', 'deviceId'],
+	}
+	const listDevices = (): Promise<Device[]> => command.client.devices.list()
+	const preselectedDeviceId = await stringTranslateToId(config, deviceFromArg, listDevices)
+	return selectFromList(command, config, preselectedDeviceId, listDevices)
+}
 export default class DevicesCommand extends APICommand {
 	static description = 'list all devices available in a user account or retrieve a single device'
 

--- a/packages/cli/src/commands/devices/capability-status.ts
+++ b/packages/cli/src/commands/devices/capability-status.ts
@@ -1,13 +1,16 @@
-import inquirer from 'inquirer'
+import { CLIError } from '@oclif/errors'
 
-import { Device, CapabilityStatus } from '@smartthings/core-sdk'
-import {APICommand, SelectingOutputAPICommand, isIndexArgument} from '@smartthings/cli-lib'
-import {prettyPrintAttribute} from './status'
-import {getComponentFromInput} from './component-status'
+import { CapabilityReference, CapabilityStatus } from '@smartthings/core-sdk'
+
+import { APICommand, formatAndWriteItem, selectFromList, stringTranslateToId, TableGenerator } from '@smartthings/cli-lib'
+
+import { chooseComponent } from './component-status'
+import { prettyPrintAttribute } from './status'
+import { chooseDevice } from '../devices'
 
 
-export function buildTableOutput(this: APICommand, capability: CapabilityStatus): string {
-	const table = this.tableGenerator.newOutputTable({head: ['Attribute','Value']})
+export function buildTableOutput(tableGenerator: TableGenerator, capability: CapabilityStatus): string {
+	const table = tableGenerator.newOutputTable({head: ['Attribute', 'Value']})
 
 	for (const attributeName of Object.keys(capability)) {
 		const attribute = capability[attributeName]
@@ -19,10 +22,13 @@ export function buildTableOutput(this: APICommand, capability: CapabilityStatus)
 	return table.toString()
 }
 
-export default class DeviceCapabilityStatusCommand extends SelectingOutputAPICommand<CapabilityStatus, Device> {
-	static description = "get the current status of all of a device capabilities's attributes"
+export default class DeviceCapabilityStatusCommand extends APICommand {
+	static description = "get the current status of all of a device capability's attributes"
 
-	static flags = SelectingOutputAPICommand.flags
+	static flags = {
+		...APICommand.flags,
+		...formatAndWriteItem.flags,
+	}
 
 	static args = [
 		{
@@ -39,63 +45,31 @@ export default class DeviceCapabilityStatusCommand extends SelectingOutputAPICom
 		},
 	]
 
-	protected buildTableOutput = buildTableOutput
-
-	primaryKeyName = 'deviceId'
-	sortKeyName = 'label'
-	listTableFieldDefinitions = ['label', 'name', 'type', 'deviceId']
-	acceptIndexId = true
-
-	protected getComponentFromInput = getComponentFromInput
-
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(DeviceCapabilityStatusCommand)
 		await super.setup(args, argv, flags)
 
-		await this.processNormally(
-			args.id,
-			() => this.client.devices.list(),
-			async (id) => {
-				let component = args.component
-				let capability = args.capability
-				if (!component) {
-					const device = await this.client.devices.get(id)
-					component = await this.getComponentFromInput(device)
-					if (!capability) {
-						const item = device.components?.find(it => it.id === component)
-						if (item && item.capabilities) {
-							this.log('\nCapabilities:')
-							let index = 1
-							const table = this.tableGenerator.newOutputTable()
-							let first = true
-							for (const cap of item.capabilities) {
-								if (first) {
-									table.push([index, `${cap.id} (default)`])
-									first = false
-								} else {
-									table.push([index, cap.id])
-								}
-								index++
-							}
-							this.log(table.toString())
-							const input = (await inquirer.prompt({
-								type: 'input',
-								name: 'capability',
-								message: 'Enter capability id',
-							})).capability || item.capabilities[0].id
+		const deviceId = await chooseDevice(this, args.id)
 
-							if (isIndexArgument(input)) {
-								capability = item.capabilities[Number.parseInt(input) - 1].id
-							} else if (input.length) {
-								capability = input
-							} else {
-								capability = item.capabilities[0].id
-							}
-						}
-					}
-				}
-				return this.client.devices.getCapabilityStatus(id, component, capability)
-			},
-		)
+		const device = await this.client.devices.get(deviceId)
+		const componentName = await chooseComponent(this, args.component, device.components)
+
+		const component = device.components?.find(it => it.id === componentName)
+		const capabilities = component?.capabilities
+		if (!capabilities) {
+			throw new CLIError(`no capabilities found for component ${componentName} of device ${deviceId}`)
+		}
+
+		const config = {
+			itemName: 'capability',
+			primaryKeyName: 'id',
+			sortKeyName: 'id',
+			listTableFieldDefinitions: ['id'],
+		}
+		const listCapabilities = async (): Promise<CapabilityReference[]> => capabilities
+		const preselectedCapabilityId = await stringTranslateToId(config, args.capability, listCapabilities)
+		const capabilityId = await selectFromList(this, config, preselectedCapabilityId, listCapabilities)
+		const capabilityStatus = await this.client.devices.getCapabilityStatus(deviceId, componentName, capabilityId)
+		await formatAndWriteItem(this, { buildTableOutput: data => buildTableOutput(this.tableGenerator, data) }, capabilityStatus)
 	}
 }

--- a/packages/cli/src/commands/devices/presentation.ts
+++ b/packages/cli/src/commands/devices/presentation.ts
@@ -1,33 +1,30 @@
-import { Device, PresentationDevicePresentation } from '@smartthings/core-sdk'
-import {SelectingOutputAPICommand} from '@smartthings/cli-lib'
+import { APICommand, formatAndWriteItem } from '@smartthings/cli-lib'
+
 import { buildTableOutput } from '../presentation'
+import { chooseDevice } from '../devices'
 
 
 export const tableFieldDefinitions = ['clientName', 'scope', 'redirectUris']
 
-export default class DevicePresentationCommand extends SelectingOutputAPICommand<PresentationDevicePresentation, Device> {
+export default class DevicePresentationCommand extends APICommand {
 	static description = 'get a device presentation'
 
-	static flags = SelectingOutputAPICommand.flags
+	static flags = {
+		...APICommand.flags,
+		...formatAndWriteItem.flags,
+	}
 
 	static args = [{
 		name: 'id',
 		description: 'the device id or number in the list',
 	}]
 
-	primaryKeyName = 'deviceId'
-	sortKeyName = 'label'
-	acceptIndexId = true
-
-	buildTableOutput: (data: PresentationDevicePresentation) => string = data => buildTableOutput(this.tableGenerator, data)
-
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(DevicePresentationCommand)
 		await super.setup(args, argv, flags)
 
-		await this.processNormally(args.id,
-			() => this.client.devices.list(),
-			id => this.client.devices.getPresentation(id),
-		)
+		const deviceId = await chooseDevice(this, args.id)
+		const presentation = await this.client.devices.getPresentation(deviceId)
+		await formatAndWriteItem(this, { buildTableOutput: data => buildTableOutput(this.tableGenerator, data) }, presentation)
 	}
 }

--- a/packages/cli/src/commands/devices/rename.ts
+++ b/packages/cli/src/commands/devices/rename.ts
@@ -1,14 +1,17 @@
 import inquirer from 'inquirer'
 
-import { Device } from '@smartthings/core-sdk'
-import { SelectingOutputAPICommand } from '@smartthings/cli-lib'
-import { buildTableOutput } from '../devices'
+import { APICommand, outputItem } from '@smartthings/cli-lib'
+
+import { buildTableOutput, chooseDevice } from '../devices'
 
 
-export default class DeviceComponentStatusCommand extends SelectingOutputAPICommand<Device, Device> {
+export default class DeviceRenameCommand extends APICommand {
 	static description = 'rename a device'
 
-	static flags = SelectingOutputAPICommand.flags
+	static flags = {
+		...APICommand.flags,
+		...outputItem.flags,
+	}
 
 	static args = [
 		{
@@ -21,31 +24,19 @@ export default class DeviceComponentStatusCommand extends SelectingOutputAPIComm
 		},
 	]
 
-	protected buildTableOutput: (data: Device) => string = data => buildTableOutput(this.tableGenerator, data)
-
-	primaryKeyName = 'deviceId'
-	sortKeyName = 'label'
-	listTableFieldDefinitions = ['label', 'name', 'type', 'deviceId']
-	acceptIndexId = true
-
 	async run(): Promise<void> {
-		const { args, argv, flags } = this.parse(DeviceComponentStatusCommand)
+		const { args, argv, flags } = this.parse(DeviceRenameCommand)
 		await super.setup(args, argv, flags)
 
-		await this.processNormally(
-			args.id,
-			() => this.client.devices.list(),
-			async (id) => {
-				let label = args.label
-				if (!label) {
-					label = (await inquirer.prompt({
-						type: 'input',
-						name: 'label',
-						message: 'Enter new device label:',
-					})).label
-				}
-				return this.client.devices.update(id, {label})
-			},
-		)
+		const id = await chooseDevice(this, args.id)
+
+		const label = args.label ?? (await inquirer.prompt({
+			type: 'input',
+			name: 'label',
+			message: 'Enter new device label:',
+		})).label
+
+		await outputItem(this, { buildTableOutput: data => buildTableOutput(this.tableGenerator, data) },
+			() => this.client.devices.update(id, { label }))
 	}
 }

--- a/packages/cli/src/commands/presentation/device-config.ts
+++ b/packages/cli/src/commands/presentation/device-config.ts
@@ -93,9 +93,7 @@ export default class DeviceConfigPresentationCommand extends APICommand {
 		const { args, argv, flags } = this.parse(DeviceConfigPresentationCommand)
 		await super.setup(args, argv, flags)
 
-		const config = {
-			buildTableOutput: (data: PresentationDeviceConfig) => buildTableOutput(this.tableGenerator, data),
-		}
-		await outputItem(this, config, () => this.client.presentation.get(args.presentationId))
+		await outputItem(this, { buildTableOutput: data => buildTableOutput(this.tableGenerator, data) },
+			() => this.client.presentation.get(args.presentationId))
 	}
 }

--- a/packages/lib/src/__tests__/basic-io.test.ts
+++ b/packages/lib/src/__tests__/basic-io.test.ts
@@ -102,7 +102,7 @@ describe('basic-io', () => {
 
 			expect(result).toBe(list)
 			expect(formatAndWriteListSpy).toHaveBeenCalledTimes(1)
-			expect(formatAndWriteListSpy).toHaveBeenLastCalledWith(command, config, list, false)
+			expect(formatAndWriteListSpy).toHaveBeenLastCalledWith(command, config, list, false, false)
 		})
 
 		it('passes includeIndex value on to formatAndWriteList', async () => {
@@ -118,7 +118,23 @@ describe('basic-io', () => {
 
 			expect(result).toBe(list)
 			expect(formatAndWriteListSpy).toHaveBeenCalledTimes(1)
-			expect(formatAndWriteListSpy).toHaveBeenLastCalledWith(command, config, list, true)
+			expect(formatAndWriteListSpy).toHaveBeenLastCalledWith(command, config, list, true, false)
+		})
+
+		it('passes forceCommonOutput value on to formatAndWriteList', async () => {
+			const config = {
+				listTableFieldDefinitions: [],
+				primaryKeyName: 'num',
+				sortKeyName: 'str',
+			}
+
+			const getDataMock = jest.fn().mockResolvedValue(list)
+
+			const result = await outputList<SimpleType>(command, config, getDataMock, false, true)
+
+			expect(result).toBe(list)
+			expect(formatAndWriteListSpy).toHaveBeenCalledTimes(1)
+			expect(formatAndWriteListSpy).toHaveBeenLastCalledWith(command, config, list, false, true)
 		})
 	})
 

--- a/packages/lib/src/__tests__/command-util.test.ts
+++ b/packages/lib/src/__tests__/command-util.test.ts
@@ -55,6 +55,15 @@ describe('command-util', () => {
 	describe('stringTranslateToId', () => {
 		const listFunction = jest.fn()
 
+		it('simply returns undefined given undefined idOrIndex', async () => {
+			const listFunction = jest.fn()
+
+			const computedId = await stringTranslateToId(command, undefined, listFunction)
+
+			expect(computedId).toBeUndefined()
+			expect(listFunction).toHaveBeenCalledTimes(0)
+		})
+
 		it('simply returns id when not matching index argument', async () => {
 			const listFunction = jest.fn()
 

--- a/packages/lib/src/__tests__/output.test.ts
+++ b/packages/lib/src/__tests__/output.test.ts
@@ -19,9 +19,9 @@ describe('sort', () => {
 
 	it('sorts in a case insensitive manner', () => {
 		const st = (str: string): SimpleType => ({ str, num: 1 })
-		const input: SimpleType[] = [ st('xyz'), st('abc'), st('ABC') ]
+		const input: SimpleType[] = [ st('xyz'), st('abc'), st('ABC'), st('this'), st('that') ]
 		const result = sort(input, 'str')
-		expect(result).toEqual([st('abc'), st('ABC'), st('xyz')])
+		expect(result).toEqual([st('abc'), st('ABC'), st('that'), st('this'), st('xyz')])
 	})
 })
 

--- a/packages/lib/src/__tests__/select.test.ts
+++ b/packages/lib/src/__tests__/select.test.ts
@@ -1,12 +1,13 @@
-import { selectFromList } from '../select'
+import { indefiniteArticleFor, selectFromList, selectGeneric } from '../select'
 import * as basicIO from '../basic-io'
 import * as commandUtil from '../command-util'
 import { buildMockCommand, exitMock } from './test-lib/mock-command'
 
 
 describe('select', () => {
-	const item = { str: 'string-id', num: 5 }
-	const list = [item]
+	const item1 = { str: 'string-id', num: 5 }
+	const item2 = { str: 'string-id', num: 5 }
+	const list = [item1, item2]
 	const command = {
 		...buildMockCommand(),
 		flags: {
@@ -28,6 +29,39 @@ describe('select', () => {
 		jest.clearAllMocks()
 	})
 
+	describe('indefiniteArticleFor', () => {
+		it.each(['apple', 'Animal', 'egret', 'item', 'orange', 'unicorn'])('returns "an" for "%s"', word => {
+			expect(indefiniteArticleFor(word)).toBe('an')
+		})
+
+		it.each(['banana', 'Balloon', 'tree'])('returns "a" for "%s"', word => {
+			expect(indefiniteArticleFor(word)).toBe('a')
+		})
+	})
+
+	describe('selectGeneric', () => {
+		// cover the one test case we can't get at through `selectFromList`.
+		it('defaults to autoChoose === false', async () => {
+			outputListSpy.mockResolvedValue(list)
+			listFunction.mockResolvedValue(list)
+
+			const resultId = await selectGeneric(command, config, undefined, listFunction, commandUtil.stringGetIdFromUser)
+
+			expect(resultId).toBe('chosen id')
+			expect(listFunction).toHaveBeenCalledTimes(1)
+			expect(outputListSpy).toHaveBeenCalledTimes(1)
+			expect(outputListSpy).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
+			expect(getIdFromUserSpy).toHaveBeenCalledTimes(1)
+			expect(getIdFromUserSpy).toHaveBeenCalledWith(config, list, undefined)
+
+			// Anonymous function passed to outputList should return same list as listFunction
+			// without calling it again.
+			const anonymousListFunction = outputListSpy.mock.calls[0][2]
+			expect(await anonymousListFunction()).toBe(list)
+			expect(listFunction).toHaveBeenCalledTimes(1)
+		})
+	})
+
 	describe('selectFromList', () => {
 		it('returns id when present', async () => {
 			expect(await selectFromList(command, config, 'sample-id', listFunction)).toBe('sample-id')
@@ -38,15 +72,62 @@ describe('select', () => {
 
 		it('gets list and asks user for selection with no id', async () => {
 			outputListSpy.mockResolvedValue(list)
+			listFunction.mockResolvedValue(list)
 
 			const resultId = await selectFromList(command, config, undefined, listFunction)
 
 			expect(resultId).toBe('chosen id')
-			expect(listFunction).toHaveBeenCalledTimes(0)
+			expect(listFunction).toHaveBeenCalledTimes(1)
 			expect(outputListSpy).toHaveBeenCalledTimes(1)
-			expect(outputListSpy).toHaveBeenCalledWith(command, config, listFunction, true)
+			expect(outputListSpy).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
 			expect(getIdFromUserSpy).toHaveBeenCalledTimes(1)
 			expect(getIdFromUserSpy).toHaveBeenCalledWith(config, list, undefined)
+
+			// Anonymous function passed to outputList should return same list as listFunction
+			// without calling it again.
+			const anonymousListFunction = outputListSpy.mock.calls[0][2]
+			expect(await anonymousListFunction()).toBe(list)
+			expect(listFunction).toHaveBeenCalledTimes(1)
+		})
+
+		it('returns single item automatically when autoChoose on', async () => {
+			outputListSpy.mockResolvedValue([item1])
+			listFunction.mockResolvedValue([item1])
+
+			const resultId = await selectFromList(command, config, undefined, listFunction, undefined, true)
+
+			expect(resultId).toBe('string-id')
+			expect(listFunction).toHaveBeenCalledTimes(1)
+			expect(outputListSpy).toHaveBeenCalledTimes(0)
+			expect(getIdFromUserSpy).toHaveBeenCalledTimes(0)
+		})
+
+		it('gets list and asks users when more than one item, even with autoChoose', async () => {
+			outputListSpy.mockResolvedValue(list)
+			listFunction.mockResolvedValue(list)
+
+			const resultId = await selectFromList(command, config, undefined, listFunction, undefined, true)
+
+			expect(resultId).toBe('chosen id')
+			expect(listFunction).toHaveBeenCalledTimes(1)
+			expect(outputListSpy).toHaveBeenCalledTimes(1)
+			expect(outputListSpy).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
+			expect(getIdFromUserSpy).toHaveBeenCalledTimes(1)
+			expect(getIdFromUserSpy).toHaveBeenCalledWith(config, list, undefined)
+		})
+
+		it('builds prompt message automatically from name', async () => {
+			outputListSpy.mockResolvedValue(list)
+			const configWithName = { ...config, itemName: 'thingamabob' }
+
+			const resultId = await selectFromList(command, configWithName, undefined, listFunction)
+
+			expect(resultId).toBe('chosen id')
+			expect(listFunction).toHaveBeenCalledTimes(1)
+			expect(outputListSpy).toHaveBeenCalledTimes(1)
+			expect(outputListSpy).toHaveBeenCalledWith(command, configWithName, expect.any(Function), true, true)
+			expect(getIdFromUserSpy).toHaveBeenCalledTimes(1)
+			expect(getIdFromUserSpy).toHaveBeenCalledWith(configWithName, list, 'Select a thingamabob.')
 		})
 
 		it('passes custom prompt on', async () => {
@@ -55,9 +136,9 @@ describe('select', () => {
 			const resultId = await selectFromList(command, config, undefined, listFunction, 'custom prompt')
 
 			expect(resultId).toBe('chosen id')
-			expect(listFunction).toHaveBeenCalledTimes(0)
+			expect(listFunction).toHaveBeenCalledTimes(1)
 			expect(outputListSpy).toHaveBeenCalledTimes(1)
-			expect(outputListSpy).toHaveBeenCalledWith(command, config, listFunction, true)
+			expect(outputListSpy).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
 			expect(getIdFromUserSpy).toHaveBeenCalledTimes(1)
 			expect(getIdFromUserSpy).toHaveBeenCalledWith(config, list, 'custom prompt')
 		})
@@ -69,9 +150,9 @@ describe('select', () => {
 
 			await expect(selectFromList(command, config, undefined, listFunction)).rejects.toThrow('should exit')
 
-			expect(listFunction).toHaveBeenCalledTimes(0)
+			expect(listFunction).toHaveBeenCalledTimes(1)
 			expect(outputListSpy).toHaveBeenCalledTimes(1)
-			expect(outputListSpy).toHaveBeenCalledWith(command, config, listFunction, true)
+			expect(outputListSpy).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
 			expect(getIdFromUserSpy).toHaveBeenCalledTimes(0)
 		})
 	})

--- a/packages/lib/src/__tests__/table-generator.test.ts
+++ b/packages/lib/src/__tests__/table-generator.test.ts
@@ -192,7 +192,7 @@ describe('tableGenerator', () => {
 		expect(output).toHaveLabel('Shorter Name')
 	})
 
-	it('buildTableFromItem to use calculated value', function() {
+	it('buildTableFromItem uses calculated value', function() {
 		const fieldDefinitions = [{
 			prop: 'reallyLongFieldName',
 			value: (item: SimpleData): string => `${item.reallyLongFieldName} ms`,
@@ -201,6 +201,16 @@ describe('tableGenerator', () => {
 
 		expect(output).not.toHaveValue('7.2')
 		expect(output).toHaveValue('7.2 ms')
+	})
+
+	it('buildTableFromItem uses empty string for undefined calculated value', function() {
+		const fieldDefinitions = [{
+			prop: 'reallyLongFieldName',
+			value: (): string | undefined => undefined,
+		}]
+		const output = tableGenerator.buildTableFromItem(basicData, fieldDefinitions)
+
+		expect(output).toHaveValue('')
 	})
 
 	it('buildTableFromItem skips rows when include returns false', function() {

--- a/packages/lib/src/api-command.ts
+++ b/packages/lib/src/api-command.ts
@@ -29,7 +29,7 @@ export abstract class APICommand extends SmartThingsCommand {
 	protected clientIdProvider = defaultClientIdProvider
 	private _client?: SmartThingsClient
 
-	protected get client(): SmartThingsClient {
+	get client(): SmartThingsClient {
 		if (!this._client) {
 			throw new Error('APICommand not properly initialized')
 		}

--- a/packages/lib/src/basic-io.ts
+++ b/packages/lib/src/basic-io.ts
@@ -49,9 +49,9 @@ export async function outputItem<O>(command: SmartThingsCommandInterface, config
 outputItem.flags = buildOutputFormatter.flags
 
 export async function outputList<L>(command: SmartThingsCommandInterface, config: CommonListOutputProducer<L> & Sorting,
-		getData: GetDataFunction<L[]>, includeIndex = false): Promise<L[]> {
+		getData: GetDataFunction<L[]>, includeIndex = false, forceCommonOutput = false): Promise<L[]> {
 	const list = sort(await getData(), config.sortKeyName)
-	await formatAndWriteList(command, config, list, includeIndex)
+	await formatAndWriteList(command, config, list, includeIndex, forceCommonOutput)
 	return list
 }
 outputList.flags = buildOutputFormatter.flags

--- a/packages/lib/src/command-util.ts
+++ b/packages/lib/src/command-util.ts
@@ -17,8 +17,13 @@ export function pluralItemName(command: Naming): string {
 	return command.pluralItemName ?? (command.itemName ? `${command.itemName}s` : 'items')
 }
 
-export async function stringTranslateToId<L>(config: Sorting & Naming, idOrIndex: string,
-		listFunction: ListDataFunction<L>): Promise<string> {
+export async function stringTranslateToId<L>(config: Sorting & Naming, idOrIndex: string, listFunction: ListDataFunction<L>): Promise<string>
+export async function stringTranslateToId<L>(config: Sorting & Naming, idOrIndex: string | undefined, listFunction: ListDataFunction<L>): Promise<string | undefined>
+export async function stringTranslateToId<L>(config: Sorting & Naming, idOrIndex: string | undefined, listFunction: ListDataFunction<L>): Promise<string | undefined> {
+	if (!idOrIndex) {
+		return undefined
+	}
+
 	const primaryKeyName = config.primaryKeyName
 	if (!isIndexArgument(idOrIndex)) {
 		// idOrIndex isn't a valid index so has to be an id (or bad)

--- a/packages/lib/src/format.ts
+++ b/packages/lib/src/format.ts
@@ -34,8 +34,8 @@ export async function formatAndWriteItem<O>(command: SmartThingsCommandInterface
 formatAndWriteItem.flags = buildOutputFormatter.flags
 
 export async function formatAndWriteList<L>(command: SmartThingsCommandInterface,
-		config: CommonListOutputProducer<L> & Naming,
-		list: L[], includeIndex = false): Promise<void> {
+		config: CommonListOutputProducer<L> & Naming, list: L[], includeIndex = false,
+		forceCommonOutput = false): Promise<void> {
 	let commonFormatter: OutputFormatter<L[]>
 	if (list.length === 0) {
 		const pluralName = config.pluralItemName ?? (config.itemName ? `${config.itemName}s` : 'items')
@@ -47,6 +47,6 @@ export async function formatAndWriteList<L>(command: SmartThingsCommandInterface
 	} else {
 		commonFormatter = listTableFormatter<L>(command.tableGenerator, [config.sortKeyName, config.primaryKeyName], includeIndex)
 	}
-	const outputFormatter = buildOutputFormatter(command, undefined, commonFormatter)
+	const outputFormatter = forceCommonOutput ? commonFormatter : buildOutputFormatter(command, undefined, commonFormatter)
 	await writeOutput(outputFormatter(list), command.flags.output)
 }

--- a/packages/lib/src/listing-io.ts
+++ b/packages/lib/src/listing-io.ts
@@ -8,6 +8,7 @@ import { TableFieldDefinition } from './table-generator'
 export type ListingOutputConfig<O, L> = Sorting & CommonOutputProducer<O> & {
 	listTableFieldDefinitions?: TableFieldDefinition<L>[]
 }
+// TODO: rename both of these to something like outputItemOrList
 export async function outputGenericListing<ID, O, L>(command: SmartThingsCommandInterface,
 		config: ListingOutputConfig<O, L>, idOrIndex: ID | string | undefined,
 		listFunction: ListDataFunction<L>, getFunction: LookupDataFunction<ID, O>,

--- a/packages/lib/src/select.ts
+++ b/packages/lib/src/select.ts
@@ -4,32 +4,48 @@ import { CommonListOutputProducer } from './format'
 import { SmartThingsCommandInterface } from './smartthings-command'
 
 
-// Functions in this file support commands that act on an item. The biggest difference
-// between these and the methods from listing-io.ts is that they list items and immediately
-// query the user for an item to act on (if one wasn't specified on the command line). This
-// makes them safe to use for actions that make changes to the item or delete it.
-
-// TODO: implement equivalent of acceptIndexId from old code
-
 export type SelectingConfig<L> = Sorting & Naming & CommonListOutputProducer<L>
+
+export const indefiniteArticleFor = (name: string): string => name.match(/^[aeiou]/i) ? 'an' : 'a'
+
+function promptFromNaming(config: Naming): string | undefined {
+	return config.itemName ? `Select ${indefiniteArticleFor(config.itemName)} ${config.itemName}.` : undefined
+}
 
 export async function selectGeneric<ID, L>(command: SmartThingsCommandInterface, config: SelectingConfig<L>,
 		preselectedId: ID | undefined, listItems: ListDataFunction<L>,
-		getIdFromUser: IdRetrievalFunction<ID, L>, promptMessage?: string): Promise<ID> {
+		getIdFromUser: IdRetrievalFunction<ID, L>, promptMessage?: string, autoChoose = false): Promise<ID> {
 	if (preselectedId) {
 		return preselectedId
 	}
 
-	const list = await outputList(command, config, listItems, true)
+	const items = await listItems()
+	if (autoChoose && items.length === 1) {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore Typescript can't check that run-time variable `config.primaryKeyName` exists.
+		return items[0][config.primaryKeyName]
+	}
+	const list = await outputList(command, config, async () => items, true, true)
 	if (list.length === 0) {
 		// Nothing was found; user was already notified.
 		command.exit(0)
 	}
 
-	return await getIdFromUser(config, list, promptMessage)
+	return await getIdFromUser(config, list, promptMessage ?? promptFromNaming(config))
 }
 
+/**
+ * Process selection of an item from a list. Use `preselectedId` if specified and ask the user to
+ * choose from items returned by `listItems` if not.
+ *
+ * @param command The command that is requesting the selection.
+ * @param config Configuration for primary key, sorting key and fields to display when asking the user for a selection.
+ * @param preselectedId If the value passed here is truthy, it is simply returned and no further processing is done.
+ * @param listItems A function that returns the list of items to display.
+ * @param promptMessage A message to display to the user
+ * @param autoChoose Set this to true if you want to automatically choose for the user if `listItems` returns exactly one item.
+ */
 export async function selectFromList<L>(command: SmartThingsCommandInterface, config: SelectingConfig<L>,
-		preselectedId: string | undefined, listItems: ListDataFunction<L>, promptMessage?: string): Promise<string> {
-	return selectGeneric(command, config, preselectedId, listItems, stringGetIdFromUser, promptMessage)
+		preselectedId: string | undefined, listItems: ListDataFunction<L>, promptMessage?: string, autoChoose = false): Promise<string> {
+	return selectGeneric(command, config, preselectedId, listItems, stringGetIdFromUser, promptMessage, autoChoose)
 }

--- a/packages/lib/src/table-generator.ts
+++ b/packages/lib/src/table-generator.ts
@@ -88,7 +88,7 @@ export type TableFieldDefinition<T> = string | {
 	 * to be displayed. If not, the property of the given name, simply coerced
 	 * to a string, will be used.
 	 */
-	value?: (i: T) => string
+	value?: (i: T) => string | undefined
 
 	/**
 	 * Use this function if you want to optionally include this field.
@@ -168,7 +168,7 @@ export class DefaultTableGenerator implements TableGenerator {
 	}
 	private getDisplayValueFor<T>(item: T, definition: TableFieldDefinition<T>): string {
 		if (!(typeof definition === 'string') && definition.value) {
-			return definition.value(item)
+			return definition.value(item) ?? ''
 		}
 
 		const propertyName = typeof definition === 'string' ? definition : definition.prop


### PR DESCRIPTION
<!-- Describe your pull request. -->

* converted commands that used `SelectingOutputAPICommand` to use the new functional API and removed it.
* updated several commands that needed device selection to use shared `chooseDevice` function
* updated several commands that needed device profile selection to use shared `chooseDeviceProfile` function

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [X] My code follows the code style of this project (`lerna run lint` produces no warnings/errors)
- [X] Any required documentation has been added
- [ ] I have added tests to cover my changes
