### PR TITLE
refactor: convert more Selecting* commands to functional version

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -339,6 +339,7 @@ ARGUMENTS
   ID  the app id
 
 OPTIONS
+  -d, --dry-run          produce JSON but don't actually submit
   -h, --help             show CLI help
   -i, --input=input      specify input file
   -j, --json             use JSON format of input and/or output
@@ -366,6 +367,7 @@ ARGUMENTS
   ID  the app id
 
 OPTIONS
+  -d, --dry-run          produce JSON but don't actually submit
   -h, --help             show CLI help
   -i, --input=input      specify input file
   -j, --json             use JSON format of input and/or output
@@ -439,6 +441,7 @@ ARGUMENTS
   ID  the app id
 
 OPTIONS
+  -d, --dry-run          produce JSON but don't actually submit
   -h, --help             show CLI help
   -i, --input=input      specify input file
   -j, --json             use JSON format of input and/or output
@@ -466,6 +469,7 @@ ARGUMENTS
   ID  the app id
 
 OPTIONS
+  -d, --dry-run                produce JSON but don't actually submit
   -h, --help                   show CLI help
   -i, --input=input            specify input file
   -j, --json                   use JSON format of input and/or output

--- a/packages/cli/src/commands/apps/delete.ts
+++ b/packages/cli/src/commands/apps/delete.ts
@@ -1,4 +1,6 @@
-import { APICommand, selectFromList } from '@smartthings/cli-lib'
+import { APICommand } from '@smartthings/cli-lib'
+
+import { chooseApp } from '../apps'
 
 
 export default class AppDeleteCommand extends APICommand {
@@ -15,12 +17,7 @@ export default class AppDeleteCommand extends APICommand {
 		const { args, argv, flags } = this.parse(AppDeleteCommand)
 		await super.setup(args, argv, flags)
 
-		const config = {
-			primaryKeyName: 'appId',
-			sortKeyName: 'displayName',
-		}
-		const id = await selectFromList(this, config, args.id, async () => await this.client.apps.list(),
-			'Select an app to delete.')
+		const id = await chooseApp(this, args.id)
 		await this.client.apps.delete(id)
 		this.log(`App ${id} deleted.`)
 	}

--- a/packages/cli/src/commands/apps/oauth.ts
+++ b/packages/cli/src/commands/apps/oauth.ts
@@ -1,6 +1,6 @@
-import { App } from '@smartthings/core-sdk'
+import { APICommand, outputItem, outputListing } from '@smartthings/cli-lib'
 
-import { APICommand, outputItem, outputListing, selectFromList, stringTranslateToId } from '@smartthings/cli-lib'
+import { chooseApp } from '../apps'
 
 
 export const tableFieldDefinitions = ['clientName', 'scope', 'redirectUris']
@@ -22,14 +22,7 @@ export default class AppOauthCommand extends APICommand {
 		const { args, argv, flags } = this.parse(AppOauthCommand)
 		await super.setup(args, argv, flags)
 
-		const config = {
-			primaryKeyName: 'appId',
-			sortKeyName: 'displayName',
-		}
-		const listApps = (): Promise<App[]> => this.client.apps.list()
-
-		const preselectedId = await stringTranslateToId(config, args.id, listApps)
-		const id = await selectFromList(this, config, preselectedId, listApps, 'Select an app.')
+		const id = await chooseApp(this, args.id, { allowIndex: true })
 		await outputItem(this, { tableFieldDefinitions }, () => this.client.apps.getOauth(id))
 	}
 }

--- a/packages/cli/src/commands/apps/oauth/update.ts
+++ b/packages/cli/src/commands/apps/oauth/update.ts
@@ -1,31 +1,30 @@
-import { App, AppOAuth } from '@smartthings/core-sdk'
+import { AppOAuth } from '@smartthings/core-sdk'
 
-import { SelectingInputOutputAPICommand } from '@smartthings/cli-lib'
+import { APICommand, inputAndOutputItem } from '@smartthings/cli-lib'
 
 import { tableFieldDefinitions } from '../oauth'
+import { chooseApp } from '../../apps'
 
 
-export default class AppOauthUpdateCommand extends SelectingInputOutputAPICommand<AppOAuth, AppOAuth, App> {
+export default class AppOauthUpdateCommand extends APICommand {
 	static description = 'update the OAuth settings of the app'
 
-	static flags = SelectingInputOutputAPICommand.flags
+	static flags = {
+		...APICommand.flags,
+		...inputAndOutputItem.flags,
+	}
 
 	static args = [{
 		name: 'id',
 		description: 'the app id',
 	}]
 
-	primaryKeyName = 'appId'
-	sortKeyName = 'displayName'
-
-	protected tableFieldDefinitions = tableFieldDefinitions
-
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(AppOauthUpdateCommand)
 		await super.setup(args, argv, flags)
 
-		await this.processNormally(args.id,
-			() => { return this.client.apps.list() },
-			async (id, data) => { return this.client.apps.updateOauth(id, data) })
+		const appId = await chooseApp(this, args.id)
+		await inputAndOutputItem(this, { tableFieldDefinitions },
+			(_, data: AppOAuth) => this.client.apps.updateOauth(appId, data))
 	}
 }

--- a/packages/cli/src/commands/apps/settings.ts
+++ b/packages/cli/src/commands/apps/settings.ts
@@ -1,6 +1,8 @@
-import { App, AppSettings } from '@smartthings/core-sdk'
+import { AppSettings } from '@smartthings/core-sdk'
 
-import { APICommand, outputItem, outputListing, selectFromList, stringTranslateToId, TableGenerator } from '@smartthings/cli-lib'
+import { APICommand, outputItem, outputListing, TableGenerator } from '@smartthings/cli-lib'
+
+import { chooseApp } from '../apps'
 
 
 export function buildTableOutput(tableGenerator: TableGenerator, appSettings: AppSettings): string {
@@ -34,14 +36,7 @@ export default class AppSettingsCommand extends APICommand {
 		const { args, argv, flags } = this.parse(AppSettingsCommand)
 		await super.setup(args, argv, flags)
 
-		const config = {
-			primaryKeyName: 'appId',
-			sortKeyName: 'displayName',
-		}
-		const listApps = (): Promise<App[]> => this.client.apps.list()
-
-		const preselectedId = await stringTranslateToId(config, args.id, listApps)
-		const id = await selectFromList(this, config, preselectedId, listApps, 'Select an app.')
+		const id = await chooseApp(this, args.id, { allowIndex: true })
 		await outputItem(this,
 			{ buildTableOutput: data => buildTableOutput(this.tableGenerator, data) },
 			() => this.client.apps.getSettings(id))

--- a/packages/cli/src/commands/apps/update.ts
+++ b/packages/cli/src/commands/apps/update.ts
@@ -1,19 +1,20 @@
 import { flags } from '@oclif/command'
 
-import { App, AppRequest} from '@smartthings/core-sdk'
+import { App, AppRequest } from '@smartthings/core-sdk'
 
-import { SelectingInputOutputAPICommand } from '@smartthings/cli-lib'
+import { ActionFunction, APICommand, inputAndOutputItem } from '@smartthings/cli-lib'
 
-import { tableFieldDefinitions } from '../apps'
+import { chooseApp, tableFieldDefinitions } from '../apps'
 import { addPermission } from '../../lib/aws-utils'
 import { lambdaAuthFlags } from '../../lib/common-flags'
 
 
-export default class AppUpdateCommand extends SelectingInputOutputAPICommand<AppRequest, App, App> {
+export default class AppUpdateCommand extends APICommand {
 	static description = 'update the OAuth settings of the app'
 
 	static flags = {
-		...SelectingInputOutputAPICommand.flags,
+		...APICommand.flags,
+		...inputAndOutputItem.flags,
 		authorize: flags.boolean({
 			description: 'authorize Lambda functions to be called by SmartThings',
 		}),
@@ -25,31 +26,27 @@ export default class AppUpdateCommand extends SelectingInputOutputAPICommand<App
 		description: 'the app id',
 	}]
 
-	primaryKeyName = 'appId'
-	sortKeyName = 'displayName'
-
-	protected tableFieldDefinitions = tableFieldDefinitions
-
 	async run(): Promise<void> {
 		const { args, argv, flags } = this.parse(AppUpdateCommand)
 		await super.setup(args, argv, flags)
 
-		await this.processNormally(args.id,
-			() => { return this.client.apps.list() },
-			async (id, data) => {
-				if (flags.authorize) {
-					if (data.lambdaSmartApp) {
-						if (data.lambdaSmartApp.functions) {
-							const requests = data.lambdaSmartApp.functions.map((it) => {
-								return addPermission(it, flags.principal, flags['statement-id'])
-							})
-							await Promise.all(requests)
-						}
-					} else {
-						throw new Error('Authorization is not applicable to web-hook SmartApps')
+		const appId = await chooseApp(this, args.id)
+
+		const executeUpdate: ActionFunction<void, AppRequest, App> = async (_, data) => {
+			if (flags.authorize) {
+				if (data.lambdaSmartApp) {
+					if (data.lambdaSmartApp.functions) {
+						const requests = data.lambdaSmartApp.functions.map((it) => {
+							return addPermission(it, flags.principal, flags['statement-id'])
+						})
+						await Promise.all(requests)
 					}
+				} else {
+					throw new Error('Authorization is not applicable to web-hook SmartApps')
 				}
-				return this.client.apps.update(id, data)
-			})
+			}
+			return this.client.apps.update(appId, data)
+		}
+		await inputAndOutputItem(this, { tableFieldDefinitions }, executeUpdate)
 	}
 }

--- a/packages/lib/src/__tests__/basic-io.test.ts
+++ b/packages/lib/src/__tests__/basic-io.test.ts
@@ -121,7 +121,7 @@ describe('basic-io', () => {
 			expect(formatAndWriteListSpy).toHaveBeenLastCalledWith(command, config, list, true, false)
 		})
 
-		it('passes forceCommonOutput value on to formatAndWriteList', async () => {
+		it('passes forUserQuery value on to formatAndWriteList', async () => {
 			const config = {
 				listTableFieldDefinitions: [],
 				primaryKeyName: 'num',

--- a/packages/lib/src/__tests__/format.test.ts
+++ b/packages/lib/src/__tests__/format.test.ts
@@ -243,5 +243,25 @@ describe('format', () => {
 			expect(writeOutputSpy).toHaveBeenCalledTimes(1)
 			expect(writeOutputSpy).toHaveBeenCalledWith('output', 'output.yaml')
 		})
+
+		it('writes common formatted output to stdout when forUserQuery specified', async () => {
+			const config = {
+				listTableFieldDefinitions: [],
+			}
+
+			const commonFormatter = jest.fn().mockReturnValue('common output')
+			listTableFormatterSpy.mockReturnValue(commonFormatter)
+
+			await formatAndWriteList(command, config, list, false, true)
+
+			expect(listTableFormatterSpy).toHaveBeenCalledTimes(1)
+			expect(listTableFormatterSpy).toHaveBeenCalledWith(command.tableGenerator, config.listTableFieldDefinitions, false)
+			expect(buildOutputFormatterSpy).toHaveBeenCalledTimes(0)
+			expect(outputFormatter).toHaveBeenCalledTimes(0)
+			expect(commonFormatter).toHaveBeenCalledTimes(1)
+			expect(commonFormatter).toHaveBeenCalledWith(list)
+			expect(writeOutputSpy).toHaveBeenCalledTimes(1)
+			expect(writeOutputSpy).toHaveBeenCalledWith('common output', undefined)
+		})
 	})
 })

--- a/packages/lib/src/basic-io.ts
+++ b/packages/lib/src/basic-io.ts
@@ -49,9 +49,9 @@ export async function outputItem<O>(command: SmartThingsCommandInterface, config
 outputItem.flags = buildOutputFormatter.flags
 
 export async function outputList<L>(command: SmartThingsCommandInterface, config: CommonListOutputProducer<L> & Sorting,
-		getData: GetDataFunction<L[]>, includeIndex = false, forceCommonOutput = false): Promise<L[]> {
+		getData: GetDataFunction<L[]>, includeIndex = false, forUserQuery = false): Promise<L[]> {
 	const list = sort(await getData(), config.sortKeyName)
-	await formatAndWriteList(command, config, list, includeIndex, forceCommonOutput)
+	await formatAndWriteList(command, config, list, includeIndex, forUserQuery)
 	return list
 }
 outputList.flags = buildOutputFormatter.flags

--- a/packages/lib/src/input-builder.ts
+++ b/packages/lib/src/input-builder.ts
@@ -26,6 +26,3 @@ buildInputProcessor.flags = {
 	...commonIOFlags,
 	...inputFlag,
 }
-
-
-// TODO: more convenience methods for making these processors more easily


### PR DESCRIPTION
<!-- Describe your pull request. -->

Converted some of the `SelectingInputOutputAPICommand` commands to the new functional versions. I'm doing this one in multiple steps to keep the pull request size down.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [X] My code follows the code style of this project (`lerna run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [X] I have added tests to cover my changes
