### PR TITLE
feat: Accept manufacturerName in device config command

### DIFF
--- a/packages/cli/src/__tests__/commands/presentation/device-config.test.ts
+++ b/packages/cli/src/__tests__/commands/presentation/device-config.test.ts
@@ -21,7 +21,17 @@ describe('DeviceConfigPresentationCommand', () => {
 	})
 
 	it('outputs item when required arg is provided', async () => {
+		const outputItemMock = outputItem as unknown as jest.Mock<typeof outputItem>
 		await expect(DeviceConfigPresentationCommand.run(['presentationId'])).resolves.not.toThrow()
-		expect(outputItem).toBeCalledTimes(1)
+		expect(outputItemMock).toBeCalledTimes(1)
+		expect(outputItemMock.mock.calls[0][0].argv[0]).toBe('presentationId')
+	})
+
+	it('outputs item when required and optional args are provided', async () => {
+		const outputItemMock = outputItem as unknown as jest.Mock<typeof outputItem>
+		await expect(DeviceConfigPresentationCommand.run(['presentationId', 'manufacturerName'])).resolves.not.toThrow()
+		expect(outputItemMock).toBeCalledTimes(1)
+		expect(outputItemMock.mock.calls[0][0].argv[0]).toBe('presentationId')
+		expect(outputItemMock.mock.calls[0][0].argv[1]).toBe('manufacturerName')
 	})
 })

--- a/packages/cli/src/commands/presentation/device-config.ts
+++ b/packages/cli/src/commands/presentation/device-config.ts
@@ -87,6 +87,11 @@ export default class DeviceConfigPresentationCommand extends APICommand {
 		name: 'presentationId',
 		description: 'system generated identifier that corresponds to a device presentation',
 		required: true,
+	},
+	{
+		name: 'manufacturerName',
+		description: 'manufacturer name. Defaults to SmartThingsCommunity',
+		required: false,
 	}]
 
 	async run(): Promise<void> {
@@ -94,6 +99,6 @@ export default class DeviceConfigPresentationCommand extends APICommand {
 		await super.setup(args, argv, flags)
 
 		await outputItem(this, { buildTableOutput: data => buildTableOutput(this.tableGenerator, data) },
-			() => this.client.presentation.get(args.presentationId))
+			() => this.client.presentation.get(args.presentationId, args.manufacturerName))
 	}
 }


### PR DESCRIPTION
Adds optional second _manufacturerName_ argument to the `presentation:device-config` command so that non-default configurations can be retrieved.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`lerna run lint` produces no warnings/errors)
- [x] Any required documentation has been added
- [x] I have added tests to cover my changes
