### PR TITLE
fix: pin pkg to resolve missing commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -394,9 +394,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.13.10",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
-			"integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+			"version": "7.13.17",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
+			"integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -4171,12 +4171,14 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
 		},
 		"are-we-there-yet": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+			"dev": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -4186,6 +4188,7 @@
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -4199,12 +4202,14 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -5445,7 +5450,8 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+			"dev": true
 		},
 		"contains-path": {
 			"version": "0.1.0",
@@ -6051,7 +6057,8 @@
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+			"dev": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -6083,11 +6090,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
 			"integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA=="
-		},
-		"detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 		},
 		"detect-newline": {
 			"version": "3.1.0",
@@ -7471,6 +7473,7 @@
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"dev": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -7485,12 +7488,14 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -7499,6 +7504,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -7509,6 +7515,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -8043,11 +8050,6 @@
 				"ini": "^1.3.2"
 			}
 		},
-		"github-from-package": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
-		},
 		"github-slugger": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
@@ -8273,7 +8275,8 @@
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+			"dev": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -8560,7 +8563,8 @@
 		"ini": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true
 		},
 		"init-package-json": {
 			"version": "2.0.2",
@@ -11435,11 +11439,6 @@
 				"to-regex": "^3.0.1"
 			}
 		},
-		"napi-build-utils": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
-		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -11465,21 +11464,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-		},
-		"node-abi": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.21.0.tgz",
-			"integrity": "sha512-smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==",
-			"requires": {
-				"semver": "^5.4.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				}
-			}
 		},
 		"node-fetch": {
 			"version": "2.6.1",
@@ -11561,11 +11545,6 @@
 			"version": "1.1.71",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
 			"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
-		},
-		"noop-logger": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
 		},
 		"nopt": {
 			"version": "4.0.3",
@@ -11761,6 +11740,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"dev": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -11786,7 +11766,8 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -12670,12 +12651,12 @@
 			}
 		},
 		"pkg": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/pkg/-/pkg-4.5.1.tgz",
-			"integrity": "sha512-UXKL88jGQ+FD4//PyrFeRcqurVQ3BVIfUNaEU9cXY24EJz08JyBj85qrGh0CFGvyzNb1jpwHOnns5Sw0M5H92Q==",
+			"version": "4.4.9",
+			"resolved": "https://registry.npmjs.org/pkg/-/pkg-4.4.9.tgz",
+			"integrity": "sha512-FK4GqHtcCY2PPPVaKViU0NyRzpo6gCS7tPKN5b7AkElqjAOCH1bsRKgohEnxThr6DWfTGByGqba2YHGR/BqbmA==",
 			"requires": {
-				"@babel/parser": "7.13.12",
-				"@babel/runtime": "7.13.10",
+				"@babel/parser": "^7.9.4",
+				"@babel/runtime": "^7.9.2",
 				"chalk": "^3.0.0",
 				"escodegen": "^1.14.1",
 				"fs-extra": "^8.1.0",
@@ -12683,18 +12664,12 @@
 				"into-stream": "^5.1.1",
 				"minimist": "^1.2.5",
 				"multistream": "^2.1.1",
-				"pkg-fetch": "2.6.9",
-				"prebuild-install": "6.0.1",
+				"pkg-fetch": "^2.6.9",
 				"progress": "^2.0.3",
 				"resolve": "^1.15.1",
 				"stream-meter": "^1.0.4"
 			},
 			"dependencies": {
-				"@babel/parser": {
-					"version": "7.13.12",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.12.tgz",
-					"integrity": "sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw=="
-				},
 				"chalk": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -12909,28 +12884,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
-		},
-		"prebuild-install": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
-			"integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
-			"requires": {
-				"detect-libc": "^1.0.3",
-				"expand-template": "^2.0.3",
-				"github-from-package": "0.0.0",
-				"minimist": "^1.2.3",
-				"mkdirp-classic": "^0.5.3",
-				"napi-build-utils": "^1.0.1",
-				"node-abi": "^2.7.0",
-				"noop-logger": "^0.1.1",
-				"npmlog": "^4.0.1",
-				"pump": "^3.0.0",
-				"rc": "^1.2.7",
-				"simple-get": "^3.0.3",
-				"tar-fs": "^2.0.0",
-				"tunnel-agent": "^0.6.0",
-				"which-pm-runs": "^1.0.0"
-			}
 		},
 		"prelude-ls": {
 			"version": "1.2.1",
@@ -13239,6 +13192,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dev": true,
 			"requires": {
 				"deep-extend": "^0.6.0",
 				"ini": "~1.3.0",
@@ -13249,7 +13203,8 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"dev": true
 				}
 			}
 		},
@@ -14541,36 +14496,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
-		},
-		"simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
-		},
-		"simple-get": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-			"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-			"requires": {
-				"decompress-response": "^4.2.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			},
-			"dependencies": {
-				"decompress-response": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-					"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-					"requires": {
-						"mimic-response": "^2.0.0"
-					}
-				},
-				"mimic-response": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-					"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
-				}
-			}
 		},
 		"sisteransi": {
 			"version": "1.0.5",
@@ -16072,15 +15997,11 @@
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
-		"which-pm-runs": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
-		},
 		"wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			},
@@ -16088,17 +16009,20 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -16108,6 +16032,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -89,7 +89,7 @@
 		"eslint-plugin-jest": "^24.1.3",
 		"jest": "^26.5.2",
 		"jest-extended": "^0.11.5",
-		"pkg": "^4.4.9",
+		"pkg": "4.4.9",
 		"ts-jest": "^26.4.1",
 		"ts-node": "^9.0.0",
 		"typescript": "^4.0.3",


### PR DESCRIPTION
* pin `pkg` to 4.4.9 as [4.5.0](https://github.com/vercel/pkg/releases/tag/4.5.0) seems to have broken our build (built binaries would not have expected OCLIF commands)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`lerna run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
