### PR TITLE
fix: Default schema authorization to the correct principal

### DIFF
--- a/packages/cli/src/commands/schema/authorize.ts
+++ b/packages/cli/src/commands/schema/authorize.ts
@@ -35,7 +35,10 @@ export default class SchemaAppAuthorizeCommand extends SmartThingsCommand {
 		const { args, argv, flags } = this.parse(SchemaAppAuthorizeCommand)
 		await super.setup(args, argv, flags)
 
-		addPermission(args.arn, flags.principal, flags['statement-id']).then(async (message) => {
+		const principal = flags.principal || '148790070172'
+		const statementId = flags['statement-id']
+
+		addPermission(args.arn, principal, statementId).then(async (message) => {
 			this.log(message)
 		}).catch(err => {
 			this.log(`caught error ${err}`)

--- a/packages/cli/src/commands/schema/create.ts
+++ b/packages/cli/src/commands/schema/create.ts
@@ -27,17 +27,20 @@ export default class SchemaAppCreateCommand extends APICommand {
 		const createApp = async (_: void, data: SchemaAppRequest): Promise<SchemaCreateResponse> => {
 			if (flags.authorize) {
 				if (data.hostingType === 'lambda') {
+					const principal = flags.principal || '148790070172'
+					const statementId = flags['statement-id']
+
 					if (data.lambdaArn) {
-						await addSchemaPermission(data.lambdaArn, flags.principal, flags['statement-id'])
+						await addSchemaPermission(data.lambdaArn, principal, statementId)
 					}
 					if (data.lambdaArnAP) {
-						await addSchemaPermission(data.lambdaArnAP, flags.principal, flags['statement-id'])
+						await addSchemaPermission(data.lambdaArnAP, principal, statementId)
 					}
 					if (data.lambdaArnCN) {
-						await addSchemaPermission(data.lambdaArnCN, flags.principal, flags['statement-id'])
+						await addSchemaPermission(data.lambdaArnCN, principal, statementId)
 					}
 					if (data.lambdaArnEU) {
-						await addSchemaPermission(data.lambdaArnEU, flags.principal, flags['statement-id'])
+						await addSchemaPermission(data.lambdaArnEU, principal, statementId)
 					}
 				} else {
 					this.logger.error('Authorization is not applicable to WebHook schema connectors')


### PR DESCRIPTION
Use the correct principal when authorizing st schema apps

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`lerna run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
