### PR TITLE
fix: Interactive device profile creation with standard capabilities

### DIFF
--- a/packages/cli/src/commands/deviceprofiles/create.ts
+++ b/packages/cli/src/commands/deviceprofiles/create.ts
@@ -12,7 +12,7 @@ import { APICommand, inputAndOutputItem, userInputProcessor } from '@smartthings
 
 import { buildTableOutput } from '../deviceprofiles'
 import { DeviceDefinitionRequest } from './view'
-import { chooseCapability } from '../capabilities'
+import {CapabilityId, chooseCapabilityFiltered} from '../capabilities'
 
 
 const capabilitiesWithoutPresentations = ['healthCheck', 'execute']
@@ -169,8 +169,36 @@ export default class DeviceProfileCreateCommand extends APICommand {
 			createDeviceProfile, userInputProcessor(this))
 	}
 
-	protected async promptAndAddCapability(deviceProfile: DeviceProfileRequest, componentId: string, prompt = 'Capability ID'): Promise<void> {
-		const capabilityId = await chooseCapability(this, undefined, undefined, `${prompt}: `)
+	// TODO - update once capability versions are supported
+	protected async capabilityDefined(idStr:string): Promise<boolean> {
+		try {
+			const capability = await this.client.capabilities.get(idStr, 1)
+			return !!capability
+		} catch (e) {
+			return false
+		}
+	}
+	protected async promptAndAddCapability(deviceProfile: DeviceProfileRequest, componentId: string, prompt = 'Capability ID'): Promise<CapabilityId | false> {
+		let capabilityId: CapabilityId | false = false
+		const idStr = (await inquirer.prompt({
+			type: 'input',
+			name: 'id',
+			message: `${prompt} (type ? for a list):`,
+			validate: async (input) => {
+				return (input.endsWith('?') || input === '' || await this.capabilityDefined(input))
+					? true
+					: `Invalid ID "${input}". Please enter a valid capability ID or ? for a list of available capabilities.`
+			},
+		})).id
+
+		if (idStr) {
+			if (idStr.endsWith('?')) {
+				capabilityId = await chooseCapabilityFiltered(this, `${prompt}:`, idStr.slice(0, idStr.length - 1))
+			} else {
+				// TODO - update once capability versions are supported
+				capabilityId = {id: idStr, version: 1}
+			}
+		}
 
 		if (capabilityId) {
 			const component = deviceProfile.components?.find(it => it.id === componentId)
@@ -180,6 +208,8 @@ export default class DeviceProfileCreateCommand extends APICommand {
 				throw new CLIError(`Component ${componentId} not defined in profile`)
 			}
 		}
+
+		return capabilityId
 	}
 
 	protected async promptAndAddComponent(deviceProfile: DeviceProfileRequest, previousComponentId: string): Promise<string> {
@@ -221,7 +251,10 @@ export default class DeviceProfileCreateCommand extends APICommand {
 			],
 		}
 
-		await this.promptAndAddCapability(deviceProfile, 'main', 'Primary capability ID')
+		let primaryCapabilityId: CapabilityId | false
+		do {
+			primaryCapabilityId = await this.promptAndAddCapability(deviceProfile, 'main', 'Primary capability ID')
+		} while (!primaryCapabilityId)
 
 		const enum Action {
 			ADD_CAPABILITY = 'Add another capability to this component',

--- a/packages/lib/src/basic-io.ts
+++ b/packages/lib/src/basic-io.ts
@@ -15,7 +15,7 @@ export type ListDataFunction<L> = () => Promise<L[]>
 export type LookupDataFunction<ID, O> = (id: ID) => Promise<O>
 export type ActionFunction<ID, I, O> = (id: ID, input: I) => Promise<O>
 export type IdTranslationFunction<ID, L> = (idOrIndex: ID | string, listFunction: ListDataFunction<L>) => Promise<ID>
-export type IdRetrievalFunction<ID, L> = (fieldInfo: Sorting, list: L[], promptMessage?: string) => Promise<ID>
+export type IdRetrievalFunction<ID, L> = (fieldInfo: Sorting, list: L[], promptMessage?: string, optional?: boolean) => Promise<ID>
 
 
 export interface Sorting {

--- a/packages/lib/src/select.ts
+++ b/packages/lib/src/select.ts
@@ -14,7 +14,7 @@ function promptFromNaming(config: Naming): string | undefined {
 
 export async function selectGeneric<ID, L>(command: SmartThingsCommandInterface, config: SelectingConfig<L>,
 		preselectedId: ID | undefined, listItems: ListDataFunction<L>,
-		getIdFromUser: IdRetrievalFunction<ID, L>, promptMessage?: string, autoChoose = false): Promise<ID> {
+		getIdFromUser: IdRetrievalFunction<ID, L>, promptMessage?: string, autoChoose = false, optional = false): Promise<ID> {
 	if (preselectedId) {
 		return preselectedId
 	}
@@ -31,7 +31,7 @@ export async function selectGeneric<ID, L>(command: SmartThingsCommandInterface,
 		command.exit(0)
 	}
 
-	return await getIdFromUser(config, list, promptMessage ?? promptFromNaming(config))
+	return await getIdFromUser(config, list, promptMessage ?? promptFromNaming(config), optional)
 }
 
 /**


### PR DESCRIPTION
Corrects a bug in the current implementation that only allows for the selection of custom capabilities in the interactive `deviceprofiles:create` process. That was because a list of only the custom capabilities was displayed, and the entry was validated by checking for membership in the list. Two legitimate scenarios were therefore unsupported:
1. Standard capabilities (the most common case)
2. Custom capabilities that weren't owned by the user (less common but still valid)

Since there are over 200 standard capabilities, prompting with a list of all of them plus any custom capabilities seems needlessly noisy. On the other hand, being able to select from a list is useful, especially for new users. Therefore this change:
* Doesn't initially prompt with a list
* Prompts the user to enter a `?` symbol if a list is desired
* Prompts with a list of all standard and custom capabilities if `?` is entered
* Also accepts a string followed by `?`, for example `temperature?`
* Prompts with a list of all standard and custom capabilities that contain the string
* Also accepts an empty string for the capability ID, which returns the user to the previous interactive level, so that some errors can be handled without starting over again

For example:
```
~$ smartthings deviceprofiles:create
? Device Profile Name: Demo Profile
? Primary capability ID (type ? for a list): switch
? Select an action... Add another capability to this component
? Capability ID (type ? for a list): temperature?
┌───┬────────────────────────────┬─────────┬────────┐
│ # │ Id                         │ Version │ Status │
├───┼────────────────────────────┼─────────┼────────┤
│ 1 │ colorTemperature           │ 1       │ live   │
│ 2 │ statelessTemperatureButton │ 1       │ live   │
│ 3 │ temperatureAlarm           │ 1       │ live   │
│ 4 │ temperatureMeasurement     │ 1       │ live   │
└───┴────────────────────────────┴─────────┴────────┘
? Capability ID: 4
? Select an action... Finish & Create
Basic Information
┌───────────────────┬──────────────────────────────────────┐
│ Name              │ Demo Profile                         │
│ main component    │ switch                               │
│                   │ temperatureMeasurement               │
│ Id                │ fbd8626b-e7ba-4d51-a779-81f6b85441f4 │
│ Device Type       │                                      │
│ OCF Device Type   │                                      │
│ Manufacturer Name │ SmartThingsCommunity                 │
│ Presentation ID   │ 5f5f5814-d577-3738-87f5-b03314cab296 │
│ Status            │ DEVELOPMENT                          │
└───────────────────┴──────────────────────────────────────┘
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`lerna run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
