### PR TITLE
fix: Support standard capabilities in interactive profile creation

### DIFF
--- a/packages/cli/src/commands/schema/authorize.ts
+++ b/packages/cli/src/commands/schema/authorize.ts
@@ -4,6 +4,8 @@ import { addPermission } from '../../lib/aws-utils'
 import { lambdaAuthFlags } from '../../lib/common-flags'
 
 
+export const SCHEMA_AWS_PRINCIPAL = '148790070172'
+
 export default class SchemaAppAuthorizeCommand extends SmartThingsCommand {
 	static description = 'authorize calls to your ST Schema Lambda function from SmartThings'
 
@@ -35,7 +37,7 @@ export default class SchemaAppAuthorizeCommand extends SmartThingsCommand {
 		const { args, argv, flags } = this.parse(SchemaAppAuthorizeCommand)
 		await super.setup(args, argv, flags)
 
-		const principal = flags.principal || '148790070172'
+		const principal = flags.principal ?? SCHEMA_AWS_PRINCIPAL
 		const statementId = flags['statement-id']
 
 		addPermission(args.arn, principal, statementId).then(async (message) => {

--- a/packages/cli/src/commands/schema/create.ts
+++ b/packages/cli/src/commands/schema/create.ts
@@ -6,6 +6,7 @@ import { APICommand, inputAndOutputItem } from '@smartthings/cli-lib'
 
 import { addSchemaPermission } from '../../lib/aws-utils'
 import { lambdaAuthFlags } from '../../lib/common-flags'
+import { SCHEMA_AWS_PRINCIPAL } from './authorize'
 
 
 export default class SchemaAppCreateCommand extends APICommand {
@@ -27,7 +28,7 @@ export default class SchemaAppCreateCommand extends APICommand {
 		const createApp = async (_: void, data: SchemaAppRequest): Promise<SchemaCreateResponse> => {
 			if (flags.authorize) {
 				if (data.hostingType === 'lambda') {
-					const principal = flags.principal || '148790070172'
+					const principal = flags.principal ?? SCHEMA_AWS_PRINCIPAL
 					const statementId = flags['statement-id']
 
 					if (data.lambdaArn) {


### PR DESCRIPTION
Corrects a bug in the current implementation that only allows for the selection of custom capabilities in the interactive `deviceprofiles:create` process. That was because a list of only the custom capabilities was displayed, and the entry was validated by checking for membership in the list. Two legitimate scenarios were therefore unsupported:
1. Standard capabilities (the most common case)
2. Custom capabilities that weren't owned by the user (less common but still valid)

Since there are over 200 standard capabilities, prompting with a list of all of them plus any custom capabilities seems needlessly noisy. On the other hand, being able to select from a list is useful, especially for new users. Therefore this change:
* Doesn't initially prompt with a list
* Prompts the user to enter a `?` symbol if a list is desired
* Prompts with a list of all standard and custom capabilities if `?` is entered
* Also accepts a string followed by `?`, for example `temperature?`
* Prompts with a list of all standard and custom capabilities that contain the string

For example:
```
~$ smartthings deviceprofiles:create
? Device Profile Name: Demo Profile
? Primary capability ID (type ? for a list): switch
? Select an action... Add another capability to this component
? Capability ID (type ? for a list): temperature?
┌───┬────────────────────────────┬─────────┬────────┐
│ # │ Id                         │ Version │ Status │
├───┼────────────────────────────┼─────────┼────────┤
│ 1 │ colorTemperature           │ 1       │ live   │
│ 2 │ statelessTemperatureButton │ 1       │ live   │
│ 3 │ temperatureAlarm           │ 1       │ live   │
│ 4 │ temperatureMeasurement     │ 1       │ live   │
└───┴────────────────────────────┴─────────┴────────┘
? Capability ID: 4
? Select an action... Finish & Create
Basic Information
┌───────────────────┬──────────────────────────────────────┐
│ Name              │ Demo Profile                         │
│ main component    │ switch                               │
│                   │ temperatureMeasurement               │
│ Id                │ fbd8626b-e7ba-4d51-a779-81f6b85441f4 │
│ Device Type       │                                      │
│ OCF Device Type   │                                      │
│ Manufacturer Name │ SmartThingsCommunity                 │
│ Presentation ID   │ 5f5f5814-d577-3738-87f5-b03314cab296 │
│ Status            │ DEVELOPMENT                          │
└───────────────────┴──────────────────────────────────────┘
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`lerna run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
