### PR TITLE
fix: Don't consider lack of custom capabilities an error in list command

### DIFF
--- a/packages/cli/src/commands/capabilities.ts
+++ b/packages/cli/src/commands/capabilities.ts
@@ -146,11 +146,6 @@ export async function getCustomByNamespace(client: SmartThingsClient, namespace?
 		namespaces = (await client.capabilities.listNamespaces()).map((ns: CapabilityNamespace) => ns.name)
 	}
 
-	if (!namespaces || namespaces.length == 0) {
-		throw Error('could not find any namespaces for your account. Perhaps ' +
-			"you haven't created any capabilities yet.")
-	}
-
 	let capabilities: CapabilitySummaryWithNamespace[] = []
 	for (const namespace of namespaces) {
 		const caps = await client.capabilities.list(namespace)


### PR DESCRIPTION
The CLI is currently returning an error from the `capabilities` command when the user has no custom capabilities. That's inconsistent with all other list commands that return a "no items found" message.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`lerna run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
