### PR TITLE
chore: change preid to beta

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -11,7 +11,7 @@
 			"gitRemote": "upstream",
 			"message": "chore(release): publish %s",
 			"conventionalPrerelease": true,
-			"preid": "pre"
+			"preid": "beta"
 		}
 	}
 }


### PR DESCRIPTION
The intent of this PR is to prepare the repo for a version change from `0.0.0-pre` to `1.0.0-beta`. Once merged, we will locally version at `1.0.0-beta.0` and publish.
