### PR TITLE
build: don't remove lib directory in prepack script

### DIFF
--- a/.changeset/friendly-maps-learn.md
+++ b/.changeset/friendly-maps-learn.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+build fix (don't remove compiled files before publish)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Package CLI
         id: cli-package
         if: steps.cli-metadata.outcome == 'success'
-        run: npm run package
+        run: pwd && ls -l . packages/cli packages/cli/lib && echo 'packaging' && npm run package && echo 'done packaging' && pwd && ls -l . packages/cli packages/cli/lib packages/cli/dist_bin
 
       - name: Create Github Release
         if: steps.cli-package.outcome == 'success'

--- a/package-lock.json
+++ b/package-lock.json
@@ -17629,7 +17629,7 @@
 		},
 		"packages/cli": {
 			"name": "@smartthings/cli",
-			"version": "1.0.0-beta.2",
+			"version": "1.0.0-beta.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@oclif/core": "^1.6.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -114,7 +114,7 @@
 		"test-watch": "jest --watch",
 		"test-coverage": "jest --coverage=true",
 		"postpack": "rimraf oclif.manifest.json",
-		"prepack": "rimraf lib && tsc -b && oclif manifest && oclif readme",
+		"prepack": "tsc -b && oclif manifest && oclif readme",
 		"version": "oclif readme && git add README.md",
 		"package": "pkg package.json && npm run zip-binaries",
 		"zip-binaries": "./zip-binaries.sh"


### PR DESCRIPTION
<!-- Describe your pull request. -->

* Removed command removing lib directory in prepack script.
* Added a little debug to the packaging. We might want to remove this at some point in the future but I think it would be good to leave it in for a couple releases.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
