### PR TITLE
docs(readme): remove relative link to config doc

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -982,7 +982,7 @@ DESCRIPTION
   create a capability translation
 
 EXAMPLES
-  $ smartthings capabilities:translations:create custom1.outputModulation 1 -i en.yaml 
+  $ smartthings capabilities:translations:create custom1.outputModulation 1 -i en.yaml
 
   tag: en
 
@@ -1106,7 +1106,7 @@ DESCRIPTION
   update a capability translation
 
 EXAMPLES
-  $ smartthings capabilities:translations:update custom1.outputModulation 1 -i en.yaml 
+  $ smartthings capabilities:translations:update custom1.outputModulation 1 -i en.yaml
 
   tag: en
 
@@ -1230,7 +1230,7 @@ DESCRIPTION
   create or update a capability translation
 
 EXAMPLES
-  $ smartthings capabilities:translations:upsert custom1.outputModulation 1 -i en.yaml 
+  $ smartthings capabilities:translations:upsert custom1.outputModulation 1 -i en.yaml
 
   tag: en
 
@@ -5021,7 +5021,7 @@ ALIASES
   $ smartthings plugins:add
 
 EXAMPLES
-  $ smartthings plugins:install myplugin 
+  $ smartthings plugins:install myplugin
 
   $ smartthings plugins:install https://github.com/someuser/someplugin
 
@@ -5083,7 +5083,7 @@ ALIASES
   $ smartthings plugins:add
 
 EXAMPLES
-  $ smartthings plugins:install myplugin 
+  $ smartthings plugins:install myplugin
 
   $ smartthings plugins:install https://github.com/someuser/someplugin
 
@@ -5788,8 +5788,8 @@ _See code: [src/commands/schema/update.ts](https://github.com/SmartThingsCommuni
 Debug logging can be enabled via the `SMARTTHINGS_DEBUG` environment variable. This will log at debug level to the console as well as the default log file.
 
 ```console
-SMARTTHINGS_DEBUG=true smartthings <command>
+$ SMARTTHINGS_DEBUG=true smartthings <command>
 ```
 
 More details about advanced configuration and logging in the CLI can be found on the
-[configuration documentation page](./doc/configuration.md).
+[configuration documentation page](https://github.com/SmartThingsCommunity/smartthings-cli/blob/master/packages/cli/doc/configuration.md).


### PR DESCRIPTION
- use absolute URL since the relative link is broken from the root version of the README

<!-- Describe your pull request. -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [ ] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
