### PR TITLE
fix: correct devices:update description

### DIFF
--- a/packages/cli/src/commands/devices/update.ts
+++ b/packages/cli/src/commands/devices/update.ts
@@ -6,7 +6,7 @@ import { buildTableOutput } from '../../lib/commands/devices/devices-util'
 
 
 export default class DeviceUpdateCommand extends APICommand<typeof DeviceUpdateCommand.flags> {
-	static description = "get the current status of all of a device's component's attributes"
+	static description = "update a device's label and room"
 
 	static flags = {
 		...APICommand.flags,


### PR DESCRIPTION
Correct copy/paste error in description for devices:update. Previous description incorrectly described devices:status instead.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
