### PR TITLE
refactor: finish schema unit test coverage

### DIFF
--- a/packages/cli/src/__tests__/commands/schema/authorize.test.ts
+++ b/packages/cli/src/__tests__/commands/schema/authorize.test.ts
@@ -1,0 +1,40 @@
+import SchemaAppAuthorizeCommand from '../../../commands/schema/authorize'
+import { addSchemaPermission } from '../../../lib/aws-utils'
+
+
+jest.mock('../../../lib/aws-utils')
+
+describe('SchemaAppAuthorizeCommand', () => {
+	const addSchemaPermissionMock = jest.mocked(addSchemaPermission).mockResolvedValue('Authorization added')
+	const logSpy = jest.spyOn(SchemaAppAuthorizeCommand.prototype, 'log').mockImplementation()
+
+	it('requires ARN arg', async () => {
+		await expect(SchemaAppAuthorizeCommand.run([])).rejects.toThrow('Missing 1 required arg:\narn')
+	})
+
+	it('calls addSchemaPermission with required ARN', async () => {
+		await expect(SchemaAppAuthorizeCommand.run(['ARN'])).resolves.not.toThrow()
+
+		expect(addSchemaPermissionMock).toBeCalledWith('ARN', undefined, undefined)
+		expect(logSpy).toBeCalledWith('Authorization added')
+	})
+
+	it('passes principal flag to addSchemaPermission', async () => {
+		await expect(SchemaAppAuthorizeCommand.run(['ARN', '--principal=principal'])).resolves.not.toThrow()
+
+		expect(addSchemaPermissionMock).toBeCalledWith('ARN', 'principal', undefined)
+	})
+
+	it('passes statement-id flag to addSchemaPermission', async () => {
+		await expect(SchemaAppAuthorizeCommand.run(['ARN', '--statement-id=statementId'])).resolves.not.toThrow()
+
+		expect(addSchemaPermissionMock).toBeCalledWith('ARN', undefined, 'statementId')
+	})
+
+	it('throws unexpected errors', async () => {
+		const error = new Error('unexpected')
+		addSchemaPermissionMock.mockRejectedValueOnce(error)
+
+		await expect(SchemaAppAuthorizeCommand.run(['ARN'])).rejects.toThrow(error)
+	})
+})

--- a/packages/cli/src/__tests__/commands/schema/delete.test.ts
+++ b/packages/cli/src/__tests__/commands/schema/delete.test.ts
@@ -1,0 +1,35 @@
+import { selectFromList } from '@smartthings/cli-lib'
+import { SchemaEndpoint } from '@smartthings/core-sdk'
+import SchemaAppDeleteCommand from '../../../commands/schema/delete'
+
+
+describe('SchemaAppDeleteCommand', () => {
+	const deleteSpy = jest.spyOn(SchemaEndpoint.prototype, 'delete').mockImplementation()
+	const logSpy = jest.spyOn(SchemaAppDeleteCommand.prototype, 'log').mockImplementation()
+
+	const selectFromListMock = jest.mocked(selectFromList).mockResolvedValue('schemaAppId')
+
+	it('prompts user to choose app', async () => {
+		await expect(SchemaAppDeleteCommand.run(['schemaAppId'])).resolves.not.toThrow()
+
+		expect(selectFromListMock).toBeCalledWith(
+			expect.any(SchemaAppDeleteCommand),
+			expect.objectContaining({
+				primaryKeyName: 'endpointAppId',
+				sortKeyName: 'appName',
+			}),
+			expect.objectContaining({
+				preselectedId: 'schemaAppId',
+				listItems: expect.any(Function),
+				promptMessage: 'Select a schema app to delete.',
+			}),
+		)
+	})
+
+	it('uses correct endpoint to delete app', async () => {
+		await expect(SchemaAppDeleteCommand.run([])).resolves.not.toThrow()
+
+		expect(deleteSpy).toBeCalledWith('schemaAppId')
+		expect(logSpy).toBeCalledWith('Schema app schemaAppId deleted.')
+	})
+})

--- a/packages/cli/src/__tests__/commands/schema/regenerate.test.ts
+++ b/packages/cli/src/__tests__/commands/schema/regenerate.test.ts
@@ -1,0 +1,70 @@
+import { outputItem, selectFromList } from '@smartthings/cli-lib'
+import { SchemaEndpoint, SchemaCreateResponse } from '@smartthings/core-sdk'
+import SchemaAppRegenerateCommand from '../../../commands/schema/regenerate'
+
+
+describe('SchemaAppRegenerateCommand', () => {
+	const regenerateOauthSpy = jest.spyOn(SchemaEndpoint.prototype, 'regenerateOauth').mockImplementation()
+	const listSpy = jest.spyOn(SchemaEndpoint.prototype, 'list').mockImplementation()
+
+
+	const selectFromListMock = jest.mocked(selectFromList).mockResolvedValue('schemaAppId')
+	const outputItemMock = jest.mocked(outputItem)
+
+	it('prompts user to select schema app', async () => {
+		await expect(SchemaAppRegenerateCommand.run(['schemaAppId'])).resolves.not.toThrow()
+
+		expect(selectFromListMock).toBeCalledWith(
+			expect.any(SchemaAppRegenerateCommand),
+			expect.objectContaining({
+				primaryKeyName: 'endpointAppId',
+				sortKeyName: 'appName',
+			}),
+			expect.objectContaining({
+				preselectedId: 'schemaAppId',
+				listItems: expect.any(Function),
+				promptMessage: 'Select a schema app to regenerate its clientId and clientSecret.',
+			}),
+		)
+	})
+
+	it('calls correct list endpoint', async () => {
+		const list = [{ appName: 'schemaApp' }]
+		listSpy.mockResolvedValueOnce(list)
+
+		await expect(SchemaAppRegenerateCommand.run(['schemaAppId'])).resolves.not.toThrow()
+
+		const listFunction = selectFromListMock.mock.calls[0][2].listItems
+
+		await expect(listFunction()).resolves.toStrictEqual(list)
+	})
+
+	it('calls outputItem with correct config', async () => {
+		await expect(SchemaAppRegenerateCommand.run(['schemaAppId'])).resolves.not.toThrow()
+
+		expect(outputItemMock).toBeCalledWith(
+			expect.any(SchemaAppRegenerateCommand),
+			expect.objectContaining({
+				tableFieldDefinitions: ['endpointAppId', 'stClientId', 'stClientSecret'],
+			}),
+			expect.any(Function),
+		)
+	})
+
+	it('calls correct regenerate endpoint', async () => {
+		const schemaCreateResponse: SchemaCreateResponse = {
+			stClientId: 'clientId',
+			stClientSecret: 'clientSecret',
+			endpointAppId: 'schemaAppId',
+		}
+
+		regenerateOauthSpy.mockResolvedValueOnce(schemaCreateResponse)
+
+		await expect(SchemaAppRegenerateCommand.run(['schemaAppId'])).resolves.not.toThrow()
+
+		const regenerateFunction = outputItemMock.mock.calls[0][2]
+
+		await expect(regenerateFunction()).resolves.toStrictEqual(schemaCreateResponse)
+		expect(regenerateOauthSpy).toBeCalledWith('schemaAppId')
+	})
+})

--- a/packages/cli/src/commands/schema/authorize.ts
+++ b/packages/cli/src/commands/schema/authorize.ts
@@ -1,7 +1,5 @@
 import { SmartThingsCommand, lambdaAuthFlags } from '@smartthings/cli-lib'
-
-import { addPermission } from '../../lib/aws-utils'
-import { SCHEMA_AWS_PRINCIPAL } from '../../lib/commands/schema/schema-util'
+import { addSchemaPermission } from '../../lib/aws-utils'
 
 
 export default class SchemaAppAuthorizeCommand extends SmartThingsCommand<typeof SchemaAppAuthorizeCommand.flags> {
@@ -32,13 +30,7 @@ export default class SchemaAppAuthorizeCommand extends SmartThingsCommand<typeof
 	]
 
 	async run(): Promise<void> {
-		const principal = this.flags.principal ?? SCHEMA_AWS_PRINCIPAL
-		const statementId = this.flags['statement-id']
-
-		addPermission(this.args.arn, principal, statementId).then(async (message) => {
-			this.log(message)
-		}).catch(err => {
-			this.log(`caught error ${err}`)
-		})
+		const message = await addSchemaPermission(this.args.arn, this.flags.principal, this.flags['statement-id'])
+		this.log(message)
 	}
 }


### PR DESCRIPTION
- refactor schema:authorize command to use addSchemaPermission

<!-- Describe your pull request. -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
