### PR TITLE
feat: display label when choosing device to delete

### DIFF
--- a/packages/cli/src/__tests__/commands/devices/delete.test.ts
+++ b/packages/cli/src/__tests__/commands/devices/delete.test.ts
@@ -1,39 +1,21 @@
-import { selectFromList } from '@smartthings/cli-lib'
+import { chooseDevice } from '@smartthings/cli-lib'
 import { DevicesEndpoint } from '@smartthings/core-sdk'
 import DeviceDeleteCommand from '../../../commands/devices/delete'
 
 
 describe('DeviceDeleteCommand', () => {
 	const deleteDevicesSpy = jest.spyOn(DevicesEndpoint.prototype, 'delete').mockImplementation()
-	const listDevicesSpy = jest.spyOn(DevicesEndpoint.prototype, 'list').mockImplementation()
 	const logSpy = jest.spyOn(DeviceDeleteCommand.prototype, 'log').mockImplementation()
 
-	const selectFromListMock = jest.mocked(selectFromList).mockResolvedValue('deviceId')
+	const deviceSelectionMock = jest.mocked(chooseDevice).mockResolvedValue('deviceId')
 
 	it('prompts user to select device', async () => {
 		await expect(DeviceDeleteCommand.run(['deviceId'])).resolves.not.toThrow()
 
-		expect(selectFromListMock).toBeCalledWith(
+		expect(deviceSelectionMock).toBeCalledWith(
 			expect.any(DeviceDeleteCommand),
-			expect.objectContaining({
-				primaryKeyName: 'deviceId',
-				sortKeyName: 'name',
-			}),
-			expect.objectContaining({
-				preselectedId: 'deviceId',
-				listItems: expect.any(Function),
-				promptMessage: 'Select device to delete.',
-			}),
+			'deviceId',
 		)
-	})
-
-	it('calls correct list endpoint', async () => {
-		await expect(DeviceDeleteCommand.run(['deviceId'])).resolves.not.toThrow()
-
-		const listFunction = selectFromListMock.mock.calls[0][2].listItems
-		await listFunction()
-
-		expect(listDevicesSpy).toBeCalledTimes(1)
 	})
 
 	it('deletes the device and logs success', async () => {

--- a/packages/cli/src/commands/devices/delete.ts
+++ b/packages/cli/src/commands/devices/delete.ts
@@ -1,4 +1,4 @@
-import { APICommand, selectFromList } from '@smartthings/cli-lib'
+import { APICommand, chooseDevice } from '@smartthings/cli-lib'
 
 
 export default class DeviceDeleteCommand extends APICommand<typeof DeviceDeleteCommand.flags> {
@@ -12,15 +12,8 @@ export default class DeviceDeleteCommand extends APICommand<typeof DeviceDeleteC
 	}]
 
 	async run(): Promise<void> {
-		const config = {
-			primaryKeyName: 'deviceId',
-			sortKeyName: 'name',
-		}
-		const id = await selectFromList(this, config, {
-			preselectedId: this.args.id,
-			listItems: () => this.client.devices.list(),
-			promptMessage: 'Select device to delete.',
-		})
+		const id = await chooseDevice(this, this.args.id)
+
 		await this.client.devices.delete(id)
 		this.log(`Device ${id} deleted.`)
 	}


### PR DESCRIPTION
<!-- Describe your pull request. -->
Display additional fields in the devices:delete table, including device label, to make it easier for a user to select the correct device to delete.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
