### PR TITLE
fix: clean up output of capability enum types

### DIFF
--- a/packages/cli/src/commands/capabilities.ts
+++ b/packages/cli/src/commands/capabilities.ts
@@ -34,25 +34,8 @@ export const capabilityIdOrIndexInputArgs = [
 	},
 ]
 
-function joinEnums(enums: string[], width: number): string {
-	let result = ''
-	let lineWidth = 0
-	for (const item of enums) {
-		if (result) {
-			if (lineWidth + item.length + 2 <= width) {
-				result += ', '
-				lineWidth += item.length + 2
-			} else {
-				result += '\n'
-				lineWidth = 0
-			}
-		} else {
-			lineWidth += item.length + 2
-		}
-		result += item
-	}
-	return result
-}
+export const joinEnums = (enums: string[]): string =>
+	enums.length === 0 ? '' : ('\n  - ' + enums.join('\n  - '))
 
 export function attributeType(attr: CapabilityJSONSchema, multilineObjects = true): string {
 	if (attr.type === 'array') {
@@ -80,7 +63,7 @@ export function attributeType(attr: CapabilityJSONSchema, multilineObjects = tru
 		}
 	}
 	if (attr.enum) {
-		return `enum {${joinEnums(attr.enum, 50)}}`
+		return `enum${joinEnums(attr.enum)}`
 	}
 	return attr.type || 'undefined'
 }
@@ -95,7 +78,7 @@ export function buildTableOutput(tableGenerator: TableGenerator, capability: Cap
 		const headers = type === SubItemTypes.ATTRIBUTES
 			? ['Name', 'Type', 'Setter']
 			: ['Name', 'Arguments']
-		const table = tableGenerator.newOutputTable({ head: headers })
+		const table = tableGenerator.newOutputTable({ head: headers, isList: true })
 		for (const name in capability[type]) {
 			if (type === SubItemTypes.ATTRIBUTES) {
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
<!-- Describe your pull request. -->

I noticed the output of enum values in capabilities was a little wonky sometimes. This pull request just presents each value on a separate line. I also set these tables' type to be a list so the headers are separated properly by a line.

Example of old output:

```
Attributes: 
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Name               Type                                                                                                                                                                 Setter               
 booleanAttr        boolean                                                                                                                                                              setBooleanAttr       
 largeEnumAttr      enum {value1, value2                                                                                                                                                 setLargeEnumAttr     
                    really really really, _really_ long enum value, another one, yet another one                                                                                                              
                    This here is one gash-darn long enum value. It seems to just go on and on forever. Will it ever end, someone asked but nobody answered., and even another one here}                       
```

Example of new output:

```
Attributes: 
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Name               Type                                                                                                                                         Setter               
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 booleanAttr        boolean                                                                                                                                      setBooleanAttr       
 largeEnumAttr      enum                                                                                                                                         setLargeEnumAttr     
                      - value1                                                                                                                                                        
                      - value2                                                                                                                                                        
                      - really really really, _really_ long enum value                                                                                                                
                      - another one                                                                                                                                                   
                      - yet another one                                                                                                                                               
                      - This here is one gash-darn long enum value. It seems to just go on and on forever. Will it ever end, someone asked but nobody answered.                       
                      - and even another one here                                                                                                                                     
```

Unit tests will be coming in upcoming pull request after another pull request to move these functions into a util file.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [ ] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
