### PR TITLE
ci: set stale action reason to not_planned

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -2,7 +2,7 @@ name: Close stale issues
 
 on:
   schedule:
-    - cron: "30 1 * * *"
+    - cron: '30 1 * * *'
 
 permissions:
   issues: write
@@ -17,5 +17,6 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          stale-issue-message: "This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days."
-          exempt-issue-labels: "reviewed"
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          exempt-issue-labels: 'reviewed'
+          close-issue-reason: 'not_planned'


### PR DESCRIPTION
<!-- Describe your pull request. -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [ ] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
