### PR TITLE
chore: remove istextorginary from pkg asset list

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,6 @@
 			"lib/**/*.js"
 		],
 		"assets": [
-			"../../node_modules/istextorbinary",
 			"../../node_modules/yarn"
 		],
 		"outputPath": "dist_bin",


### PR DESCRIPTION
<!-- Describe your pull request. -->

I noticed this package is no longer a dependency and therefore including it as a `pkg` asset does nothing. (I think this was something used by yeoman when we used that.)

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
