### PR TITLE
refactor: move organization handling into APIOrganizationCommand class

### DIFF
--- a/.changeset/quick-brooms-develop.md
+++ b/.changeset/quick-brooms-develop.md
@@ -1,0 +1,6 @@
+---
+"@smartthings/cli-lib": patch
+"@smartthings/cli-testlib": patch
+---
+
+refactor handling of headers on initialization

--- a/package-lock.json
+++ b/package-lock.json
@@ -18773,7 +18773,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smartthings/cli-lib": "^1.0.0-beta.10",
-				"@smartthings/core-sdk": "^5.0.0"
+				"@smartthings/core-sdk": "^5.1.0"
 			},
 			"devDependencies": {
 				"@types/jest": "^28.1.5",
@@ -21918,7 +21918,7 @@
 			"version": "file:packages/testlib",
 			"requires": {
 				"@smartthings/cli-lib": "^1.0.0-beta.10",
-				"@smartthings/core-sdk": "^5.0.0",
+				"@smartthings/core-sdk": "^5.1.0",
 				"@types/jest": "^28.1.5",
 				"@types/js-yaml": "^4.0.5",
 				"@types/node": "^16.11.44",

--- a/packages/lib/src/__tests__/api-command.test.ts
+++ b/packages/lib/src/__tests__/api-command.test.ts
@@ -91,28 +91,6 @@ describe('api-command', () => {
 			expect(configUsed?.headers).toContainEntry(['Accept-Language', 'es-US'])
 		})
 
-		it('passes organization flag on to client', async () => {
-			parseSpy.mockResolvedValueOnce({ args: {}, flags: { organization: 'organization-id-from-flag' } } as ParserOutputType)
-			await apiCommand.init()
-
-			expect(stClientSpy).toHaveBeenCalledTimes(1)
-
-			const configUsed = stClientSpy.mock.calls[0][1]
-			expect(configUsed?.headers).toContainEntry(['X-ST-Organization', 'organization-id-from-flag'])
-		})
-
-		it('passes organization config on to client', async () => {
-			const profile: Profile = { organization: 'organization-id-from-config' }
-			loadConfigMock.mockResolvedValueOnce({ profile } as CLIConfig)
-
-			await apiCommand.init()
-
-			expect(stClientSpy).toHaveBeenCalledTimes(1)
-
-			const configUsed = stClientSpy.mock.calls[0][1]
-			expect(configUsed?.headers).toContainEntry(['X-ST-Organization', 'organization-id-from-config'])
-		})
-
 		it('returns oclif config User-Agent and default if undefined', () => {
 			expect(apiCommand.userAgent).toBe('@smartthings/cli')
 
@@ -144,19 +122,6 @@ describe('api-command', () => {
 
 			// sets User-Agent
 			expect(LoginAuthenticator).toBeCalledWith(expect.anything(), expect.anything(), expect.any(String))
-		})
-
-		it('prefers organization flag over config', async () => {
-			const profile: Profile = { organization: 'organization-id-from-config' }
-			loadConfigMock.mockResolvedValueOnce({ profile } as CLIConfig)
-			parseSpy.mockResolvedValueOnce({ args: {}, flags: { organization: 'organization-id-from-flag' } } as ParserOutputType)
-
-			await apiCommand.init()
-
-			expect(stClientSpy).toHaveBeenCalledTimes(1)
-
-			const configUsed = stClientSpy.mock.calls[0][1]
-			expect(configUsed?.headers).toContainEntry(['X-ST-Organization', 'organization-id-from-flag'])
 		})
 
 		describe('warningLogger', () => {

--- a/packages/lib/src/__tests__/api-organization-command.test.ts
+++ b/packages/lib/src/__tests__/api-organization-command.test.ts
@@ -1,0 +1,79 @@
+import { Config, Interfaces } from '@oclif/core'
+
+import * as coreSDK from '@smartthings/core-sdk'
+
+import { APIOrganizationCommand } from '../api-organization-command'
+import { CLIConfig, loadConfig, Profile } from '../cli-config'
+
+
+jest.mock('@smartthings/core-sdk')
+jest.mock('../cli-config')
+jest.mock('../login-authenticator')
+
+describe('APIOrganizationCommand', () => {
+	const stClientSpy = jest.spyOn(coreSDK, 'SmartThingsClient')
+
+	class TestCommand extends APIOrganizationCommand<typeof TestCommand.flags> {
+		async run(): Promise<void> {
+			// eslint-disable-line @typescript-eslint/no-empty-function
+		}
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+		async parse(options?: Interfaces.Input<any>, argv?: string[]): Promise<Interfaces.ParserOutput<any, any>> {
+			return {
+				flags: {},
+				args: {},
+				argv: [],
+				raw: [],
+				metadata: { flags: {} },
+			}
+		}
+	}
+
+	const loadConfigMock = jest.mocked(loadConfig)
+	const parseSpy = jest.spyOn(TestCommand.prototype, 'parse')
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	type ParserOutputType = Interfaces.ParserOutput<any, any>
+
+	let apiCommand: TestCommand
+
+	beforeEach(() => {
+		apiCommand = new TestCommand([], {} as Config)
+		apiCommand.warn = jest.fn()
+	})
+
+	it('passes organization flag on to client', async () => {
+		parseSpy.mockResolvedValueOnce({ args: {}, flags: { organization: 'organization-id-from-flag' } } as ParserOutputType)
+		await apiCommand.init()
+
+		expect(stClientSpy).toHaveBeenCalledTimes(1)
+
+		const configUsed = stClientSpy.mock.calls[0][1]
+		expect(configUsed?.headers).toContainEntry(['X-ST-Organization', 'organization-id-from-flag'])
+	})
+
+	it('passes organization config on to client', async () => {
+		const profile: Profile = { organization: 'organization-id-from-config' }
+		loadConfigMock.mockResolvedValueOnce({ profile } as CLIConfig)
+
+		await apiCommand.init()
+
+		expect(stClientSpy).toHaveBeenCalledTimes(1)
+
+		const configUsed = stClientSpy.mock.calls[0][1]
+		expect(configUsed?.headers).toContainEntry(['X-ST-Organization', 'organization-id-from-config'])
+	})
+
+	it('prefers organization flag over config', async () => {
+		const profile: Profile = { organization: 'organization-id-from-config' }
+		loadConfigMock.mockResolvedValueOnce({ profile } as CLIConfig)
+		parseSpy.mockResolvedValueOnce({ args: {}, flags: { organization: 'organization-id-from-flag' } } as ParserOutputType)
+
+		await apiCommand.init()
+
+		expect(stClientSpy).toHaveBeenCalledTimes(1)
+
+		const configUsed = stClientSpy.mock.calls[0][1]
+		expect(configUsed?.headers).toContainEntry(['X-ST-Organization', 'organization-id-from-flag'])
+	})
+})

--- a/packages/lib/src/api-organization-command.ts
+++ b/packages/lib/src/api-organization-command.ts
@@ -1,6 +1,11 @@
 import { Flags } from '@oclif/core'
+
+import { HttpClientHeaders } from '@smartthings/core-sdk'
+
 import { APICommand } from './api-command'
 
+
+const ORGANIZATION_HEADER = 'X-ST-Organization'
 
 /**
  * Base class for commands that need to use Rest API commands via the
@@ -11,7 +16,22 @@ export abstract class APIOrganizationCommand<T extends typeof APIOrganizationCom
 		...APICommand.flags,
 		organization: Flags.string({
 			char: 'O',
-			description: 'The organization ID to use for this command',
+			description: 'the organization ID to use for this command',
 		}),
+	}
+
+	async initHeaders(): Promise<HttpClientHeaders> {
+		const headers = await super.initHeaders()
+
+		if (this.flags.organization) {
+			headers[ORGANIZATION_HEADER] = this.flags.organization
+		} else {
+			const configOrganization = this.stringConfigValue('organization')
+			if (configOrganization) {
+				headers[ORGANIZATION_HEADER] = configOrganization
+			}
+		}
+
+		return headers
 	}
 }

--- a/packages/testlib/package.json
+++ b/packages/testlib/package.json
@@ -29,7 +29,7 @@
 	},
 	"dependencies": {
 		"@smartthings/cli-lib": "^1.0.0-beta.10",
-		"@smartthings/core-sdk": "^5.0.0"
+		"@smartthings/core-sdk": "^5.1.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.5",


### PR DESCRIPTION
<!-- Describe your pull request. -->

* moved handling of `organization` command line flag and associated configuration option into `APIOrganizationCommand` class
* moved corresponding unit tests
* updated core SDK version in testlib package (was previously updated in lib and cli packages)

See also https://github.com/SmartThingsCommunity/edge-cli-plugin/pull/52 (draft until this pull request is merged and released).

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [ ] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
