### PR TITLE
feat: added userEmail field to schema apps

### DIFF
--- a/.changeset/long-dryers-nail.md
+++ b/.changeset/long-dryers-nail.md
@@ -1,0 +1,6 @@
+---
+"@smartthings/cli": patch
+"@smartthings/cli-lib": patch
+---
+
+Add userEmail field to ST Schema apps

--- a/package-lock.json
+++ b/package-lock.json
@@ -3733,9 +3733,9 @@
 			"link": true
 		},
 		"node_modules/@smartthings/core-sdk": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-5.0.0.tgz",
-			"integrity": "sha512-wY9ZkYKT0hn/aCtu69sTM0JRLJHylRd/j1i4kKcOCvkGdmYMB9wDXIrVE39j61E9hhvPlwXoxHhRsrsK8aFBGQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-5.1.0.tgz",
+			"integrity": "sha512-wJZlJiMfcKO9+VgYqtR7QlWe9TIePUa2UJGIyHU5HJ5+HYTBjx6p2nrpHZz8XxgqbfkbgZtPLEJlltZwJcqung==",
 			"dependencies": {
 				"async-mutex": "^0.3.2",
 				"axios": "^0.21.4",
@@ -3746,7 +3746,7 @@
 				"sshpk": "^1.17.0"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": ">=14"
 			}
 		},
 		"node_modules/@smartthings/plugin-cli-edge": {
@@ -18665,7 +18665,7 @@
 				"@oclif/plugin-not-found": "^2.3.1",
 				"@oclif/plugin-plugins": "^2.1.0",
 				"@smartthings/cli-lib": "^1.0.0-beta.11",
-				"@smartthings/core-sdk": "^5.0.0",
+				"@smartthings/core-sdk": "^5.1.0",
 				"@smartthings/plugin-cli-edge": "^1.14.1",
 				"aws-sdk": "^2.1175.0",
 				"inquirer": "^8.2.4",
@@ -18708,7 +18708,7 @@
 			"dependencies": {
 				"@log4js-node/log4js-api": "^1.0.2",
 				"@oclif/core": "^1.9.9",
-				"@smartthings/core-sdk": "^5.0.0",
+				"@smartthings/core-sdk": "^5.1.0",
 				"@types/eventsource": "^1.1.9",
 				"axios": "^0.21.4",
 				"chalk": "^4.1.2",
@@ -21834,7 +21834,7 @@
 				"@oclif/plugin-plugins": "^2.1.0",
 				"@smartthings/cli-lib": "^1.0.0-beta.11",
 				"@smartthings/cli-testlib": "^1.0.0-beta.6",
-				"@smartthings/core-sdk": "^5.0.0",
+				"@smartthings/core-sdk": "^5.1.0",
 				"@smartthings/plugin-cli-edge": "^1.14.1",
 				"@types/inquirer": "^8.2.1",
 				"@types/jest": "^28.1.5",
@@ -21865,7 +21865,7 @@
 			"requires": {
 				"@log4js-node/log4js-api": "^1.0.2",
 				"@oclif/core": "^1.9.9",
-				"@smartthings/core-sdk": "^5.0.0",
+				"@smartthings/core-sdk": "^5.1.0",
 				"@types/eventsource": "^1.1.9",
 				"@types/express": "^4.17.13",
 				"@types/inquirer": "^8.2.1",
@@ -21937,9 +21937,9 @@
 			}
 		},
 		"@smartthings/core-sdk": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-5.0.0.tgz",
-			"integrity": "sha512-wY9ZkYKT0hn/aCtu69sTM0JRLJHylRd/j1i4kKcOCvkGdmYMB9wDXIrVE39j61E9hhvPlwXoxHhRsrsK8aFBGQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-5.1.0.tgz",
+			"integrity": "sha512-wJZlJiMfcKO9+VgYqtR7QlWe9TIePUa2UJGIyHU5HJ5+HYTBjx6p2nrpHZz8XxgqbfkbgZtPLEJlltZwJcqung==",
 			"requires": {
 				"async-mutex": "^0.3.2",
 				"axios": "^0.21.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -71,7 +71,7 @@
 		"@oclif/plugin-not-found": "^2.3.1",
 		"@oclif/plugin-plugins": "^2.1.0",
 		"@smartthings/cli-lib": "^1.0.0-beta.11",
-		"@smartthings/core-sdk": "^5.0.0",
+		"@smartthings/core-sdk": "^5.1.0",
 		"@smartthings/plugin-cli-edge": "^1.14.1",
 		"aws-sdk": "^2.1175.0",
 		"inquirer": "^8.2.4",

--- a/packages/cli/src/__tests__/commands/schema.test.ts
+++ b/packages/cli/src/__tests__/commands/schema.test.ts
@@ -24,6 +24,7 @@ describe('SchemaCommand', () => {
 					{ prop: 'lambdaArnCN', skipEmpty: true },
 					{ prop: 'lambdaArnEU', skipEmpty: true },
 					{ prop: 'webhookUrl', skipEmpty: true },
+					{ prop: 'userEmail', skipEmpty: true },
 				],
 				primaryKeyName: 'endpointAppId',
 				sortKeyName: 'appName',
@@ -50,23 +51,24 @@ describe('SchemaCommand', () => {
 	})
 
 	it('adds ARN/URL to return values for lambda and webhooks', async () => {
-		const lambda: SchemaApp = {
+		const lambda = {
 			endpointAppId: 'lambdaAppId',
 			hostingType: 'lambda',
 			lambdaArn: 'ARN',
-		}
-		const webhook: SchemaApp = {
+		} as SchemaApp
+		const webhook = {
 			endpointAppId: 'webhookAppId',
 			hostingType: 'webhook',
 			webhookUrl: 'URL',
-		}
+		} as SchemaApp
+
 		listSpy.mockResolvedValueOnce([lambda, webhook])
 
 		await expect(SchemaCommand.run([])).resolves.not.toThrow()
 
 		const listFunction = outputListingMock.mock.calls[0][3] as ListDataFunction<SchemaApp & { 'ARN/URL': string }>
 
-		const expected: SchemaApp & { 'ARN/URL': string }[] = [
+		const expected = [
 			{
 				...lambda,
 				'ARN/URL': 'ARN',
@@ -87,7 +89,7 @@ describe('SchemaCommand', () => {
 
 		const getFunction = outputListingMock.mock.calls[0][4]
 
-		const schemaApp: SchemaApp = { endpointAppId: 'schemaAppId' }
+		const schemaApp = { endpointAppId: 'schemaAppId' } as SchemaApp
 		getSpy.mockResolvedValueOnce(schemaApp)
 
 		await expect(getFunction('schemaAppId')).resolves.toStrictEqual(schemaApp)

--- a/packages/cli/src/__tests__/commands/schema/create.test.ts
+++ b/packages/cli/src/__tests__/commands/schema/create.test.ts
@@ -34,9 +34,9 @@ describe('SchemaAppCreateCommand', () => {
 		}
 		createSpy.mockResolvedValueOnce(schemaCreateResponse)
 
-		const schemaAppRequest: SchemaAppRequest = {
+		const schemaAppRequest = {
 			appName: 'schemaApp',
-		}
+		} as SchemaAppRequest
 
 		const actionFunction = inputAndOutputItemMock.mock.calls[0][2]
 
@@ -53,14 +53,14 @@ describe('SchemaAppCreateCommand', () => {
 		}
 		createSpy.mockResolvedValueOnce(schemaCreateResponse)
 
-		const schemaAppRequest: SchemaAppRequest = {
+		const schemaAppRequest = {
 			appName: 'schemaApp',
 			hostingType: 'lambda',
 			lambdaArn: 'lambdaArn',
 			lambdaArnCN: 'lambdaArnCN',
 			lambdaArnEU: 'lambdaArnEU',
 			lambdaArnAP: 'lambdaArnAP',
-		}
+		} as SchemaAppRequest
 
 		const actionFunction = inputAndOutputItemMock.mock.calls[0][2]
 
@@ -79,9 +79,9 @@ describe('SchemaAppCreateCommand', () => {
 
 		const actionFunction = inputAndOutputItemMock.mock.calls[0][2]
 
-		const schemaAppRequest: SchemaAppRequest = {
+		const schemaAppRequest = {
 			hostingType: 'webhook',
-		}
+		} as SchemaAppRequest
 
 		await expect(actionFunction(undefined, schemaAppRequest)).rejects.toThrow('Authorization is not applicable to WebHook schema connectors')
 		expect(createSpy).not.toBeCalled()
@@ -90,10 +90,10 @@ describe('SchemaAppCreateCommand', () => {
 	it('ignores authorize flag for lambda apps with no ARNs', async () => {
 		await expect(SchemaAppCreateCommand.run(['--authorize'])).resolves.not.toThrow()
 
-		const schemaAppRequest: SchemaAppRequest = {
+		const schemaAppRequest = {
 			appName: 'schemaApp',
 			hostingType: 'lambda',
-		}
+		} as SchemaAppRequest
 
 		const actionFunction = inputAndOutputItemMock.mock.calls[0][2]
 
@@ -107,11 +107,11 @@ describe('SchemaAppCreateCommand', () => {
 		const principal = 'principal'
 		await expect(SchemaAppCreateCommand.run(['--authorize', `--principal=${principal}`])).resolves.not.toThrow()
 
-		const schemaAppRequest: SchemaAppRequest = {
+		const schemaAppRequest = {
 			appName: 'schemaApp',
 			hostingType: 'lambda',
 			lambdaArn: 'lambdaArn',
-		}
+		} as SchemaAppRequest
 
 		const actionFunction = inputAndOutputItemMock.mock.calls[0][2]
 
@@ -124,11 +124,11 @@ describe('SchemaAppCreateCommand', () => {
 		const statementId = 'statementId'
 		await expect(SchemaAppCreateCommand.run(['--authorize', `--statement-id=${statementId}`])).resolves.not.toThrow()
 
-		const schemaAppRequest: SchemaAppRequest = {
+		const schemaAppRequest = {
 			appName: 'schemaApp',
 			hostingType: 'lambda',
 			lambdaArn: 'lambdaArn',
-		}
+		} as SchemaAppRequest
 
 		const actionFunction = inputAndOutputItemMock.mock.calls[0][2]
 

--- a/packages/cli/src/__tests__/commands/schema/regenerate.test.ts
+++ b/packages/cli/src/__tests__/commands/schema/regenerate.test.ts
@@ -1,5 +1,5 @@
 import { outputItem, selectFromList } from '@smartthings/cli-lib'
-import { SchemaEndpoint, SchemaCreateResponse } from '@smartthings/core-sdk'
+import { SchemaEndpoint, SchemaCreateResponse, SchemaApp } from '@smartthings/core-sdk'
 import SchemaAppRegenerateCommand from '../../../commands/schema/regenerate'
 
 
@@ -29,7 +29,7 @@ describe('SchemaAppRegenerateCommand', () => {
 	})
 
 	it('calls correct list endpoint', async () => {
-		const list = [{ appName: 'schemaApp' }]
+		const list = [{ appName: 'schemaApp' } as SchemaApp]
 		listSpy.mockResolvedValueOnce(list)
 
 		await expect(SchemaAppRegenerateCommand.run(['schemaAppId'])).resolves.not.toThrow()

--- a/packages/cli/src/__tests__/commands/schema/update.test.ts
+++ b/packages/cli/src/__tests__/commands/schema/update.test.ts
@@ -12,13 +12,13 @@ describe('SchemaUpdateCommand', () => {
 	const listSpy = jest.spyOn(SchemaEndpoint.prototype, 'list')
 	const logSpy = jest.spyOn(SchemaUpdateCommand.prototype, 'log').mockImplementation()
 
-	const schemaAppRequest: SchemaAppRequest = { appName: 'schemaApp' }
+	const schemaAppRequest = { appName: 'schemaApp' } as SchemaAppRequest
 	const inputItemMock = jest.mocked(inputItem).mockResolvedValue([schemaAppRequest, IOFormat.JSON])
 	const addSchemaPermissionMock = jest.mocked(addSchemaPermission)
 	const selectFromListMock = jest.mocked(selectFromList).mockResolvedValue('schemaAppId')
 
 	it('prompts user to select schema app', async () => {
-		const schemaAppList: SchemaApp[] = [{ appName: 'schemaApp' }]
+		const schemaAppList = [{ appName: 'schemaApp' } as SchemaApp]
 		listSpy.mockResolvedValueOnce(schemaAppList)
 
 		await expect(SchemaUpdateCommand.run(['schemaAppId'])).resolves.not.toThrow()
@@ -63,14 +63,14 @@ describe('SchemaUpdateCommand', () => {
 	})
 
 	it('accepts authorize flag for lambda apps', async () => {
-		const schemaAppRequest: SchemaAppRequest = {
+		const schemaAppRequest = {
 			appName: 'schemaApp',
 			hostingType: 'lambda',
 			lambdaArn: 'lambdaArn',
 			lambdaArnCN: 'lambdaArnCN',
 			lambdaArnEU: 'lambdaArnEU',
 			lambdaArnAP: 'lambdaArnAP',
-		}
+		} as SchemaAppRequest
 
 		inputItemMock.mockResolvedValueOnce([schemaAppRequest, IOFormat.JSON])
 
@@ -84,10 +84,10 @@ describe('SchemaUpdateCommand', () => {
 	})
 
 	it('throws error if authorize flag is used on non-lambda app', async () => {
-		const webhookSchemaRequest: SchemaAppRequest = {
+		const webhookSchemaRequest = {
 			appName: 'webhookApp',
 			hostingType: 'webhook',
-		}
+		} as SchemaAppRequest
 
 		inputItemMock.mockResolvedValueOnce([webhookSchemaRequest, IOFormat.JSON])
 
@@ -96,10 +96,10 @@ describe('SchemaUpdateCommand', () => {
 	})
 
 	it('ignores authorize flag for lambda apps with no ARNs', async () => {
-		const noArnSchemaRequest: SchemaAppRequest = {
+		const noArnSchemaRequest = {
 			appName: 'schemaApp',
 			hostingType: 'lambda',
-		}
+		} as SchemaAppRequest
 
 		inputItemMock.mockResolvedValueOnce([noArnSchemaRequest, IOFormat.JSON])
 

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -31,6 +31,7 @@ export default class SchemaCommand extends APICommand<typeof SchemaCommand.flags
 				{ prop: 'lambdaArnCN', skipEmpty: true },
 				{ prop: 'lambdaArnEU', skipEmpty: true },
 				{ prop: 'webhookUrl', skipEmpty: true },
+				{ prop: 'userEmail', skipEmpty: true },
 			],
 			primaryKeyName: 'endpointAppId',
 			sortKeyName: 'appName',

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -30,7 +30,7 @@
 	"dependencies": {
 		"@log4js-node/log4js-api": "^1.0.2",
 		"@oclif/core": "^1.9.9",
-		"@smartthings/core-sdk": "^5.0.0",
+		"@smartthings/core-sdk": "^5.1.0",
 		"@types/eventsource": "^1.1.9",
 		"axios": "^0.21.4",
 		"chalk": "^4.1.2",


### PR DESCRIPTION
Added user email property to default ST Schema app output table and updated core plugin version

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
