### PR TITLE
build: enforce correct spacing for type annotations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,6 +90,7 @@ module.exports = {
 		'@typescript-eslint/object-curly-spacing': ['error', 'always'],
 		'comma-spacing': 'off',
 		'@typescript-eslint/comma-spacing': ['error'],
+		'@typescript-eslint/type-annotation-spacing': 'error',
 
 		// disallow non-import statements appearing before import statements
 		'import/first': 'error',

--- a/packages/cli/src/commands/deviceprofiles/create.ts
+++ b/packages/cli/src/commands/deviceprofiles/create.ts
@@ -175,7 +175,7 @@ export default class DeviceProfileCreateCommand extends APIOrganizationCommand<t
 	}
 
 	// TODO - update once capability versions are supported
-	protected async capabilityDefined(idStr:string): Promise<boolean> {
+	protected async capabilityDefined(idStr: string): Promise<boolean> {
 		try {
 			const capability = await this.client.capabilities.get(idStr, 1)
 			return !!capability

--- a/packages/lib/src/basic-io.ts
+++ b/packages/lib/src/basic-io.ts
@@ -98,7 +98,7 @@ outputList.flags = buildOutputFormatter.flags
  * specified and the first one to return data is used.
  */
 export async function inputAndOutputItem<I, O>(command: SmartThingsCommandInterface, config: CommonOutputProducer<O>,
-		executeAction: ActionFunction<void, I, O>, ...alternateInputProcessors: InputProcessor<I>[]) : Promise<void> {
+		executeAction: ActionFunction<void, I, O>, ...alternateInputProcessors: InputProcessor<I>[]): Promise<void> {
 	const [itemIn, defaultIOFormat] = await inputItem<I>(command, ...alternateInputProcessors)
 	if (command.flags['dry-run']) {
 		const outputFormatter = buildOutputFormatter(command, defaultIOFormat)


### PR DESCRIPTION
<!-- Describe your pull request. -->

Add lint rule for spacing around type annotations.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [ ] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
