### PR TITLE
refactor: merge two buildTableOutput functions for device profiles

### DIFF
--- a/packages/cli/src/__tests__/lib/commands/deviceprofiles-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/deviceprofiles-util.test.ts
@@ -1,0 +1,234 @@
+import {
+	DeviceProfile,
+	DeviceProfilePreferenceRequest,
+	DeviceProfileStatus,
+	PresentationDeviceConfigEntry,
+} from '@smartthings/core-sdk'
+
+import { summarizedText, Table, TableGenerator } from '@smartthings/cli-lib'
+
+import { buildTableOutput, entryValues } from '../../../lib/commands/deviceprofiles-util'
+import * as deviceprofilesUtil from '../../../lib/commands/deviceprofiles-util'
+
+
+describe('entryValues', () => {
+	it('returns empty string for empty list', () => {
+		expect(entryValues([])).toBe('')
+	})
+
+	it.each`
+		input                                          | result
+		${{ component: 'main', capability: 'cap-id' }} | ${'main/cap-id'}
+		${{ component: '', capability: 'cap-id' }}     | ${'cap-id'}
+	`('converts $input to $result', ({ input, result }) => {
+		expect(entryValues([input])).toBe(result)
+	})
+
+	it('combines items with new-lines', () => {
+		const entries = [
+			{ component: 'main', capability: 'capability-1' },
+			{ component: 'second', capability: 'capability-2' },
+		]
+		expect(entryValues(entries)).toBe('main/capability-1\nsecond/capability-2')
+	})
+})
+
+describe('buildTableOutput', () => {
+	const pushMock = jest.fn()
+	const tableToStringMock = jest.fn().mockReturnValue('table-output')
+	const mockTable = {
+		push: pushMock,
+		toString: tableToStringMock,
+	} as Table
+	const newOutputTableMock = jest.fn().mockReturnValue(mockTable)
+	const buildTableFromListMock = jest.fn().mockReturnValue('table from list')
+	const tableGenerator = {
+		newOutputTable: newOutputTableMock,
+		buildTableFromList: buildTableFromListMock,
+	} as unknown as TableGenerator
+
+	const entryValuesSpy = jest.spyOn(deviceprofilesUtil, 'entryValues')
+
+	const baseDeviceProfile: DeviceProfile = {
+		id: 'device-profile-id',
+		name:'Device Profile',
+		components: [],
+		status: DeviceProfileStatus.PUBLISHED,
+	}
+
+	it('includes basic info', () => {
+		expect(buildTableOutput(tableGenerator, baseDeviceProfile)).toBe(`table-output\n\n${summarizedText}`)
+
+		expect(newOutputTableMock).toHaveBeenCalledTimes(1)
+		expect(newOutputTableMock).toHaveBeenCalledWith()
+		expect(pushMock).toHaveBeenCalledTimes(7)
+		expect(pushMock).toHaveBeenCalledWith(['Name', 'Device Profile'])
+		expect(pushMock).toHaveBeenCalledWith(['Id', 'device-profile-id'])
+		expect(pushMock).toHaveBeenCalledWith(['Device Type', ''])
+		expect(pushMock).toHaveBeenCalledWith(['OCF Device Type', ''])
+		expect(pushMock).toHaveBeenCalledWith(['Manufacturer Name', ''])
+		expect(pushMock).toHaveBeenCalledWith(['Presentation Id', ''])
+		expect(pushMock).toHaveBeenCalledWith(['Status', 'PUBLISHED'])
+		expect(buildTableFromListMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('includes metadata', () => {
+		const deviceProfile = {
+			...baseDeviceProfile,
+			metadata: {
+				deviceType: 'device-type',
+				ocfDeviceType: 'ocf-device-type',
+				mnmn: 'manufacturer-name',
+				vid: 'presentation-id',
+			},
+		}
+
+		expect(buildTableOutput(tableGenerator, deviceProfile)).toBe(`table-output\n\n${summarizedText}`)
+
+		expect(newOutputTableMock).toHaveBeenCalledTimes(1)
+		expect(newOutputTableMock).toHaveBeenCalledWith()
+		expect(pushMock).toHaveBeenCalledTimes(7)
+		expect(pushMock).toHaveBeenCalledWith(['Device Type', 'device-type'])
+		expect(pushMock).toHaveBeenCalledWith(['OCF Device Type', 'ocf-device-type'])
+		expect(pushMock).toHaveBeenCalledWith(['Manufacturer Name', 'manufacturer-name'])
+		expect(pushMock).toHaveBeenCalledWith(['Presentation Id', 'presentation-id'])
+		expect(buildTableFromListMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('includes components with capabilities', () => {
+		const deviceProfile = {
+			...baseDeviceProfile,
+			components: [
+				{ id: 'main', capabilities: [{ id: 'switch', version: 1 }] },
+				{ id: 'second', capabilities: [{ id: 'switch', version: 1 }, { id: 'cap-2', version: 1 }] },
+				{ id: 'third' },
+			],
+		}
+
+		expect(buildTableOutput(tableGenerator, deviceProfile)).toBe(`table-output\n\n${summarizedText}`)
+
+		expect(newOutputTableMock).toHaveBeenCalledTimes(1)
+		expect(newOutputTableMock).toHaveBeenCalledWith()
+		expect(pushMock).toHaveBeenCalledTimes(10)
+		expect(pushMock).toHaveBeenCalledWith(['main component', 'switch'])
+		expect(pushMock).toHaveBeenCalledWith(['second component', 'switch\ncap-2'])
+		expect(pushMock).toHaveBeenCalledWith(['third component', ''])
+		expect(buildTableFromListMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('includes dashboard info when view info requested', () => {
+		const states = [{ component: 'main' } as PresentationDeviceConfigEntry]
+		const actions = [{ component: 'second' } as PresentationDeviceConfigEntry]
+		const deviceProfile = {
+			...baseDeviceProfile,
+			view: { dashboard: { states, actions } },
+		}
+
+		entryValuesSpy
+			.mockReturnValueOnce('state entries')
+			.mockReturnValueOnce('action entries')
+
+		expect(buildTableOutput(tableGenerator, deviceProfile, { includeViewInfo: true }))
+			.toBe(`table-output\n\n${summarizedText}`)
+
+		expect(newOutputTableMock).toHaveBeenCalledTimes(1)
+		expect(newOutputTableMock).toHaveBeenCalledWith()
+		expect(entryValuesSpy).toHaveBeenCalledTimes(2)
+		expect(entryValuesSpy).toHaveBeenCalledWith(states)
+		expect(entryValuesSpy).toHaveBeenCalledWith(actions)
+		expect(pushMock).toHaveBeenCalledTimes(9)
+		expect(pushMock).toHaveBeenCalledWith(['Dashboard states', 'state entries'])
+		expect(pushMock).toHaveBeenCalledWith(['Dashboard actions', 'action entries'])
+		expect(buildTableFromListMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('includes detail view when view info requested', () => {
+		const detailView = [{ component: 'main' } as PresentationDeviceConfigEntry]
+		const deviceProfile = {
+			...baseDeviceProfile,
+			view: { detailView },
+		}
+
+		entryValuesSpy
+			.mockReturnValueOnce('detail view entries')
+
+		expect(buildTableOutput(tableGenerator, deviceProfile, { includeViewInfo: true }))
+			.toBe(`table-output\n\n${summarizedText}`)
+
+		expect(newOutputTableMock).toHaveBeenCalledTimes(1)
+		expect(newOutputTableMock).toHaveBeenCalledWith()
+		expect(entryValuesSpy).toHaveBeenCalledTimes(1)
+		expect(entryValuesSpy).toHaveBeenCalledWith(detailView)
+		expect(pushMock).toHaveBeenCalledTimes(8)
+		expect(pushMock).toHaveBeenCalledWith(['Detail view', 'detail view entries'])
+		expect(buildTableFromListMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('includes automation conditions info when view info requested', () => {
+		const conditions = [{ component: 'main' } as PresentationDeviceConfigEntry]
+		const actions = [{ component: 'second' } as PresentationDeviceConfigEntry]
+		const deviceProfile = {
+			...baseDeviceProfile,
+			view: { automation: { conditions, actions } },
+		}
+
+		entryValuesSpy
+			.mockReturnValueOnce('condition entries')
+			.mockReturnValueOnce('action entries')
+
+		expect(buildTableOutput(tableGenerator, deviceProfile, { includeViewInfo: true }))
+			.toBe(`table-output\n\n${summarizedText}`)
+
+		expect(newOutputTableMock).toHaveBeenCalledTimes(1)
+		expect(newOutputTableMock).toHaveBeenCalledWith()
+		expect(entryValuesSpy).toHaveBeenCalledTimes(2)
+		expect(entryValuesSpy).toHaveBeenCalledWith(conditions)
+		expect(entryValuesSpy).toHaveBeenCalledWith(actions)
+		expect(pushMock).toHaveBeenCalledTimes(9)
+		expect(pushMock).toHaveBeenCalledWith(['Automation conditions', 'condition entries'])
+		expect(pushMock).toHaveBeenCalledWith(['Automation actions', 'action entries'])
+		expect(buildTableFromListMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('includes "No Preferences" message when preferences requested but not included', () => {
+		const deviceProfile = {
+			...baseDeviceProfile,
+		}
+
+		entryValuesSpy
+			.mockReturnValueOnce('state entries')
+			.mockReturnValueOnce('action entries')
+
+		expect(buildTableOutput(tableGenerator, deviceProfile, { includePreferences: true }))
+			.toBe(`Basic Information\ntable-output\n\nNo preferences\n\n${summarizedText}`)
+
+		expect(newOutputTableMock).toHaveBeenCalledTimes(1)
+		expect(newOutputTableMock).toHaveBeenCalledWith()
+		expect(pushMock).toHaveBeenCalledTimes(7)
+		expect(buildTableFromListMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('includes preferences requested', () => {
+		const deviceProfile = {
+			...baseDeviceProfile,
+			preferences: [{ title: 'pref-request' } as DeviceProfilePreferenceRequest],
+		}
+		buildTableFromListMock.mockReturnValueOnce('preferences-table')
+
+		entryValuesSpy
+			.mockReturnValueOnce('state entries')
+			.mockReturnValueOnce('action entries')
+
+		expect(buildTableOutput(tableGenerator, deviceProfile, { includePreferences: true }))
+			.toBe(`Basic Information\ntable-output\n\nDevice Preferences\npreferences-table\n\n${summarizedText}`)
+
+		expect(newOutputTableMock).toHaveBeenCalledTimes(1)
+		expect(newOutputTableMock).toHaveBeenCalledWith()
+		expect(pushMock).toHaveBeenCalledTimes(7)
+		expect(buildTableFromListMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromListMock).toHaveBeenCalledWith(
+			deviceProfile.preferences,
+			expect.arrayContaining(['preferenceId', 'title']),
+		)
+	})
+})

--- a/packages/cli/src/commands/deviceprofiles/create.ts
+++ b/packages/cli/src/commands/deviceprofiles/create.ts
@@ -2,8 +2,7 @@ import { DeviceProfile } from '@smartthings/core-sdk'
 
 import { APIOrganizationCommand, inputAndOutputItem, inputProcessor } from '@smartthings/cli-lib'
 
-import { buildTableOutput } from '../../lib/commands/deviceprofiles-util'
-import { DeviceDefinitionRequest } from '../../lib/commands/deviceprofiles/view-util'
+import { buildTableOutput, DeviceDefinitionRequest } from '../../lib/commands/deviceprofiles-util'
 import { cleanupRequest, createWithDefaultConfig, getInputFromUser } from '../../lib/commands/deviceprofiles/create-util'
 
 

--- a/packages/cli/src/commands/deviceprofiles/update.ts
+++ b/packages/cli/src/commands/deviceprofiles/update.ts
@@ -4,8 +4,12 @@ import { DeviceProfile } from '@smartthings/core-sdk'
 
 import { ActionFunction, APIOrganizationCommand, inputAndOutputItem } from '@smartthings/cli-lib'
 
-import { buildTableOutputWithoutPreferences, chooseDeviceProfile, cleanupDeviceProfileRequest } from '../../lib/commands/deviceprofiles-util'
-import { DeviceDefinitionRequest } from '../../lib/commands/deviceprofiles/view-util'
+import {
+	buildTableOutput,
+	chooseDeviceProfile,
+	cleanupDeviceProfileRequest,
+	DeviceDefinitionRequest,
+} from '../../lib/commands/deviceprofiles-util'
 
 
 export default class DeviceProfileUpdateCommand extends APIOrganizationCommand<typeof DeviceProfileUpdateCommand.flags> {
@@ -32,6 +36,8 @@ export default class DeviceProfileUpdateCommand extends APIOrganizationCommand<t
 
 			return this.client.deviceProfiles.update(id, cleanupDeviceProfileRequest(data))
 		}
-		await inputAndOutputItem(this, { buildTableOutput: data => buildTableOutputWithoutPreferences(this.tableGenerator, data) }, executeUpdate)
+		await inputAndOutputItem(this, {
+			buildTableOutput: data => buildTableOutput(this.tableGenerator, data, { includePreferences: true }),
+		}, executeUpdate)
 	}
 }

--- a/packages/cli/src/commands/deviceprofiles/view.ts
+++ b/packages/cli/src/commands/deviceprofiles/view.ts
@@ -2,7 +2,8 @@ import { DeviceProfile } from '@smartthings/core-sdk'
 
 import { APIOrganizationCommand, ListingOutputConfig, outputListing } from '@smartthings/cli-lib'
 
-import { buildTableOutput, DeviceDefinition, prunePresentationValues } from '../../lib/commands/deviceprofiles/view-util'
+import { buildTableOutput, DeviceDefinition } from '../../lib/commands/deviceprofiles-util'
+import { prunePresentationValues } from '../../lib/commands/deviceprofiles/view-util'
 
 
 export default class DeviceProfilesViewCommand extends APIOrganizationCommand<typeof DeviceProfilesViewCommand.flags> {

--- a/packages/cli/src/commands/deviceprofiles/view/create.ts
+++ b/packages/cli/src/commands/deviceprofiles/view/create.ts
@@ -1,12 +1,10 @@
 import { APIOrganizationCommand, inputAndOutputItem } from '@smartthings/cli-lib'
 
 import { cleanupRequest, createWithDefaultConfig } from '../../../lib/commands/deviceprofiles/create-util'
+import { buildTableOutput, DeviceDefinition, DeviceDefinitionRequest } from '../../../lib/commands/deviceprofiles-util'
 import {
-	buildTableOutput,
 	prunePresentationValues,
 	augmentPresentationValues,
-	DeviceDefinition,
-	DeviceDefinitionRequest,
 } from '../../../lib/commands/deviceprofiles/view-util'
 
 
@@ -78,7 +76,7 @@ export default class DeviceDefCreateCommand extends APIOrganizationCommand<typeo
 			return { ...profileAndConfig.deviceProfile, view: prunePresentationValues(profileAndConfig.deviceConfig) }
 		}
 		await inputAndOutputItem(this,
-			{ buildTableOutput: data => buildTableOutput(this.tableGenerator, data) },
+			{ buildTableOutput: data => buildTableOutput(this.tableGenerator, data, { includeViewInfo: true }) },
 			createDeviceDefinition)
 	}
 }

--- a/packages/cli/src/commands/deviceprofiles/view/update.ts
+++ b/packages/cli/src/commands/deviceprofiles/view/update.ts
@@ -1,11 +1,9 @@
 import { ActionFunction, APIOrganizationCommand, inputAndOutputItem } from '@smartthings/cli-lib'
 
 import { generateDefaultConfig } from '../../../lib/commands/deviceprofiles/create-util'
+import { buildTableOutput, DeviceDefinition, DeviceDefinitionRequest } from '../../../lib/commands/deviceprofiles-util'
 import {
 	augmentPresentationValues,
-	buildTableOutput,
-	DeviceDefinition,
-	DeviceDefinitionRequest,
 	prunePresentationValues,
 } from '../../../lib/commands/deviceprofiles/view-util'
 import { chooseDeviceProfile, cleanupDeviceProfileRequest } from '../../../lib/commands/deviceprofiles-util'
@@ -78,6 +76,8 @@ export default class DeviceProfilesViewUpdateCommand extends APIOrganizationComm
 
 			return { ...profile, presentation: prunePresentationValues(presentation) }
 		}
-		await inputAndOutputItem(this, { buildTableOutput: data => buildTableOutput(this.tableGenerator, data) }, executeUpdate)
+		await inputAndOutputItem(this, {
+			buildTableOutput: data => buildTableOutput(this.tableGenerator, data, { includeViewInfo: true }),
+		}, executeUpdate)
 	}
 }

--- a/packages/cli/src/lib/commands/deviceprofiles/create-util.ts
+++ b/packages/cli/src/lib/commands/deviceprofiles/create-util.ts
@@ -12,7 +12,7 @@ import {
 import { APICommand } from '@smartthings/cli-lib'
 
 import { CapabilityId, chooseCapabilityFiltered } from '../capabilities-util'
-import { DeviceDefinitionRequest } from './view-util'
+import { DeviceDefinitionRequest } from '../deviceprofiles-util'
 
 
 const capabilitiesWithoutPresentations = ['healthCheck', 'execute']

--- a/packages/cli/src/lib/commands/deviceprofiles/view-util.ts
+++ b/packages/cli/src/lib/commands/deviceprofiles/view-util.ts
@@ -1,58 +1,7 @@
-import { DeviceProfile, DeviceProfileRequest, PresentationDeviceConfigEntry } from '@smartthings/core-sdk'
+import { PresentationDeviceConfigEntry } from '@smartthings/core-sdk'
 
-import { TableGenerator } from '@smartthings/cli-lib'
+import { DeviceView } from '../deviceprofiles-util'
 
-import { buildTableOutput as deviceProfileBuildTableOutput } from '../deviceprofiles-util'
-
-
-export interface DeviceView {
-	dashboard?: {
-		states: PresentationDeviceConfigEntry[]
-		actions: PresentationDeviceConfigEntry[]
-	}
-	detailView?: PresentationDeviceConfigEntry[]
-	automation?: {
-		conditions: PresentationDeviceConfigEntry[]
-		actions: PresentationDeviceConfigEntry[]
-	}
-}
-
-export interface DeviceDefinition extends DeviceProfile {
-	view?: DeviceView
-}
-
-export interface DeviceDefinitionRequest extends DeviceProfileRequest {
-	view?: DeviceView
-}
-
-export const entryValues = (entries: PresentationDeviceConfigEntry[]): string =>
-	entries.map(entry => entry.component ? `${entry.component}/${entry.capability}` : `${entry.capability}`).join('\n')
-
-export const buildTableOutput = (tableGenerator: TableGenerator, data: DeviceDefinition): string => {
-	return deviceProfileBuildTableOutput(tableGenerator, data, table => {
-		if (data.view) {
-			if (data.view.dashboard) {
-				if (data.view.dashboard.states) {
-					table.push(['Dashboard states', entryValues(data.view.dashboard.states)])
-				}
-				if (data.view.dashboard.actions) {
-					table.push(['Dashboard actions', entryValues(data.view.dashboard.actions)])
-				}
-			}
-			if (data.view.detailView) {
-				table.push(['Detail view', entryValues(data.view.detailView)])
-			}
-			if (data.view.automation) {
-				if (data.view.automation.conditions) {
-					table.push(['Automation conditions', entryValues(data.view.automation.conditions)])
-				}
-				if (data.view.automation.actions) {
-					table.push(['Automation actions', entryValues(data.view.automation.actions)])
-				}
-			}
-		}
-	})
-}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const prunePresentation = (view: { [key: string]: any }): void => {


### PR DESCRIPTION
<!-- Describe your pull request. -->

* merge two `buildTableOutput` functions for device profiles
* update code that calls them where necessary
* wrote unit tests for merged function

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
