### PR TITLE
refactor: clean up cleanup methods for device profiles

### DIFF
--- a/packages/cli/src/__tests__/lib/commands/deviceprofiles-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/deviceprofiles-util.test.ts
@@ -1,13 +1,30 @@
 import {
 	DeviceProfile,
 	DeviceProfilePreferenceRequest,
+	DeviceProfilesEndpoint,
 	DeviceProfileStatus,
 	PresentationDeviceConfigEntry,
+	SmartThingsClient,
 } from '@smartthings/core-sdk'
 
-import { summarizedText, Table, TableGenerator } from '@smartthings/cli-lib'
+import {
+	APIOrganizationCommand,
+	chooseOptionsDefaults,
+	chooseOptionsWithDefaults,
+	selectFromList,
+	stringTranslateToId,
+	summarizedText,
+	Table,
+	TableGenerator,
+} from '@smartthings/cli-lib'
 
-import { buildTableOutput, entryValues } from '../../../lib/commands/deviceprofiles-util'
+import {
+	buildTableOutput,
+	chooseDeviceProfile,
+	cleanupForCreate,
+	cleanupForUpdate,
+	entryValues,
+} from '../../../lib/commands/deviceprofiles-util'
 import * as deviceprofilesUtil from '../../../lib/commands/deviceprofiles-util'
 
 
@@ -230,5 +247,236 @@ describe('buildTableOutput', () => {
 			deviceProfile.preferences,
 			expect.arrayContaining(['preferenceId', 'title']),
 		)
+	})
+})
+
+describe('chooseDeviceProfile', () => {
+	const profile1 = { id: 'device-profile-1' }
+	const deviceProfiles = [profile1]
+
+	const listMock = jest.fn().mockResolvedValue(deviceProfiles)
+	const listLocalesMock = jest.fn()
+	const deviceProfilesMock = {
+		list: listMock,
+		listLocales: listLocalesMock,
+	} as unknown as DeviceProfilesEndpoint
+	const client = { deviceProfiles: deviceProfilesMock } as SmartThingsClient
+	const command = { client } as APIOrganizationCommand<typeof APIOrganizationCommand.flags>
+
+	const selectFromListMock = jest.mocked(selectFromList).mockResolvedValue('chosen-profile-id')
+	const stringTranslateToIdMock = jest.mocked(stringTranslateToId).mockResolvedValue('translated-profile-id')
+	const chooseOptionsWithDefaultsMock = jest.mocked(chooseOptionsWithDefaults)
+
+	it('uses selectFromList', async () => {
+		expect(await chooseDeviceProfile(command)).toBe('chosen-profile-id')
+
+		expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledTimes(1)
+		expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledWith(undefined)
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(
+			command,
+			expect.objectContaining({
+				itemName: 'device profile',
+				listTableFieldDefinitions: ['name', 'status', 'id'],
+			}),
+			expect.objectContaining({ preselectedId: undefined, listItems: expect.any(Function) }),
+		)
+		expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('includes locales when verbose is requested', async () => {
+		chooseOptionsWithDefaultsMock.mockReturnValueOnce({ ...chooseOptionsDefaults, verbose: true })
+
+		expect(await chooseDeviceProfile(command, undefined, { verbose: true })).toBe('chosen-profile-id')
+
+		expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledTimes(1)
+		expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledWith({ verbose: true })
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(
+			command,
+			expect.objectContaining({
+				itemName: 'device profile',
+				listTableFieldDefinitions: ['name', 'status', 'id', 'locales'],
+			}),
+			expect.objectContaining({ preselectedId: undefined, listItems: expect.any(Function) }),
+		)
+		expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('passes on `deviceProfileFromArg`', async () => {
+		expect(await chooseDeviceProfile(command, 'profile-arg')).toBe('chosen-profile-id')
+
+		expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledTimes(1)
+		expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledWith(undefined)
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(
+			command,
+			expect.objectContaining({ itemName: 'device profile' }),
+			expect.objectContaining({ preselectedId: 'profile-arg', listItems: expect.any(Function) }),
+		)
+		expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('translates id from arg when `allowIndex` specified', async () => {
+		chooseOptionsWithDefaultsMock.mockReturnValueOnce({ ...chooseOptionsDefaults, allowIndex: true })
+
+		expect(await chooseDeviceProfile(command, 'profile-arg', { allowIndex: true })).toBe('chosen-profile-id')
+
+		expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledTimes(1)
+		expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledWith({ allowIndex: true })
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(
+			command,
+			expect.objectContaining({ itemName: 'device profile' }),
+			expect.objectContaining({ preselectedId: 'translated-profile-id', listItems: expect.any(Function) }),
+		)
+		expect(stringTranslateToIdMock).toHaveBeenCalledTimes(1)
+		expect(stringTranslateToIdMock).toHaveBeenCalledWith(
+			expect.objectContaining({ itemName: 'device profile' }),
+			'profile-arg',
+			expect.any(Function),
+		)
+	})
+
+	describe('listItems', () => {
+		it('just uses list normally', async () => {
+			expect(await chooseDeviceProfile(command)).toBe('chosen-profile-id')
+
+			expect(selectFromListMock).toHaveBeenCalledTimes(1)
+
+			const listItems = selectFromListMock.mock.calls[0][2].listItems
+
+			expect(await listItems()).toBe(deviceProfiles)
+
+			expect(listMock).toHaveBeenCalledTimes(1)
+			expect(listMock).toHaveBeenCalledWith()
+			expect(listLocalesMock).toHaveBeenCalledTimes(0)
+		})
+
+		it('sorts and joins locales', async () => {
+			chooseOptionsWithDefaultsMock.mockReturnValueOnce({ ...chooseOptionsDefaults, verbose: true })
+
+			expect(await chooseDeviceProfile(command)).toBe('chosen-profile-id')
+
+			expect(selectFromListMock).toHaveBeenCalledTimes(1)
+
+			const listItems = selectFromListMock.mock.calls[0][2].listItems
+			listLocalesMock.mockResolvedValueOnce([{ tag: 'ko' }, { tag: 'en' }, { tag: 'es' }])
+
+			expect(await listItems()).toStrictEqual([{ ...profile1, locales: 'en, es, ko' }])
+
+			expect(listMock).toHaveBeenCalledTimes(1)
+			expect(listMock).toHaveBeenCalledWith()
+			expect(listLocalesMock).toHaveBeenCalledTimes(1)
+			expect(listLocalesMock).toHaveBeenCalledWith('device-profile-1')
+		})
+
+		it('handles 404 from listLocales', async () => {
+			chooseOptionsWithDefaultsMock.mockReturnValueOnce({ ...chooseOptionsDefaults, verbose: true })
+
+			expect(await chooseDeviceProfile(command)).toBe('chosen-profile-id')
+
+			expect(selectFromListMock).toHaveBeenCalledTimes(1)
+
+			const listItems = selectFromListMock.mock.calls[0][2].listItems
+			listLocalesMock.mockImplementationOnce(() => { throw Error('status code 404') })
+
+			expect(await listItems()).toStrictEqual([{ ...profile1, locales: '' }])
+
+			expect(listMock).toHaveBeenCalledTimes(1)
+			expect(listMock).toHaveBeenCalledWith()
+			expect(listLocalesMock).toHaveBeenCalledTimes(1)
+			expect(listLocalesMock).toHaveBeenCalledWith('device-profile-1')
+		})
+
+		it('rethrows non-404 error', async () => {
+			chooseOptionsWithDefaultsMock.mockReturnValueOnce({ ...chooseOptionsDefaults, verbose: true })
+
+			expect(await chooseDeviceProfile(command)).toBe('chosen-profile-id')
+
+			expect(selectFromListMock).toHaveBeenCalledTimes(1)
+
+			const listItems = selectFromListMock.mock.calls[0][2].listItems
+			listLocalesMock.mockImplementationOnce(() => { throw Error('unexpected') })
+
+			await expect(listItems()).rejects.toThrow('unexpected')
+
+			expect(listMock).toHaveBeenCalledTimes(1)
+			expect(listMock).toHaveBeenCalledWith()
+			expect(listLocalesMock).toHaveBeenCalledTimes(1)
+			expect(listLocalesMock).toHaveBeenCalledWith('device-profile-1')
+		})
+	})
+})
+
+describe('convertToCreateRequest', () => {
+	it('removes appropriate fields', () => {
+		const expectedComponent = { id: 'component-id' }
+		const expectedResult = {
+			name: 'profile name',
+			metadata: { field: 'value' },
+			components: [expectedComponent],
+		}
+		const deviceProfile = {
+			...expectedResult,
+			id: 'old-profile-id',
+			status: DeviceProfileStatus.PUBLISHED,
+			restrictions: 'old restrictions',
+			components: [
+				{ ...expectedComponent, label: 'old label' },
+			],
+		} as DeviceProfile
+		const original = { ...deviceProfile, components: [{ ...deviceProfile.components[0] }] }
+
+		const result = cleanupForCreate(deviceProfile)
+		expect(result).toStrictEqual(expectedResult)
+
+		// Make sure original was left alone
+		expect(result).not.toBe(deviceProfile)
+		expect(deviceProfile).toStrictEqual(original)
+	})
+
+	it('handles non-existent components', () => {
+		const expectedResult = {
+			name: 'profile name',
+			metadata: { field: 'value' },
+			components: undefined,
+		}
+		const deviceProfile = {
+			...expectedResult,
+			id: 'old-profile-id',
+			status: DeviceProfileStatus.PUBLISHED,
+			restrictions: 'old restrictions',
+		} as unknown as DeviceProfile
+
+		expect(cleanupForCreate(deviceProfile)).toStrictEqual(expectedResult)
+	})
+})
+
+describe('convertToUpdateRequest', () => {
+	it('removes appropriate fields', () => {
+		const expectedComponent = { id: 'component-id' }
+		const expectedResult = {
+			metadata: { field: 'value' },
+			components: [expectedComponent],
+		}
+		const deviceProfile = {
+			...expectedResult,
+			id: 'old-profile-id',
+			status: DeviceProfileStatus.PUBLISHED,
+			name: 'old profile name',
+			restrictions: 'old restrictions',
+			components: [
+				{ ...expectedComponent, label: 'old label' },
+			],
+		} as DeviceProfile
+		const original = { ...deviceProfile, components: [{ ...deviceProfile.components[0] }] }
+
+		const result = cleanupForUpdate(deviceProfile)
+		expect(result).toStrictEqual(expectedResult)
+
+		// Make sure original was left alone
+		expect(result).not.toBe(deviceProfile)
+		expect(deviceProfile).toStrictEqual(original)
 	})
 })

--- a/packages/cli/src/commands/deviceprofiles/create.ts
+++ b/packages/cli/src/commands/deviceprofiles/create.ts
@@ -2,12 +2,12 @@ import { DeviceProfile } from '@smartthings/core-sdk'
 
 import { APIOrganizationCommand, inputAndOutputItem, inputProcessor } from '@smartthings/cli-lib'
 
-import { buildTableOutput, DeviceDefinitionRequest } from '../../lib/commands/deviceprofiles-util'
-import { cleanupRequest, createWithDefaultConfig, getInputFromUser } from '../../lib/commands/deviceprofiles/create-util'
+import { buildTableOutput, cleanupForCreate, DeviceDefinitionRequest } from '../../lib/commands/deviceprofiles-util'
+import { createWithDefaultConfig, getInputFromUser } from '../../lib/commands/deviceprofiles/create-util'
 
 
 export default class DeviceProfileCreateCommand extends APIOrganizationCommand<typeof DeviceProfileCreateCommand.flags> {
-	static description = 'Create a new device profile\n' +
+	static description = 'create a new device profile\n' +
 		'Creates a new device profile. If a vid field is not present in the meta\n' +
 		'then a default device presentation will be created for this profile and the\n' +
 		'vid set to reference it.'
@@ -36,7 +36,7 @@ export default class DeviceProfileCreateCommand extends APIOrganizationCommand<t
 				return profileAndConfig.deviceProfile
 			}
 
-			return await this.client.deviceProfiles.create(cleanupRequest(data))
+			return await this.client.deviceProfiles.create(cleanupForCreate(data))
 		}
 		await inputAndOutputItem(this,
 			{ buildTableOutput: data => buildTableOutput(this.tableGenerator, data) },

--- a/packages/cli/src/commands/deviceprofiles/translations.ts
+++ b/packages/cli/src/commands/deviceprofiles/translations.ts
@@ -8,7 +8,7 @@ import { buildTableOutput } from '../../lib/commands/deviceprofiles/translations
 
 
 export default class DeviceProfileTranslationsCommand extends APIOrganizationCommand<typeof DeviceProfileTranslationsCommand.flags> {
-	static description = 'Get list of locales supported by the device profiles'
+	static description = 'get list of locales supported by the device profiles'
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/deviceprofiles/update.ts
+++ b/packages/cli/src/commands/deviceprofiles/update.ts
@@ -7,7 +7,7 @@ import { ActionFunction, APIOrganizationCommand, inputAndOutputItem } from '@sma
 import {
 	buildTableOutput,
 	chooseDeviceProfile,
-	cleanupDeviceProfileRequest,
+	cleanupForUpdate,
 	DeviceDefinitionRequest,
 } from '../../lib/commands/deviceprofiles-util'
 
@@ -34,7 +34,7 @@ export default class DeviceProfileUpdateCommand extends APIOrganizationCommand<t
 				throw new Errors.CLIError('Input contains "view" property. Use deviceprofiles:view:update instead.')
 			}
 
-			return this.client.deviceProfiles.update(id, cleanupDeviceProfileRequest(data))
+			return this.client.deviceProfiles.update(id, cleanupForUpdate(data))
 		}
 		await inputAndOutputItem(this, {
 			buildTableOutput: data => buildTableOutput(this.tableGenerator, data, { includePreferences: true }),

--- a/packages/cli/src/commands/deviceprofiles/view/create.ts
+++ b/packages/cli/src/commands/deviceprofiles/view/create.ts
@@ -1,7 +1,7 @@
 import { APIOrganizationCommand, inputAndOutputItem } from '@smartthings/cli-lib'
 
-import { cleanupRequest, createWithDefaultConfig } from '../../../lib/commands/deviceprofiles/create-util'
-import { buildTableOutput, DeviceDefinition, DeviceDefinitionRequest } from '../../../lib/commands/deviceprofiles-util'
+import { createWithDefaultConfig } from '../../../lib/commands/deviceprofiles/create-util'
+import { buildTableOutput, cleanupForCreate, DeviceDefinition, DeviceDefinitionRequest } from '../../../lib/commands/deviceprofiles-util'
 import {
 	prunePresentationValues,
 	augmentPresentationValues,
@@ -61,7 +61,7 @@ export default class DeviceDefCreateCommand extends APIOrganizationCommand<typeo
 		delete data.view
 
 		// Create the profile
-		const profile = await this.client.deviceProfiles.create(cleanupRequest(data))
+		const profile = await this.client.deviceProfiles.create(cleanupForCreate(data))
 
 		// Return the composite object
 		return { ...profile, view: prunePresentationValues(deviceConfig) }

--- a/packages/cli/src/commands/deviceprofiles/view/update.ts
+++ b/packages/cli/src/commands/deviceprofiles/view/update.ts
@@ -6,7 +6,7 @@ import {
 	augmentPresentationValues,
 	prunePresentationValues,
 } from '../../../lib/commands/deviceprofiles/view-util'
-import { chooseDeviceProfile, cleanupDeviceProfileRequest } from '../../../lib/commands/deviceprofiles-util'
+import { chooseDeviceProfile, cleanupForUpdate } from '../../../lib/commands/deviceprofiles-util'
 
 
 export default class DeviceProfilesViewUpdateCommand extends APIOrganizationCommand<typeof DeviceProfilesViewUpdateCommand.flags> {
@@ -72,7 +72,7 @@ export default class DeviceProfilesViewUpdateCommand extends APIOrganizationComm
 			}
 			profileData.metadata.vid = presentation.presentationId
 			profileData.metadata.mnmn = presentation.manufacturerName
-			const profile = await this.client.deviceProfiles.update(id, cleanupDeviceProfileRequest(profileData))
+			const profile = await this.client.deviceProfiles.update(id, cleanupForUpdate(profileData))
 
 			return { ...profile, presentation: prunePresentationValues(presentation) }
 		}


### PR DESCRIPTION
<!-- Describe your pull request. -->

* refactor device profile cleanup methods
  * rename them
  * combine common code
  * make them return new objects (don't modify incoming objects)
  * include unit tests
* finish unit tests for all of `deviceprofiles-util` module
* a couple of random case-corrections for command descriptions

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
