### PR TITLE
feat: add info for virtual devices in table output

### DIFF
--- a/.changeset/short-guests-fry.md
+++ b/.changeset/short-guests-fry.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+include virtual device info in device output

--- a/package-lock.json
+++ b/package-lock.json
@@ -3733,9 +3733,9 @@
 			"link": true
 		},
 		"node_modules/@smartthings/core-sdk": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-5.1.0.tgz",
-			"integrity": "sha512-wJZlJiMfcKO9+VgYqtR7QlWe9TIePUa2UJGIyHU5HJ5+HYTBjx6p2nrpHZz8XxgqbfkbgZtPLEJlltZwJcqung==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-5.1.1.tgz",
+			"integrity": "sha512-BYSsMoxRyhFvDvLFy2bgix50KkufyDxOFDd1VtBlcWbePHE7tF7RHwnjjXWqEmraDQDb2a4fCCIaWQ5W21CkXw==",
 			"dependencies": {
 				"async-mutex": "^0.3.2",
 				"axios": "^0.21.4",
@@ -18665,7 +18665,7 @@
 				"@oclif/plugin-not-found": "^2.3.1",
 				"@oclif/plugin-plugins": "^2.1.0",
 				"@smartthings/cli-lib": "^1.0.0-beta.12",
-				"@smartthings/core-sdk": "^5.1.0",
+				"@smartthings/core-sdk": "^5.1.1",
 				"@smartthings/plugin-cli-edge": "^1.14.1",
 				"aws-sdk": "^2.1175.0",
 				"inquirer": "^8.2.4",
@@ -18805,7 +18805,7 @@
 			"dependencies": {
 				"@log4js-node/log4js-api": "^1.0.2",
 				"@oclif/core": "1.9.6",
-				"@smartthings/core-sdk": "^5.1.0",
+				"@smartthings/core-sdk": "^5.1.1",
 				"@types/eventsource": "^1.1.9",
 				"axios": "^0.21.4",
 				"chalk": "^4.1.2",
@@ -18967,7 +18967,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smartthings/cli-lib": "^1.0.0-beta.12",
-				"@smartthings/core-sdk": "^5.1.0"
+				"@smartthings/core-sdk": "^5.1.1"
 			},
 			"devDependencies": {
 				"@types/jest": "^28.1.5",
@@ -22028,7 +22028,7 @@
 				"@oclif/plugin-plugins": "^2.1.0",
 				"@smartthings/cli-lib": "^1.0.0-beta.12",
 				"@smartthings/cli-testlib": "^1.0.0-beta.7",
-				"@smartthings/core-sdk": "^5.1.0",
+				"@smartthings/core-sdk": "^5.1.1",
 				"@smartthings/plugin-cli-edge": "^1.14.1",
 				"@types/inquirer": "^8.2.1",
 				"@types/jest": "^28.1.5",
@@ -22140,7 +22140,7 @@
 			"requires": {
 				"@log4js-node/log4js-api": "^1.0.2",
 				"@oclif/core": "1.9.6",
-				"@smartthings/core-sdk": "^5.1.0",
+				"@smartthings/core-sdk": "^5.1.1",
 				"@types/eventsource": "^1.1.9",
 				"@types/express": "^4.17.13",
 				"@types/inquirer": "^8.2.1",
@@ -22272,7 +22272,7 @@
 			"version": "file:packages/testlib",
 			"requires": {
 				"@smartthings/cli-lib": "^1.0.0-beta.12",
-				"@smartthings/core-sdk": "^5.1.0",
+				"@smartthings/core-sdk": "^5.1.1",
 				"@types/jest": "^28.1.5",
 				"@types/js-yaml": "^4.0.5",
 				"@types/node": "^16.11.44",
@@ -22291,9 +22291,9 @@
 			}
 		},
 		"@smartthings/core-sdk": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-5.1.0.tgz",
-			"integrity": "sha512-wJZlJiMfcKO9+VgYqtR7QlWe9TIePUa2UJGIyHU5HJ5+HYTBjx6p2nrpHZz8XxgqbfkbgZtPLEJlltZwJcqung==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-5.1.1.tgz",
+			"integrity": "sha512-BYSsMoxRyhFvDvLFy2bgix50KkufyDxOFDd1VtBlcWbePHE7tF7RHwnjjXWqEmraDQDb2a4fCCIaWQ5W21CkXw==",
 			"requires": {
 				"async-mutex": "^0.3.2",
 				"axios": "^0.21.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -71,7 +71,7 @@
 		"@oclif/plugin-not-found": "^2.3.1",
 		"@oclif/plugin-plugins": "^2.1.0",
 		"@smartthings/cli-lib": "^1.0.0-beta.12",
-		"@smartthings/core-sdk": "^5.1.0",
+		"@smartthings/core-sdk": "^5.1.1",
 		"@smartthings/plugin-cli-edge": "^1.14.1",
 		"aws-sdk": "^2.1175.0",
 		"inquirer": "^8.2.4",

--- a/packages/cli/src/__tests__/lib/commands/devices-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/devices-util.test.ts
@@ -249,6 +249,21 @@ describe('devices-util', () => {
 				['uniqueIdentifier', 'manufacturerName', 'modelName', 'swVersion', 'hwVersion'])
 		})
 
+		it('includes virtual device info', () => {
+			const virtual = { name: 'Virtual Device' }
+			const device = { virtual } as unknown as Device
+			tableToStringMock.mockReturnValueOnce('main table')
+			buildTableFromItemMock.mockReturnValue('virtual device info')
+
+			expect(buildTableOutput(tableGeneratorMock, device))
+				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from virtual)\nvirtual device info\n\n' + summarizedText)
+
+			expect(tablePushMock).toHaveBeenCalledTimes(9)
+			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+			expect(buildTableFromItemMock).toHaveBeenCalledWith(virtual,
+				['name', { prop: 'hubId', skipEmpty: true }, { prop: 'driverId', skipEmpty: true }])
+		})
+
 		it.todo('adds multiple components')
 		it.todo('joins multiple component capabilities with newlines')
 		it.todo('joins multiple children with newlines')

--- a/packages/cli/src/lib/commands/devices-util.ts
+++ b/packages/cli/src/lib/commands/devices-util.ts
@@ -70,6 +70,10 @@ export const buildTableOutput = (tableGenerator: TableGenerator, device: Device 
 		infoFrom = 'viper'
 		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.viper,
 			['uniqueIdentifier', 'manufacturerName', 'modelName', 'swVersion', 'hwVersion'])
+	} else if ('virtual' in device) {
+		infoFrom = 'virtual'
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.virtual,
+			['name', { prop: 'hubId', skipEmpty: true }, { prop: 'driverId', skipEmpty: true }])
 	}
 
 	return `Main Info\n${mainInfo}\n\n` +

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -30,7 +30,7 @@
 	"dependencies": {
 		"@log4js-node/log4js-api": "^1.0.2",
 		"@oclif/core": "1.9.6",
-		"@smartthings/core-sdk": "^5.1.0",
+		"@smartthings/core-sdk": "^5.1.1",
 		"@types/eventsource": "^1.1.9",
 		"axios": "^0.21.4",
 		"chalk": "^4.1.2",

--- a/packages/testlib/package.json
+++ b/packages/testlib/package.json
@@ -29,7 +29,7 @@
 	},
 	"dependencies": {
 		"@smartthings/cli-lib": "^1.0.0-beta.12",
-		"@smartthings/core-sdk": "^5.1.0"
+		"@smartthings/core-sdk": "^5.1.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.5",


### PR DESCRIPTION
<!-- Describe your pull request. -->

Include driver and hub id in default output for virtual devices if present.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [ ] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
