### PR TITLE
refactor: refactor view-utils functions to remove ts-ignore

### DIFF
--- a/packages/cli/src/__tests__/lib/commands/deviceprofiles/view-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/deviceprofiles/view-util.test.ts
@@ -1,0 +1,186 @@
+import { PresentationDeviceConfig } from '@smartthings/core-sdk'
+import { augmentPresentation, augmentPresentationEntries, prunePresentation, prunePresentationEntries } from '../../../../lib/commands/deviceprofiles/view-util'
+
+
+const entry1PrunedOnlyMain = {
+	capability: 'capability-id-1',
+	values: [{ key: 'key' }],
+}
+const entry1Pruned = {
+	...entry1PrunedOnlyMain,
+	component: 'main',
+}
+const entry1 = {
+	...entry1Pruned,
+	component: 'main',
+	version: 1,
+}
+const entry2Pruned = {
+	component: 'second',
+	capability: 'capability-id-2',
+}
+const entry2 = {
+	...entry2Pruned,
+	version: 1,
+}
+const entry3Pruned = {
+	component: 'second',
+	capability: 'capability-id-2',
+	version: 2,
+}
+const entry3 = {
+	...entry3Pruned,
+}
+
+const baseView: PresentationDeviceConfig = {
+	manufacturerName: 'deleted',
+	presentationId: 'deleted',
+	type: 'profile',
+	iconUrl: 'icon-url',
+}
+
+describe('prunePresentationEntries', () => {
+	it('returns empty array for empty input', () => {
+		expect(prunePresentationEntries([])).toStrictEqual([])
+	})
+
+	it('prunes main component and version', () => {
+		expect(prunePresentationEntries([entry1])).toStrictEqual([entry1PrunedOnlyMain])
+	})
+
+	it('does not prune component when there is more than just main', () => {
+		expect(prunePresentationEntries([entry1, entry2])).toStrictEqual([entry1Pruned, entry2Pruned])
+	})
+
+	it('removed empty values array', () => {
+		expect(prunePresentationEntries([{ ...entry2, values: [] }])).toStrictEqual([entry2Pruned])
+	})
+})
+
+describe('prunePresentation', () => {
+	it('removes top-level fields', () => {
+		expect(prunePresentation(baseView)).toStrictEqual({ iconUrl: 'icon-url' })
+	})
+
+	it('removes null dpInfo', () => {
+		const view = {
+			dpInfo: null,
+			iconUrl: 'icon-url',
+		} as unknown as PresentationDeviceConfig
+		expect(prunePresentation(view)).toStrictEqual({ iconUrl: 'icon-url' })
+	})
+
+	it('removes null iconURL', () => {
+		const view = {
+			dpInfo: [],
+			iconUrl: null,
+		} as unknown as PresentationDeviceConfig
+		expect(prunePresentation(view)).toStrictEqual({ dpInfo: [] })
+	})
+
+	it('prunes dashboard entries', () => {
+		const view: PresentationDeviceConfig = {
+			...baseView,
+			dashboard: {
+				states: [entry1],
+				actions: [entry2],
+			},
+		}
+
+		expect(prunePresentation(view)).toStrictEqual({
+			iconUrl: 'icon-url',
+			dashboard: {
+				states: [entry1PrunedOnlyMain],
+				actions: [entry2Pruned],
+			},
+		})
+	})
+
+	it('prunes detailView entries', () => {
+		const view: PresentationDeviceConfig = {
+			...baseView,
+			detailView: [entry1],
+		}
+
+		expect(prunePresentation(view)).toStrictEqual({
+			iconUrl: 'icon-url',
+			detailView: [entry1PrunedOnlyMain],
+		})
+	})
+
+	it('prunes automation entries', () => {
+		const view: PresentationDeviceConfig = {
+			...baseView,
+			automation: {
+				conditions: [entry1],
+				actions: [entry2],
+			},
+		}
+
+		expect(prunePresentation(view)).toStrictEqual({
+			iconUrl: 'icon-url',
+			automation: {
+				conditions: [entry1PrunedOnlyMain],
+				actions: [entry2Pruned],
+			},
+		})
+	})
+})
+
+describe('augmentPresentationEntries', () => {
+	it('returns empty array for empty array input', () => {
+		expect(augmentPresentationEntries([])).toStrictEqual([])
+	})
+
+	it('uses "main" for component if omitted', () => {
+		expect(augmentPresentationEntries([entry1Pruned, entry2Pruned])).toStrictEqual([entry1, entry2])
+	})
+
+	it('adds version 1 if omitted', () => {
+		expect(augmentPresentationEntries([entry2Pruned, entry3Pruned])).toStrictEqual([entry2, entry3])
+	})
+})
+
+describe('augmentPresentation', () => {
+	it('augments dashboard entries', () => {
+		const view = {
+			dashboard: {
+				states: [entry1PrunedOnlyMain],
+				actions: [entry2Pruned],
+			},
+		}
+
+		expect(augmentPresentation(view)).toStrictEqual({
+			dashboard: {
+				states: [entry1],
+				actions: [entry2],
+			},
+		})
+	})
+
+	it('augments detailView entries', () => {
+		const view = {
+			detailView: [entry1PrunedOnlyMain],
+		}
+
+		expect(augmentPresentation(view)).toStrictEqual({
+			detailView: [entry1],
+		})
+	})
+
+	it('augments automation entries', () => {
+		const view = {
+			automation: {
+				conditions: [entry1PrunedOnlyMain],
+				actions: [entry2Pruned],
+			},
+		}
+
+		expect(augmentPresentation(view)).toStrictEqual({
+			automation: {
+				conditions: [entry1],
+				actions: [entry2],
+			},
+		})
+	})
+})

--- a/packages/cli/src/commands/deviceprofiles/view.ts
+++ b/packages/cli/src/commands/deviceprofiles/view.ts
@@ -3,7 +3,7 @@ import { DeviceProfile } from '@smartthings/core-sdk'
 import { APIOrganizationCommand, ListingOutputConfig, outputListing } from '@smartthings/cli-lib'
 
 import { buildTableOutput, DeviceDefinition } from '../../lib/commands/deviceprofiles-util'
-import { prunePresentationValues } from '../../lib/commands/deviceprofiles/view-util'
+import { prunePresentation } from '../../lib/commands/deviceprofiles/view-util'
 
 
 export default class DeviceProfilesViewCommand extends APIOrganizationCommand<typeof DeviceProfilesViewCommand.flags> {
@@ -33,16 +33,15 @@ export default class DeviceProfilesViewCommand extends APIOrganizationCommand<ty
 			if (profile.metadata) {
 				try {
 					const view = await this.client.presentation.get(profile.metadata.vid, profile.metadata.mnmn)
-					prunePresentationValues(view)
-					return { ...profile, view }
+					return { ...profile, view: prunePresentation(view) }
 				} catch (error) {
 					this.logger.warn(error)
 					return profile
 				}
-			} else {
-				return profile
 			}
+			return profile
 		}
+
 		await outputListing(this, config, this.args.id,
 			() => this.client.deviceProfiles.list(),
 			getDeviceProfileAndConfig)

--- a/packages/cli/src/commands/deviceprofiles/view/create.ts
+++ b/packages/cli/src/commands/deviceprofiles/view/create.ts
@@ -3,8 +3,8 @@ import { APIOrganizationCommand, inputAndOutputItem } from '@smartthings/cli-lib
 import { createWithDefaultConfig } from '../../../lib/commands/deviceprofiles/create-util'
 import { buildTableOutput, cleanupForCreate, DeviceDefinition, DeviceDefinitionRequest } from '../../../lib/commands/deviceprofiles-util'
 import {
-	prunePresentationValues,
-	augmentPresentationValues,
+	prunePresentation,
+	augmentPresentation,
 } from '../../../lib/commands/deviceprofiles/view-util'
 
 
@@ -50,7 +50,7 @@ export default class DeviceDefCreateCommand extends APIOrganizationCommand<typeo
 		}
 
 		// create the device config from the view data
-		const deviceConfig = await this.client.presentation.create(augmentPresentationValues(data.view))
+		const deviceConfig = await this.client.presentation.create(augmentPresentation(data.view))
 
 		// Set the vid and mnmn from the config
 		if (!data.metadata) {
@@ -64,7 +64,7 @@ export default class DeviceDefCreateCommand extends APIOrganizationCommand<typeo
 		const profile = await this.client.deviceProfiles.create(cleanupForCreate(data))
 
 		// Return the composite object
-		return { ...profile, view: prunePresentationValues(deviceConfig) }
+		return { ...profile, view: prunePresentation(deviceConfig) }
 	}
 
 	async run(): Promise<void> {
@@ -73,7 +73,7 @@ export default class DeviceDefCreateCommand extends APIOrganizationCommand<typeo
 				return this.createWithCustomConfig(data)
 			}
 			const profileAndConfig = await createWithDefaultConfig(this.client, data)
-			return { ...profileAndConfig.deviceProfile, view: prunePresentationValues(profileAndConfig.deviceConfig) }
+			return { ...profileAndConfig.deviceProfile, view: prunePresentation(profileAndConfig.deviceConfig) }
 		}
 		await inputAndOutputItem(this,
 			{ buildTableOutput: data => buildTableOutput(this.tableGenerator, data, { includeViewInfo: true }) },

--- a/packages/cli/src/commands/virtualdevices/create.ts
+++ b/packages/cli/src/commands/virtualdevices/create.ts
@@ -75,7 +75,6 @@ export default class VirtualDeviceCreateCommand extends APIOrganizationCommand<t
 	}
 
 	private mergeCreateFlagValues(flags: InferredFlagsType<typeof VirtualDeviceCreateCommand.flags>, data: VirtualDeviceCreateRequest): VirtualDeviceCreateRequest {
-
 		if (flags.name) {
 			data.name = flags.name
 		}

--- a/packages/cli/src/lib/commands/deviceprofiles-util.ts
+++ b/packages/cli/src/lib/commands/deviceprofiles-util.ts
@@ -18,15 +18,17 @@ import {
 } from '@smartthings/cli-lib'
 
 
+export type ViewPresentationDeviceConfigEntry =
+	Omit<PresentationDeviceConfigEntry, 'component'> & Partial<Pick<PresentationDeviceConfigEntry, 'component'>>
 export interface DeviceView {
 	dashboard?: {
-		states: PresentationDeviceConfigEntry[]
-		actions: PresentationDeviceConfigEntry[]
+		states: ViewPresentationDeviceConfigEntry[]
+		actions: ViewPresentationDeviceConfigEntry[]
 	}
-	detailView?: PresentationDeviceConfigEntry[]
+	detailView?: ViewPresentationDeviceConfigEntry[]
 	automation?: {
-		conditions: PresentationDeviceConfigEntry[]
-		actions: PresentationDeviceConfigEntry[]
+		conditions: ViewPresentationDeviceConfigEntry[]
+		actions: ViewPresentationDeviceConfigEntry[]
 	}
 }
 
@@ -38,7 +40,7 @@ export interface DeviceDefinitionRequest extends DeviceProfileRequest {
 	view?: DeviceView
 }
 
-export const entryValues = (entries: PresentationDeviceConfigEntry[]): string =>
+export const entryValues = (entries: ViewPresentationDeviceConfigEntry[]): string =>
 	entries.map(entry => entry.component ? `${entry.component}/${entry.capability}` : `${entry.capability}`).join('\n')
 
 export interface TableOutputOptions {

--- a/packages/cli/src/lib/commands/deviceprofiles/view-util.ts
+++ b/packages/cli/src/lib/commands/deviceprofiles/view-util.ts
@@ -1,72 +1,88 @@
-import { PresentationDeviceConfigEntry } from '@smartthings/core-sdk'
+import { PresentationDeviceConfig, PresentationDeviceConfigCreate, PresentationDeviceConfigEntry } from '@smartthings/core-sdk'
 
-import { DeviceView } from '../deviceprofiles-util'
+import { DeviceView, ViewPresentationDeviceConfigEntry } from '../deviceprofiles-util'
 
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const prunePresentation = (view: { [key: string]: any }): void => {
-	delete view.manufacturerName
-	delete view.presentationId
-	delete view.type
-	if (view.dpInfo === null) {
-		delete view.dpInfo
+export const prunePresentationEntries = (entries: PresentationDeviceConfigEntry[]): ViewPresentationDeviceConfigEntry[] => {
+	const mcd = entries.find(it => it.component !== 'main')
+	return entries.map(entry => {
+		const viewEntry: ViewPresentationDeviceConfigEntry = { ...entry }
+		if (entry.version === 1) {
+			delete viewEntry.version
+		}
+		if (entry.values && entry.values.length === 0) {
+			delete viewEntry.values
+		}
+		if (!entry.visibleCondition) {
+			delete viewEntry.visibleCondition
+		}
+		if (!mcd) {
+			delete viewEntry.component
+		}
+		return viewEntry
+	})
+}
+
+/**
+ * Prune the input `PresentationDeviceConfig`, removing components when there is only one named
+ * "main", the version number from a capability reference if it is 1 and empty arrays.
+ */
+export const prunePresentation = (view: PresentationDeviceConfig): DeviceView => {
+	const retVal = { ...view } as DeviceView & Partial<Omit<PresentationDeviceConfig, 'dashboard' | 'detailView' | 'automation'>>
+	delete retVal.manufacturerName
+	delete retVal.presentationId
+	delete retVal.type
+	if (retVal.dpInfo === null) {
+		delete retVal.dpInfo
 	}
 	if (view.iconUrl === null) {
-		delete view.iconUrl
+		delete retVal.iconUrl
 	}
-}
-
-export const prunePresentationEntries = (entries?: PresentationDeviceConfigEntry[]): void => {
-	if (entries) {
-		const mcd = entries.find(it => it.component !== 'main')
-		for (const entry of entries) {
-			if (entry.version === 1) {
-				delete entry.version
-			}
-			if (entry.values && entry.values.length === 0) {
-				delete entry.values
-			}
-			if (!entry.visibleCondition) {
-				delete entry.visibleCondition
-			}
-			if (!mcd) {
-				// TODO: I'm guessing component should be optional in PresentationDeviceConfigEntry
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore
-				delete entry.component
-			}
-		}
+	if (view.dashboard) {
+		const states = prunePresentationEntries(view.dashboard.states)
+		const actions = prunePresentationEntries(view.dashboard.actions)
+		retVal.dashboard = { states, actions }
 	}
-}
-
-export const prunePresentationValues = (view: DeviceView): DeviceView => {
-	prunePresentation(view)
-	prunePresentationEntries(view.dashboard?.states)
-	prunePresentationEntries(view.dashboard?.actions)
-	prunePresentationEntries(view.detailView)
-	prunePresentationEntries(view.automation?.conditions)
-	prunePresentationEntries(view.automation?.actions)
-	return view
-}
-
-export const augmentPresentationEntries = (entries?: PresentationDeviceConfigEntry[]): void => {
-	if (entries) {
-		for (const entry of entries) {
-			if (!entry.version) {
-				entry.version = 1
-			}
-			if (!entry.component) {
-				entry.component = 'main'
-			}
-		}
+	if (view.detailView) {
+		retVal.detailView = prunePresentationEntries(view.detailView)
 	}
+	if (view.automation) {
+		const conditions = prunePresentationEntries(view.automation.conditions)
+		const actions = prunePresentationEntries(view.automation.actions)
+		retVal.automation = { conditions, actions }
+	}
+	return retVal
 }
 
-export const augmentPresentationValues = (view: DeviceView): DeviceView => {
-	augmentPresentationEntries(view.dashboard?.states)
-	augmentPresentationEntries(view.dashboard?.actions)
-	augmentPresentationEntries(view.detailView)
-	augmentPresentationEntries(view.automation?.conditions)
-	augmentPresentationEntries(view.automation?.actions)
-	return view
+export const augmentPresentationEntries = (entries: ViewPresentationDeviceConfigEntry[]): PresentationDeviceConfigEntry[] => {
+	return entries.map(entry => {
+		return {
+			...entry,
+			version: entry.version ?? 1,
+			component: entry.component ?? 'main',
+		} as PresentationDeviceConfigEntry
+	})
+}
+
+/**
+ * Update the `DeviceView` to be a `PresentationDeviceConfigCreate` by ensuring all entries
+ * reference a component (by filling in "main" if not present) and all capabilities have a version
+ * (using 1 if none present).
+ */
+export const augmentPresentation = (view: DeviceView): PresentationDeviceConfigCreate => {
+	const retVal = { ...view } as PresentationDeviceConfigCreate
+	if (view.dashboard) {
+		const states = augmentPresentationEntries(view.dashboard.states)
+		const actions = augmentPresentationEntries(view.dashboard.actions)
+		retVal.dashboard = { states, actions }
+	}
+	if (view.detailView) {
+		retVal.detailView = augmentPresentationEntries(view.detailView)
+	}
+	if (view.automation) {
+		const conditions = augmentPresentationEntries(view.automation.conditions)
+		const actions = augmentPresentationEntries(view.automation.actions)
+		retVal.automation = { conditions, actions }
+	}
+	return retVal
 }


### PR DESCRIPTION
<!-- Describe your pull request. -->

* Refactored methods in `view-util.ts` so they don't need `ts-ignore`. Mostly this meant changing their return types and arguments to be a little more explicit.
* The methods in view-utils.ts now return new objects without modifying the originals. (This isn't super important here but it's a good habit.)
* Wrote tests for `view-utils.ts`.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
