### PR TITLE
refactor: use chooseDevices more places

### DIFF
--- a/packages/cli/src/__tests__/commands/devices/commands.test.ts
+++ b/packages/cli/src/__tests__/commands/devices/commands.test.ts
@@ -1,8 +1,11 @@
-import { CapabilitiesEndpoint, Capability, Command, Device, DevicesEndpoint } from '@smartthings/core-sdk'
-import DeviceCommandsCommand from '../../../commands/devices/commands'
-import { selectFromList, StdinInputProcessor } from '@smartthings/cli-lib'
-import inquirer from 'inquirer'
 import { ExitError } from '@oclif/core/lib/errors'
+import inquirer from 'inquirer'
+
+import { CapabilitiesEndpoint, Capability, Command, Device, DevicesEndpoint } from '@smartthings/core-sdk'
+
+import { chooseDevice, StdinInputProcessor } from '@smartthings/cli-lib'
+
+import DeviceCommandsCommand from '../../../commands/devices/commands'
 
 
 // restore inputItem implementation for testing this command
@@ -11,7 +14,7 @@ jest.mock('@smartthings/cli-lib', () => {
 
 	return {
 		...originalLib,
-		selectFromList: jest.fn(),
+		chooseDevice: jest.fn(),
 	}
 })
 
@@ -43,7 +46,7 @@ describe('DeviceCommandsCommand', () => {
 	jest.spyOn(DeviceCommandsCommand.prototype, 'log').mockImplementation()
 	jest.spyOn(StdinInputProcessor.prototype, 'hasInput').mockReturnValue(false)
 
-	const selectFromListMock = jest.mocked(selectFromList).mockResolvedValue('deviceId')
+	const chooseDeviceMock = jest.mocked(chooseDevice).mockResolvedValue('deviceId')
 
 	it('only executes commands once', async () => {
 		const commandString = 'switch:on()'
@@ -58,18 +61,7 @@ describe('DeviceCommandsCommand', () => {
 
 		await expect(DeviceCommandsCommand.run(['deviceId', commandString])).resolves.not.toThrow()
 
-		expect(selectFromListMock).toBeCalledWith(
-			expect.any(DeviceCommandsCommand),
-			expect.objectContaining({
-				primaryKeyName: 'deviceId',
-				sortKeyName: 'label',
-				listTableFieldDefinitions: ['label', 'name', 'type', 'deviceId'],
-			}),
-			expect.objectContaining({
-				preselectedId: 'deviceId',
-				listItems: expect.any(Function),
-			}),
-		)
+		expect(chooseDeviceMock).toBeCalledWith(expect.any(DeviceCommandsCommand), 'deviceId')
 	})
 
 	describe('command parsing', () => {

--- a/packages/cli/src/__tests__/commands/virtualdevices/delete.test.ts
+++ b/packages/cli/src/__tests__/commands/virtualdevices/delete.test.ts
@@ -1,41 +1,24 @@
-import { selectFromList } from '@smartthings/cli-lib'
 import { DeviceIntegrationType, DevicesEndpoint } from '@smartthings/core-sdk'
+
+import { chooseDevice } from '@smartthings/cli-lib'
+
 import VirtualDeviceDeleteCommand from '../../../commands/virtualdevices/delete'
 
 
 describe('VirtualDeviceDeleteCommand', () => {
 	const deleteDevicesSpy = jest.spyOn(DevicesEndpoint.prototype, 'delete').mockImplementation()
-	const listDevicesSpy = jest.spyOn(DevicesEndpoint.prototype, 'list').mockImplementation()
 	const logSpy = jest.spyOn(VirtualDeviceDeleteCommand.prototype, 'log').mockImplementation()
 
-	const selectFromListMock = jest.mocked(selectFromList).mockResolvedValue('deviceId')
+	const chooseDeviceMock = jest.mocked(chooseDevice).mockResolvedValue('deviceId')
 
 	it('prompts user to select device', async () => {
 		await expect(VirtualDeviceDeleteCommand.run(['deviceId'])).resolves.not.toThrow()
 
-		expect(selectFromListMock).toBeCalledWith(
+		expect(chooseDeviceMock).toBeCalledWith(
 			expect.any(VirtualDeviceDeleteCommand),
-			expect.objectContaining({
-				primaryKeyName: 'deviceId',
-				sortKeyName: 'name',
-
-			}),
-			expect.objectContaining({
-				preselectedId: 'deviceId',
-				listItems: expect.any(Function),
-				promptMessage: 'Select device to delete.',
-			}),
+			'deviceId',
+			expect.objectContaining({ deviceListOptions: { type: DeviceIntegrationType.VIRTUAL } }),
 		)
-	})
-
-	it('calls correct list endpoint', async () => {
-		await expect(VirtualDeviceDeleteCommand.run(['deviceId'])).resolves.not.toThrow()
-
-		const listFunction = selectFromListMock.mock.calls[0][2].listItems
-		await listFunction()
-
-		expect(listDevicesSpy).toBeCalledTimes(1)
-		expect(listDevicesSpy).toBeCalledWith({ type: DeviceIntegrationType.VIRTUAL })
 	})
 
 	it('deletes the device and logs success', async () => {

--- a/packages/cli/src/__tests__/commands/virtualdevices/events.test.ts
+++ b/packages/cli/src/__tests__/commands/virtualdevices/events.test.ts
@@ -1,8 +1,4 @@
 import {
-	inputAndOutputItem,
-	selectFromList,
-} from '@smartthings/cli-lib'
-import {
 	Capability,
 	CapabilitiesEndpoint,
 	Component,
@@ -10,7 +6,14 @@ import {
 	DeviceEvent,
 	DevicesEndpoint,
 	VirtualDevicesEndpoint,
+	DeviceIntegrationType,
 } from '@smartthings/core-sdk'
+
+import {
+	chooseDevice,
+	inputAndOutputItem,
+} from '@smartthings/cli-lib'
+
 import VirtualDeviceEventsCommand from '../../../commands/virtualdevices/events'
 import {
 	CapabilityAttributeItem,
@@ -25,7 +28,7 @@ import {
 jest.mock('../../../lib/commands/virtualdevices-util')
 
 describe('VirtualDeviceEventsCommand', () => {
-	const mockSelectFromList = jest.mocked(selectFromList)
+	const mockChooseDevice = jest.mocked(chooseDevice)
 
 	const mockInputAndOutputItem = jest.mocked(inputAndOutputItem)
 	const createEventsSpy = jest.spyOn(VirtualDevicesEndpoint.prototype, 'createEvents').mockImplementation()
@@ -46,7 +49,7 @@ describe('VirtualDeviceEventsCommand', () => {
 			await actionFunction(undefined, createRequest)
 		})
 
-		mockSelectFromList.mockResolvedValueOnce('device-id')
+		mockChooseDevice.mockResolvedValueOnce('device-id')
 
 		await expect(VirtualDeviceEventsCommand.run(['device-id'])).resolves.not.toThrow()
 
@@ -57,16 +60,11 @@ describe('VirtualDeviceEventsCommand', () => {
 			expect.anything(),
 		)
 
-		expect(mockSelectFromList).toHaveBeenCalledTimes(1)
-		expect(mockSelectFromList).toBeCalledWith(
+		expect(mockChooseDevice).toHaveBeenCalledTimes(1)
+		expect(mockChooseDevice).toBeCalledWith(
 			expect.any(VirtualDeviceEventsCommand),
-			expect.objectContaining({
-				primaryKeyName: 'deviceId',
-				sortKeyName: 'label',
-			}),
-			expect.objectContaining({
-				preselectedId: 'device-id',
-			}),
+			'device-id',
+			{ deviceListOptions: { type: DeviceIntegrationType.VIRTUAL } },
 		)
 		expect(createEventsSpy).toHaveBeenCalledTimes(1)
 		expect(createEventsSpy).toBeCalledWith('device-id', createRequest)
@@ -87,7 +85,7 @@ describe('VirtualDeviceEventsCommand', () => {
 			await actionFunction(undefined, data)
 		})
 
-		mockSelectFromList.mockResolvedValueOnce('device-id')
+		mockChooseDevice.mockResolvedValueOnce('device-id')
 		const capability = {
 			attributes: {
 				switch: {
@@ -124,7 +122,7 @@ describe('VirtualDeviceEventsCommand', () => {
 			await actionFunction(undefined, data)
 		})
 
-		mockSelectFromList.mockResolvedValueOnce('device-id')
+		mockChooseDevice.mockResolvedValueOnce('device-id')
 		const capability = {
 			attributes: {
 				level: {
@@ -162,7 +160,7 @@ describe('VirtualDeviceEventsCommand', () => {
 			await actionFunction(undefined, data)
 		})
 
-		mockSelectFromList.mockResolvedValueOnce('device-id')
+		mockChooseDevice.mockResolvedValueOnce('device-id')
 		const capability = {
 			attributes: {
 				temperature: {
@@ -207,7 +205,7 @@ describe('VirtualDeviceEventsCommand', () => {
 
 		getDeviceSpy.mockResolvedValueOnce({} as Device)
 		getCapabilitySpy.mockResolvedValueOnce({} as Capability)
-		mockSelectFromList.mockResolvedValueOnce('device-id')
+		mockChooseDevice.mockResolvedValueOnce('device-id')
 		mockChooseComponent.mockResolvedValueOnce({ id: 'main' } as Component)
 		mockChooseCapability.mockResolvedValueOnce({ id: 'temperatureMeasurement' })
 		mockChooseAttribute.mockResolvedValueOnce(({

--- a/packages/cli/src/commands/devices/commands.ts
+++ b/packages/cli/src/commands/devices/commands.ts
@@ -2,7 +2,7 @@ import inquirer from 'inquirer'
 
 import { Command, Component, CapabilityReference, Device } from '@smartthings/core-sdk'
 
-import { APICommand, commandLineInputProcessor, inputItem, inputProcessor, isIndexArgument, selectFromList } from '@smartthings/cli-lib'
+import { APICommand, chooseDevice, commandLineInputProcessor, inputItem, inputProcessor, isIndexArgument } from '@smartthings/cli-lib'
 
 import { attributeType } from '../../lib/commands/capabilities-util'
 
@@ -247,7 +247,6 @@ $ smartthings devices:commands 00000000-0000-0000-0000-000000000000 'switchLevel
 				const cap = component.capabilities.find(it => it.id === cmd.capability)
 				if (cap) {
 					cmd = await this.getCommandFromUser(cap, cmd)
-
 				} else {
 					throw new Error(`Capability '${cmd.capability}' of component '${cmd.component}' not found`)
 				}
@@ -257,16 +256,7 @@ $ smartthings devices:commands 00000000-0000-0000-0000-000000000000 'switchLevel
 	}
 
 	async run(): Promise<void> {
-		const config = {
-			primaryKeyName: 'deviceId',
-			sortKeyName: 'label',
-			listTableFieldDefinitions: ['label', 'name', 'type', 'deviceId'],
-		}
-
-		const deviceId = await selectFromList(this, config, {
-			preselectedId: this.args.id,
-			listItems: () => this.client.devices.list(),
-		})
+		const deviceId = await chooseDevice(this, this.args.id)
 
 		const [commands] = await inputItem<Command[]>(this, commandLineInputProcessor(this),
 			inputProcessor(() => true, () => this.getInputFromUser(deviceId)))

--- a/packages/cli/src/commands/virtualdevices/delete.ts
+++ b/packages/cli/src/commands/virtualdevices/delete.ts
@@ -1,4 +1,4 @@
-import { APICommand, selectFromList } from '@smartthings/cli-lib'
+import { APICommand, chooseDevice } from '@smartthings/cli-lib'
 import { DeviceIntegrationType } from '@smartthings/core-sdk'
 
 
@@ -13,14 +13,8 @@ export default class VirtualDeviceDeleteCommand extends APICommand<typeof Virtua
 	}]
 
 	async run(): Promise<void> {
-		const config = {
-			primaryKeyName: 'deviceId',
-			sortKeyName: 'name',
-		}
-		const id = await selectFromList(this, config, {
-			preselectedId: this.args.id,
-			listItems: () => this.client.devices.list({ type: DeviceIntegrationType.VIRTUAL }),
-			promptMessage: 'Select device to delete.',
+		const id = await chooseDevice(this, this.args.id, {
+			deviceListOptions: { type: DeviceIntegrationType.VIRTUAL },
 		})
 		await this.client.devices.delete(id)
 		this.log(`Device ${id} deleted.`)

--- a/packages/cli/src/commands/virtualdevices/events.ts
+++ b/packages/cli/src/commands/virtualdevices/events.ts
@@ -1,16 +1,18 @@
 import {
 	DeviceEvent,
 	DeviceIntegrationType,
+	VirtualDeviceEventsResponse,
 } from '@smartthings/core-sdk'
+
 import {
 	APICommand,
+	chooseDevice,
 	inputAndOutputItem,
 	inputProcessor,
-	selectFromList,
 	stringFromUnknown,
 	TableGenerator,
 } from '@smartthings/cli-lib'
-import { VirtualDeviceEventsResponse } from '@smartthings/core-sdk/dist/endpoint/virtualdevices'
+
 import {
 	chooseAttribute,
 	chooseCapability,
@@ -75,16 +77,7 @@ export default class VirtualDeviceEventsCommand extends APICommand<typeof Virtua
 	]
 
 	async run(): Promise<void> {
-		const config = {
-			primaryKeyName: 'deviceId',
-			sortKeyName: 'label',
-			listTableFieldDefinitions: ['label', 'name', 'type', 'deviceId'],
-		}
-
-		const deviceId = await selectFromList(this, config, {
-			preselectedId: this.args.id,
-			listItems: () => this.client.devices.list({ type: DeviceIntegrationType.VIRTUAL }),
-		})
+		const deviceId = await chooseDevice(this, this.args.id, { deviceListOptions: { type: DeviceIntegrationType.VIRTUAL } })
 
 		const createEvents = async (_: void, input: DeviceEvent[]): Promise<EventInputOutput> => {
 			const output = await this.client.virtualDevices.createEvents(deviceId, input)


### PR DESCRIPTION
<!-- Describe your pull request. -->

I found a three places where we weren't using `chooseDevices` to select a device and fixed them.

Also fixed a broken unit test.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [ ] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
