### PR TITLE
refactor: clean up helper functions and types

### DIFF
--- a/.changeset/neat-buses-unite.md
+++ b/.changeset/neat-buses-unite.md
@@ -1,0 +1,12 @@
+---
+"@smartthings/cli-lib": patch
+"@smartthings/cli-testlib": patch
+---
+
+clean-up refactor of command helper functions (functions we use to do most of the work for most of our commands like `selectFromList` and `formatAndWriteItem`)
+
+* made the `Sorting` interface generic, dependent on the type of the object being sorted
+* changed type of `primaryKeyName` and `sortingKeyName` for `Sorting` interface to constrain them to string keys from the object being sorted
+* added `extends object` constraint to objects handled by command helper functions
+* rename `outputListing` to `outputItemOrList` and `outputListingGeneric` to `outputItemOrListGeneric`
+* update/add config types for command helper functions with consistent naming (`InputAndOutputItemConfig` for `inputAndOutputItem`, `FormatAndWriteItemConfig` for `formatAndWriteItem`, etc.)

--- a/packages/cli/src/__tests__/commands/apps.test.ts
+++ b/packages/cli/src/__tests__/commands/apps.test.ts
@@ -1,4 +1,4 @@
-import { outputListing } from '@smartthings/cli-lib'
+import { outputItemOrList } from '@smartthings/cli-lib'
 import { AppResponse, AppClassification, AppsEndpoint, AppType, PagedApp } from '@smartthings/core-sdk'
 import AppsCommand from '../../commands/apps'
 
@@ -7,7 +7,7 @@ describe('AppsCommand', () => {
 	const appId = 'appId'
 	const app = { appId: appId, webhookSmartApp: { targetUrl: 'targetUrl' } } as AppResponse
 	const appList = [{ appId: appId }] as PagedApp[]
-	const mockOutputListing = jest.mocked(outputListing)
+	const mockOutputListing = jest.mocked(outputItemOrList)
 	const getSpy = jest.spyOn(AppsEndpoint.prototype, 'get').mockImplementation()
 	const listSpy = jest.spyOn(AppsEndpoint.prototype, 'list').mockImplementation()
 
@@ -17,10 +17,10 @@ describe('AppsCommand', () => {
 		})
 	})
 
-	it('calls outputListing with correct config', async () => {
+	it('calls outputItemOrList with correct config', async () => {
 		await expect(AppsCommand.run([])).resolves.not.toThrow()
 
-		expect(outputListing).toBeCalledWith(
+		expect(outputItemOrList).toBeCalledWith(
 			expect.any(AppsCommand),
 			expect.objectContaining({
 				primaryKeyName: 'appId',
@@ -39,7 +39,7 @@ describe('AppsCommand', () => {
 		})
 
 		await expect(AppsCommand.run([appId])).resolves.not.toThrow()
-		expect(outputListing).toBeCalledWith(
+		expect(outputItemOrList).toBeCalledWith(
 			expect.anything(),
 			expect.anything(),
 			appId,
@@ -124,7 +124,7 @@ describe('AppsCommand', () => {
 		mockOutputListing.mockResolvedValueOnce(undefined)
 
 		await expect(AppsCommand.run(['--verbose'])).resolves.not.toThrow()
-		expect(outputListing).toBeCalledWith(
+		expect(outputItemOrList).toBeCalledWith(
 			expect.anything(),
 			expect.objectContaining({
 				listTableFieldDefinitions: expect.arrayContaining(['ARN/URL']),

--- a/packages/cli/src/__tests__/commands/devicepreferences/translations.test.ts
+++ b/packages/cli/src/__tests__/commands/devicepreferences/translations.test.ts
@@ -1,4 +1,4 @@
-import { outputListing } from '@smartthings/cli-lib'
+import { outputItemOrList } from '@smartthings/cli-lib'
 import { DevicePreferencesEndpoint } from '@smartthings/core-sdk'
 import DevicePreferencesTranslationsCommand from '../../../commands/devicepreferences/translations'
 import { chooseDevicePreference } from '../../../lib/commands/devicepreferences-util'
@@ -10,7 +10,7 @@ jest.mock('../../../lib/commands/devicepreferences-util')
 
 describe('DevicePreferencesTranslationsCommand', () => {
 	const mockChooseDevicePreference = jest.mocked(chooseDevicePreference)
-	const mockOutputListing = jest.mocked(outputListing)
+	const mockOutputListing = jest.mocked(outputItemOrList)
 	const getTranslationsSpy = jest.spyOn(DevicePreferencesEndpoint.prototype, 'getTranslations').mockImplementation()
 	const listTranslationsSpy = jest.spyOn(DevicePreferencesEndpoint.prototype, 'listTranslations').mockImplementation()
 
@@ -30,7 +30,7 @@ describe('DevicePreferencesTranslationsCommand', () => {
 		)
 	})
 
-	it('calls outputListing with correct config', async () => {
+	it('calls outputItemOrList with correct config', async () => {
 		await expect(DevicePreferencesTranslationsCommand.run([preferenceId, localeTag])).resolves.not.toThrow()
 
 		expect(chooseDevicePreference).toBeCalledWith(

--- a/packages/cli/src/__tests__/commands/deviceprofiles.test.ts
+++ b/packages/cli/src/__tests__/commands/deviceprofiles.test.ts
@@ -1,24 +1,38 @@
-import { outputListing } from '@smartthings/cli-lib'
+import { outputItemOrList } from '@smartthings/cli-lib'
 
 import DeviceProfilesCommand from '../../commands/deviceprofiles'
 
 
 describe('DevicesProfilesCommand', () => {
-	const outputListingMock = jest.mocked(outputListing)
+	const outputItemOrListMock = jest.mocked(outputItemOrList)
 
 	it('uses simple fields by default', async () => {
 		await expect(DeviceProfilesCommand.run([])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
-		expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-			.toEqual(['name', 'status', 'id'])
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(DeviceProfilesCommand),
+			expect.objectContaining({
+				listTableFieldDefinitions: ['name', 'status', 'id'],
+			}),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+		)
 	})
 
 	it('includes organization with all-organizations flag', async () => {
 		await expect(DeviceProfilesCommand.run(['--all-organizations'])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
-		expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-			.toEqual(['name', 'status', 'id', 'organization'])
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(DeviceProfilesCommand),
+			expect.objectContaining({
+				listTableFieldDefinitions: ['name', 'status', 'id', 'organization'],
+			}),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+		)
 	})
 })

--- a/packages/cli/src/__tests__/commands/devices.test.ts
+++ b/packages/cli/src/__tests__/commands/devices.test.ts
@@ -1,7 +1,7 @@
 import { Device, DevicesEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
 
 import {
-	CustomCommonOutputProducer, DefaultTableGenerator, outputListing,
+	CustomCommonOutputProducer, DefaultTableGenerator, outputItemOrList,
 	withLocationsAndRooms, WithNamedRoom,
 } from '@smartthings/cli-lib'
 
@@ -15,48 +15,69 @@ jest.mock('../../lib/commands/devices-util')
 describe('DevicesCommand', () => {
 	const deviceId = 'device-id'
 	const getSpy = jest.spyOn(DevicesEndpoint.prototype, 'get').mockImplementation()
-	const outputListingMock = jest.mocked(outputListing)
+	const outputItemOrListMock = jest.mocked(outputItemOrList)
 
 	it('passes undefined for location id when not specified', async () => {
 		await expect(DevicesCommand.run([])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
-		expect(outputListingMock.mock.calls[0][2]).toBeUndefined()
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock.mock.calls[0][2]).toBeUndefined()
 	})
 
 	it('passes argument as location id', async () => {
 		await expect(DevicesCommand.run(['location-id'])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
-		expect(outputListingMock.mock.calls[0][2]).toBe('location-id')
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock.mock.calls[0][2]).toBe('location-id')
 	})
 
 	it('uses simple fields by default', async () => {
 		await expect(DevicesCommand.run([])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
-		expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-			.toEqual(['label', 'name', 'type', 'deviceId'])
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(DevicesCommand),
+			expect.objectContaining({
+				listTableFieldDefinitions: ['label', 'name', 'type', 'deviceId'],
+			}),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+		)
 	})
 
 	it('includes location and room with verbose flag', async () => {
 		await expect(DevicesCommand.run(['--verbose'])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
-		expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-			.toEqual(['label', 'name', 'type', 'location', 'room', 'deviceId'])
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(DevicesCommand),
+			expect.objectContaining({
+				listTableFieldDefinitions: ['label', 'name', 'type', 'location', 'room', 'deviceId'],
+			}),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+		)
 	})
 
 	it('uses buildTableOutput from devices-util', async () => {
 		await expect(DevicesCommand.run([])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
-		expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-			.toEqual(['label', 'name', 'type', 'deviceId'])
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(DevicesCommand),
+			expect.objectContaining({
+				listTableFieldDefinitions: ['label', 'name', 'type', 'deviceId'],
+			}),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+		)
 
 		const device = { deviceId: 'device-id' } as Device
 		const buildTableOutputMock = jest.mocked(buildTableOutput)
-		const config = outputListingMock.mock.calls[0][1] as CustomCommonOutputProducer<Device>
+		const config = outputItemOrListMock.mock.calls[0][1] as CustomCommonOutputProducer<Device>
 		buildTableOutputMock.mockReturnValueOnce('table output')
 
 		expect(config.buildTableOutput(device)).toBe('table output')
@@ -73,11 +94,18 @@ describe('DevicesCommand', () => {
 		it('uses devices.list without verbose flag', async () => {
 			await expect(DevicesCommand.run([])).resolves.not.toThrow()
 
-			expect(outputListingMock).toHaveBeenCalledTimes(1)
-			expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-				.toEqual(['label', 'name', 'type', 'deviceId'])
+			expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+			expect(outputItemOrListMock).toHaveBeenCalledWith(
+				expect.any(DevicesCommand),
+				expect.objectContaining({
+					listTableFieldDefinitions: ['label', 'name', 'type', 'deviceId'],
+				}),
+				undefined,
+				expect.any(Function),
+				expect.any(Function),
+			)
 
-			const listDevices = outputListingMock.mock.calls[0][3]
+			const listDevices = outputItemOrListMock.mock.calls[0][3]
 
 			expect(await listDevices()).toBe(devices)
 
@@ -89,11 +117,18 @@ describe('DevicesCommand', () => {
 		it('adds health status with health flag', async () => {
 			await expect(DevicesCommand.run(['--health'])).resolves.not.toThrow()
 
-			expect(outputListingMock).toHaveBeenCalledTimes(1)
-			expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-				.toEqual(['label', 'name', 'type', { label: 'Health', prop: 'healthState.state' }, 'deviceId'])
+			expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+			expect(outputItemOrListMock).toHaveBeenCalledWith(
+				expect.any(DevicesCommand),
+				expect.objectContaining({
+					listTableFieldDefinitions: ['label', 'name', 'type', { label: 'Health', prop: 'healthState.state' }, 'deviceId'],
+				}),
+				undefined,
+				expect.any(Function),
+				expect.any(Function),
+			)
 
-			const listDevices = outputListingMock.mock.calls[0][3]
+			const listDevices = outputItemOrListMock.mock.calls[0][3]
 
 			expect(await listDevices()).toBe(devices)
 
@@ -105,11 +140,18 @@ describe('DevicesCommand', () => {
 		it('adds locations with verbose flag', async () => {
 			await expect(DevicesCommand.run(['--verbose'])).resolves.not.toThrow()
 
-			expect(outputListingMock).toHaveBeenCalledTimes(1)
-			expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-				.toEqual(['label', 'name', 'type', 'location', 'room', 'deviceId'])
+			expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+			expect(outputItemOrListMock).toHaveBeenCalledWith(
+				expect.any(DevicesCommand),
+				expect.objectContaining({
+					listTableFieldDefinitions: ['label', 'name', 'type', 'location', 'room', 'deviceId'],
+				}),
+				undefined,
+				expect.any(Function),
+				expect.any(Function),
+			)
 
-			const listDevices = outputListingMock.mock.calls[0][3]
+			const listDevices = outputItemOrListMock.mock.calls[0][3]
 
 			const verboseDevices = [
 				{ deviceId: 'device-id', location: 'location name', room: 'room name' },
@@ -127,11 +169,18 @@ describe('DevicesCommand', () => {
 		it('uses capability flag in devices.list', async () => {
 			await expect(DevicesCommand.run(['--capability', 'cmd-line-capability'])).resolves.not.toThrow()
 
-			expect(outputListingMock).toHaveBeenCalledTimes(1)
-			expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-				.toEqual(['label', 'name', 'type', 'deviceId'])
+			expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+			expect(outputItemOrListMock).toHaveBeenCalledWith(
+				expect.any(DevicesCommand),
+				expect.objectContaining({
+					listTableFieldDefinitions: ['label', 'name', 'type', 'deviceId'],
+				}),
+				undefined,
+				expect.any(Function),
+				expect.any(Function),
+			)
 
-			const listDevices = outputListingMock.mock.calls[0][3]
+			const listDevices = outputItemOrListMock.mock.calls[0][3]
 
 			expect(await listDevices()).toBe(devices)
 
@@ -147,11 +196,18 @@ describe('DevicesCommand', () => {
 				'--capabilities-mode', 'or',
 			])).resolves.not.toThrow()
 
-			expect(outputListingMock).toHaveBeenCalledTimes(1)
-			expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-				.toEqual(['label', 'name', 'type', 'deviceId'])
+			expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+			expect(outputItemOrListMock).toHaveBeenCalledWith(
+				expect.any(DevicesCommand),
+				expect.objectContaining({
+					listTableFieldDefinitions: ['label', 'name', 'type', 'deviceId'],
+				}),
+				undefined,
+				expect.any(Function),
+				expect.any(Function),
+			)
 
-			const listDevices = outputListingMock.mock.calls[0][3]
+			const listDevices = outputItemOrListMock.mock.calls[0][3]
 
 			expect(await listDevices()).toBe(devices)
 
@@ -166,11 +222,18 @@ describe('DevicesCommand', () => {
 		it('uses type flag in devices.list', async () => {
 			await expect(DevicesCommand.run(['--type', 'VIRTUAL'])).resolves.not.toThrow()
 
-			expect(outputListingMock).toHaveBeenCalledTimes(1)
-			expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-				.toEqual(['label', 'name', 'type', 'deviceId'])
+			expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+			expect(outputItemOrListMock).toHaveBeenCalledWith(
+				expect.any(DevicesCommand),
+				expect.objectContaining({
+					listTableFieldDefinitions: ['label', 'name', 'type', 'deviceId'],
+				}),
+				undefined,
+				expect.any(Function),
+				expect.any(Function),
+			)
 
-			const listDevices = outputListingMock.mock.calls[0][3]
+			const listDevices = outputItemOrListMock.mock.calls[0][3]
 
 			expect(await listDevices()).toBe(devices)
 
@@ -186,11 +249,18 @@ describe('DevicesCommand', () => {
 				'--type', 'ZWAVE',
 			])).resolves.not.toThrow()
 
-			expect(outputListingMock).toHaveBeenCalledTimes(1)
-			expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-				.toEqual(['label', 'name', 'type', 'deviceId'])
+			expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+			expect(outputItemOrListMock).toHaveBeenCalledWith(
+				expect.any(DevicesCommand),
+				expect.objectContaining({
+					listTableFieldDefinitions: ['label', 'name', 'type', 'deviceId'],
+				}),
+				undefined,
+				expect.any(Function),
+				expect.any(Function),
+			)
 
-			const listDevices = outputListingMock.mock.calls[0][3]
+			const listDevices = outputItemOrListMock.mock.calls[0][3]
 
 			expect(await listDevices()).toBe(devices)
 
@@ -205,13 +275,20 @@ describe('DevicesCommand', () => {
 	it('uses devices.get to get device', async () => {
 		await expect(DevicesCommand.run([])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
-		expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-			.toEqual(['label', 'name', 'type', 'deviceId'])
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(DevicesCommand),
+			expect.objectContaining({
+				listTableFieldDefinitions: ['label', 'name', 'type', 'deviceId'],
+			}),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+		)
 
 		const device = { deviceId: 'device-id' } as Device
 		const getSpy = jest.spyOn(DevicesEndpoint.prototype, 'get').mockResolvedValue(device)
-		const getDevice = outputListingMock.mock.calls[0][4]
+		const getDevice = outputItemOrListMock.mock.calls[0][4]
 
 		expect(await getDevice('chosen-device-id')).toBe(device)
 
@@ -220,12 +297,12 @@ describe('DevicesCommand', () => {
 	})
 
 	it('uses UUID from the command line', async () => {
-		outputListingMock.mockImplementationOnce(async (_command, _config, _id, _listFunction, getFunction) => {
+		outputItemOrListMock.mockImplementationOnce(async (_command, _config, _id, _listFunction, getFunction) => {
 			await getFunction(deviceId)
 		})
 
 		await expect(DevicesCommand.run([deviceId])).resolves.not.toThrow()
-		expect(outputListing).toBeCalledWith(
+		expect(outputItemOrListMock).toBeCalledWith(
 			expect.anything(),
 			expect.anything(),
 			deviceId,
@@ -236,12 +313,12 @@ describe('DevicesCommand', () => {
 	})
 
 	it('includes attribute values when status flag is set', async () => {
-		outputListingMock.mockImplementationOnce(async (_command, _config, _id, _listFunction, getFunction) => {
+		outputItemOrListMock.mockImplementationOnce(async (_command, _config, _id, _listFunction, getFunction) => {
 			await getFunction(deviceId)
 		})
 
 		await expect(DevicesCommand.run([deviceId, '--status'])).resolves.not.toThrow()
-		expect(outputListing).toBeCalledWith(
+		expect(outputItemOrListMock).toBeCalledWith(
 			expect.anything(),
 			expect.anything(),
 			deviceId,
@@ -254,12 +331,12 @@ describe('DevicesCommand', () => {
 	it('includes health status when health flag is set', async () => {
 		const getHealthSpy = jest.spyOn(DevicesEndpoint.prototype, 'getHealth').mockImplementation()
 
-		outputListingMock.mockImplementationOnce(async (_command, _config, _id, _listFunction, getFunction) => {
+		outputItemOrListMock.mockImplementationOnce(async (_command, _config, _id, _listFunction, getFunction) => {
 			await getFunction(deviceId)
 		})
 
 		await expect(DevicesCommand.run([deviceId, '--health'])).resolves.not.toThrow()
-		expect(outputListing).toBeCalledWith(
+		expect(outputItemOrListMock).toBeCalledWith(
 			expect.anything(),
 			expect.anything(),
 			deviceId,

--- a/packages/cli/src/__tests__/commands/installedapps.test.ts
+++ b/packages/cli/src/__tests__/commands/installedapps.test.ts
@@ -1,4 +1,4 @@
-import { outputListing, withLocations, WithNamedLocation } from '@smartthings/cli-lib'
+import { outputItemOrList, withLocations, WithNamedLocation } from '@smartthings/cli-lib'
 import { InstalledApp, InstalledAppsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
 import InstalledAppsCommand from '../../commands/installedapps'
 import { listTableFieldDefinitions, tableFieldDefinitions } from '../../lib/commands/installedapps-util'
@@ -15,13 +15,13 @@ describe('InstalledAppsCommand', () => {
 	const getSpy = jest.spyOn(InstalledAppsEndpoint.prototype, 'get').mockImplementation()
 	const listSpy = jest.spyOn(InstalledAppsEndpoint.prototype, 'list').mockImplementation()
 
-	const outputListingMock = jest.mocked(outputListing)
+	const outputItemOrListMock = jest.mocked(outputItemOrList)
 	const withLocationsMock = jest.mocked(withLocations)
 
-	it('calls outputListing with correct config', async () => {
+	it('calls outputItemOrList with correct config', async () => {
 		await expect(InstalledAppsCommand.run(['installedAppId'])).resolves.not.toThrow()
 
-		expect(outputListingMock).toBeCalledWith(
+		expect(outputItemOrListMock).toBeCalledWith(
 			expect.any(InstalledAppsCommand),
 			expect.objectContaining({
 				primaryKeyName: 'installedAppId',
@@ -40,7 +40,7 @@ describe('InstalledAppsCommand', () => {
 
 		getSpy.mockResolvedValueOnce(MOCK_INSTALLED_APP)
 
-		const getFunction = outputListingMock.mock.calls[0][4]
+		const getFunction = outputItemOrListMock.mock.calls[0][4]
 
 		await expect(getFunction('installedAppId')).resolves.toStrictEqual(MOCK_INSTALLED_APP)
 		expect(getSpy).toBeCalledWith('installedAppId')
@@ -51,7 +51,7 @@ describe('InstalledAppsCommand', () => {
 
 		listSpy.mockResolvedValueOnce(MOCK_INSTALLED_APP_LIST)
 
-		const listFunction = outputListingMock.mock.calls[0][3]
+		const listFunction = outputItemOrListMock.mock.calls[0][3]
 
 		await expect(listFunction()).resolves.toEqual(MOCK_INSTALLED_APP_LIST)
 		expect(listSpy).toBeCalledWith({ locationId: undefined })
@@ -60,17 +60,17 @@ describe('InstalledAppsCommand', () => {
 	it('accepts location-id flag to filter list', async () => {
 		await expect(InstalledAppsCommand.run(['--location-id=locationId'])).resolves.not.toThrow()
 
-		let listFunction = outputListingMock.mock.calls[0][3]
+		let listFunction = outputItemOrListMock.mock.calls[0][3]
 		await listFunction()
 
 		expect(listSpy).toBeCalledWith({ locationId: ['locationId'] })
 
-		outputListingMock.mockClear()
+		outputItemOrListMock.mockClear()
 		listSpy.mockClear()
 
 		await expect(InstalledAppsCommand.run(['-l=locationId', '-l=anotherLocationId'])).resolves.not.toThrow()
 
-		listFunction = outputListingMock.mock.calls[0][3]
+		listFunction = outputItemOrListMock.mock.calls[0][3]
 		await listFunction()
 
 		expect(listSpy).toBeCalledWith({ locationId: ['locationId', 'anotherLocationId'] })
@@ -79,7 +79,7 @@ describe('InstalledAppsCommand', () => {
 	it('includes location name when verbose flag is used', async () => {
 		await expect(InstalledAppsCommand.run(['--verbose'])).resolves.not.toThrow()
 
-		expect(outputListingMock).toBeCalledWith(
+		expect(outputItemOrListMock).toBeCalledWith(
 			expect.anything(),
 			expect.objectContaining({
 				listTableFieldDefinitions: expect.arrayContaining(['location']),
@@ -93,7 +93,7 @@ describe('InstalledAppsCommand', () => {
 
 		listSpy.mockResolvedValueOnce(MOCK_INSTALLED_APP_LIST)
 		withLocationsMock.mockResolvedValueOnce(expectedList)
-		const listFunction = outputListingMock.mock.calls[0][3]
+		const listFunction = outputItemOrListMock.mock.calls[0][3]
 
 		await expect(listFunction()).resolves.toStrictEqual(expectedList)
 

--- a/packages/cli/src/__tests__/commands/locations.test.ts
+++ b/packages/cli/src/__tests__/commands/locations.test.ts
@@ -1,4 +1,4 @@
-import { outputListing, selectFromList } from '@smartthings/cli-lib'
+import { outputItemOrList, selectFromList } from '@smartthings/cli-lib'
 import LocationsCommand, { chooseLocation } from '../../commands/locations'
 import { LocationsEndpoint } from '@smartthings/core-sdk'
 import { Config } from '@oclif/core'
@@ -34,16 +34,16 @@ describe('chooseLocation', () => {
 })
 
 describe('LocationsCommand', () => {
-	const mockListing = jest.mocked(outputListing)
+	const mockListing = jest.mocked(outputItemOrList)
 
-	it('calls outputListing when no id is provided', async () => {
+	it('calls outputItemOrList when no id is provided', async () => {
 		await expect(LocationsCommand.run([])).resolves.not.toThrow()
 
 		expect(mockListing).toBeCalledTimes(1)
 		expect(mockListing.mock.calls[0][2]).toBeUndefined()
 	})
 
-	it('calls outputListing when id is provided', async () => {
+	it('calls outputItemOrList when id is provided', async () => {
 		const locationId = 'locationId'
 		await expect(LocationsCommand.run([locationId])).resolves.not.toThrow()
 

--- a/packages/cli/src/__tests__/commands/locations/rooms.test.ts
+++ b/packages/cli/src/__tests__/commands/locations/rooms.test.ts
@@ -1,4 +1,4 @@
-import { outputListing, withLocations } from '@smartthings/cli-lib'
+import { outputItemOrList, withLocations } from '@smartthings/cli-lib'
 import { RoomsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
 import RoomsCommand from '../../../commands/locations/rooms'
 import { getRoomsByLocation, RoomWithLocation } from '../../../lib/commands/locations/rooms-util'
@@ -9,7 +9,7 @@ jest.mock('../../../lib/commands/locations/rooms-util')
 describe('RoomsCommand', () => {
 	const roomId = 'roomId'
 	const locationId = 'locationId'
-	const mockOutputListing = jest.mocked(outputListing)
+	const mockOutputListing = jest.mocked(outputItemOrList)
 	const mockGetRoomsByLocation = jest.mocked(getRoomsByLocation)
 	const getSpy = jest.spyOn(RoomsEndpoint.prototype, 'get').mockImplementation()
 	const mockWithLocations = jest.mocked(withLocations)
@@ -18,7 +18,7 @@ describe('RoomsCommand', () => {
 		mockGetRoomsByLocation.mockResolvedValue([])
 	})
 
-	it('calls outputListing correctly', async () => {
+	it('calls outputItemOrList correctly', async () => {
 		await expect(RoomsCommand.run([])).resolves.not.toThrow()
 
 		expect(mockOutputListing).toBeCalledWith(

--- a/packages/cli/src/__tests__/commands/organizations.test.ts
+++ b/packages/cli/src/__tests__/commands/organizations.test.ts
@@ -1,4 +1,4 @@
-import { outputListing } from '@smartthings/cli-lib'
+import { outputItemOrList } from '@smartthings/cli-lib'
 import OrganizationsCommand from '../../commands/organizations'
 import { OrganizationsEndpoint } from '@smartthings/core-sdk'
 
@@ -7,16 +7,16 @@ const listSpy = jest.spyOn(OrganizationsEndpoint.prototype, 'list').mockImplemen
 
 describe('OrganizationsCommand', () => {
 	const organizationId = 'organizationId'
-	const mockOutputListing = jest.mocked(outputListing)
+	const mockOutputListing = jest.mocked(outputItemOrList)
 
-	it('calls outputListing when no id is provided', async () => {
+	it('calls outputItemOrList when no id is provided', async () => {
 		await expect(OrganizationsCommand.run([])).resolves.not.toThrow()
 
 		expect(mockOutputListing).toBeCalledTimes(1)
 		expect(mockOutputListing.mock.calls[0][2]).toBeUndefined()
 	})
 
-	it('calls outputListing when id is provided', async () => {
+	it('calls outputItemOrList when id is provided', async () => {
 		await expect(OrganizationsCommand.run([organizationId])).resolves.not.toThrow()
 
 		expect(mockOutputListing).toBeCalledTimes(1)

--- a/packages/cli/src/__tests__/commands/rules.test.ts
+++ b/packages/cli/src/__tests__/commands/rules.test.ts
@@ -1,4 +1,4 @@
-import { outputListing } from '@smartthings/cli-lib'
+import { outputItemOrList } from '@smartthings/cli-lib'
 import { SmartThingsClient } from '@smartthings/core-sdk'
 
 import RulesCommand from '../../commands/rules'
@@ -8,41 +8,41 @@ import { getRulesByLocation, getRuleWithLocation, RuleWithLocation } from '../..
 jest.mock('../../lib/commands/rules-util')
 
 describe('RulesCommand', () => {
-	const outputListingMock = jest.mocked(outputListing)
+	const outputItemOrListMock = jest.mocked(outputItemOrList)
 	const ruleWithLocation = { id: 'rule-id' } as RuleWithLocation
 	const rulesList = [ruleWithLocation]
 	const getRulesByLocationMock = jest.mocked(getRulesByLocation).mockResolvedValue(rulesList)
 	const getRuleWithLocationMock = jest.mocked(getRuleWithLocation).mockResolvedValue(ruleWithLocation)
 
-	it('calls outputListing to list rules', async () => {
+	it('calls outputItemOrList to list rules', async () => {
 		await expect(RulesCommand.run([])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
-		expect(outputListingMock).toHaveBeenCalledWith(expect.any(RulesCommand),
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(expect.any(RulesCommand),
 			expect.objectContaining({
 				primaryKeyName: 'id',
 				listTableFieldDefinitions: expect.arrayContaining(['name', 'id', 'locationId', 'locationName']),
 			}),
 			undefined, expect.any(Function), expect.any(Function))
 
-		const listFunction = outputListingMock.mock.calls[0][3]
+		const listFunction = outputItemOrListMock.mock.calls[0][3]
 		expect(await listFunction()).toBe(rulesList)
 		expect(getRulesByLocationMock).toHaveBeenCalledTimes(1)
 		expect(getRulesByLocationMock).toHaveBeenCalledWith(expect.any(SmartThingsClient), undefined)
 	})
 
-	it('calls outputListing to get a rule', async () => {
+	it('calls outputItemOrList to get a rule', async () => {
 		await expect(RulesCommand.run(['cmd-line-rule-id'])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
-		expect(outputListingMock).toHaveBeenCalledWith(expect.any(RulesCommand),
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(expect.any(RulesCommand),
 			expect.objectContaining({
 				primaryKeyName: 'id',
 				listTableFieldDefinitions: expect.arrayContaining(['name', 'id', 'locationId', 'locationName']),
 			}),
 			'cmd-line-rule-id', expect.any(Function), expect.any(Function))
 
-		const getFunction = outputListingMock.mock.calls[0][4]
+		const getFunction = outputItemOrListMock.mock.calls[0][4]
 		expect(await getFunction('rule-id')).toBe(ruleWithLocation)
 		expect(getRuleWithLocationMock).toHaveBeenCalledTimes(1)
 		expect(getRuleWithLocationMock).toHaveBeenCalledWith(expect.any(SmartThingsClient),
@@ -52,21 +52,21 @@ describe('RulesCommand', () => {
 	it('passes location id from command line', async () => {
 		await expect(RulesCommand.run(['--location-id', 'cmd-line-location-id'])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
-		expect(outputListingMock).toHaveBeenCalledWith(expect.any(RulesCommand),
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(expect.any(RulesCommand),
 			expect.objectContaining({
 				primaryKeyName: 'id',
 				listTableFieldDefinitions: expect.arrayContaining(['name', 'id', 'locationId', 'locationName']),
 			}),
 			undefined, expect.any(Function), expect.any(Function))
 
-		const listFunction = outputListingMock.mock.calls[0][3]
+		const listFunction = outputItemOrListMock.mock.calls[0][3]
 		expect(await listFunction()).toBe(rulesList)
 		expect(getRulesByLocationMock).toHaveBeenCalledTimes(1)
 		expect(getRulesByLocationMock).toHaveBeenCalledWith(expect.any(SmartThingsClient),
 			'cmd-line-location-id')
 
-		const getFunction = outputListingMock.mock.calls[0][4]
+		const getFunction = outputItemOrListMock.mock.calls[0][4]
 		expect(await getFunction('rule-id')).toBe(ruleWithLocation)
 		expect(getRuleWithLocationMock).toHaveBeenCalledTimes(1)
 		expect(getRuleWithLocationMock).toHaveBeenCalledWith(expect.any(SmartThingsClient),

--- a/packages/cli/src/__tests__/commands/scenes.test.ts
+++ b/packages/cli/src/__tests__/commands/scenes.test.ts
@@ -1,4 +1,4 @@
-import { outputListing } from '@smartthings/cli-lib'
+import { outputItemOrList } from '@smartthings/cli-lib'
 import ScenesCommand from '../../commands/scenes'
 import { ScenesEndpoint } from '@smartthings/core-sdk'
 
@@ -6,16 +6,16 @@ import { ScenesEndpoint } from '@smartthings/core-sdk'
 const listSpy = jest.spyOn(ScenesEndpoint.prototype, 'list').mockImplementation()
 
 describe('ScenesCommand', () => {
-	const mockListing = jest.mocked(outputListing)
+	const mockListing = jest.mocked(outputItemOrList)
 
-	it('calls outputListing when no id is provided', async () => {
+	it('calls outputItemOrList when no id is provided', async () => {
 		await expect(ScenesCommand.run([])).resolves.not.toThrow()
 
 		expect(mockListing).toBeCalledTimes(1)
 		expect(mockListing.mock.calls[0][2]).toBeUndefined()
 	})
 
-	it('calls outputListing when id is provided', async () => {
+	it('calls outputItemOrList when id is provided', async () => {
 		const sceneId = 'sceneId'
 		await expect(ScenesCommand.run([sceneId])).resolves.not.toThrow()
 

--- a/packages/cli/src/__tests__/commands/schema.test.ts
+++ b/packages/cli/src/__tests__/commands/schema.test.ts
@@ -1,4 +1,4 @@
-import { ListDataFunction, outputListing } from '@smartthings/cli-lib'
+import { ListDataFunction, outputItemOrList } from '@smartthings/cli-lib'
 import { SchemaApp, SchemaEndpoint } from '@smartthings/core-sdk'
 import SchemaCommand from '../../commands/schema'
 
@@ -7,12 +7,12 @@ describe('SchemaCommand', () => {
 	const getSpy = jest.spyOn(SchemaEndpoint.prototype, 'get').mockImplementation()
 	const listSpy = jest.spyOn(SchemaEndpoint.prototype, 'list').mockImplementation()
 
-	const outputListingMock = jest.mocked(outputListing)
+	const outputItemOrListMock = jest.mocked(outputItemOrList)
 
-	it('calls outputListing with correct config', async () => {
+	it('calls outputItemOrList with correct config', async () => {
 		await expect(SchemaCommand.run(['schemaAppId'])).resolves.not.toThrow()
 
-		expect(outputListingMock).toBeCalledWith(
+		expect(outputItemOrListMock).toBeCalledWith(
 			expect.any(SchemaCommand),
 			expect.objectContaining({
 				tableFieldDefinitions: [
@@ -39,7 +39,7 @@ describe('SchemaCommand', () => {
 	it('includes URLs and ARNs in output when verbose flag is used', async () => {
 		await expect(SchemaCommand.run(['schemaAppId', '--verbose'])).resolves.not.toThrow()
 
-		expect(outputListingMock).toBeCalledWith(
+		expect(outputItemOrListMock).toBeCalledWith(
 			expect.anything(),
 			expect.objectContaining({
 				listTableFieldDefinitions: expect.arrayContaining(['ARN/URL']),
@@ -67,7 +67,7 @@ describe('SchemaCommand', () => {
 		await expect(SchemaCommand.run([])).resolves.not.toThrow()
 
 		/* eslint-disable @typescript-eslint/naming-convention */
-		const listFunction = outputListingMock.mock.calls[0][3] as ListDataFunction<SchemaApp & { 'ARN/URL': string }>
+		const listFunction = outputItemOrListMock.mock.calls[0][3] as ListDataFunction<SchemaApp & { 'ARN/URL': string }>
 
 		const expected = [
 			{
@@ -89,7 +89,7 @@ describe('SchemaCommand', () => {
 	it('calls correct get endpoint', async () => {
 		await expect(SchemaCommand.run([])).resolves.not.toThrow()
 
-		const getFunction = outputListingMock.mock.calls[0][4]
+		const getFunction = outputItemOrListMock.mock.calls[0][4]
 
 		const schemaApp = { endpointAppId: 'schemaAppId' } as SchemaApp
 		getSpy.mockResolvedValueOnce(schemaApp)

--- a/packages/cli/src/__tests__/commands/virtualdevices.test.ts
+++ b/packages/cli/src/__tests__/commands/virtualdevices.test.ts
@@ -1,43 +1,57 @@
-import { outputListing } from '@smartthings/cli-lib'
+import { outputItemOrList } from '@smartthings/cli-lib'
 import VirtualDevicesCommand from '../../commands/virtualdevices'
 import { Device, DeviceIntegrationType, DevicesEndpoint } from '@smartthings/core-sdk'
 
 
 describe('VirtualDevicesCommand', () => {
-	const outputListingMock = jest.mocked(outputListing)
+	const outputItemOrListMock = jest.mocked(outputItemOrList)
 	const devices = [{ deviceId: 'device-id' }] as Device[]
 	const listSpy = jest.spyOn(DevicesEndpoint.prototype, 'list').mockResolvedValue(devices)
 
 	test('virtual devices in all locations', async() => {
 		await expect(VirtualDevicesCommand.run([])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
 	})
 
 	test('use simple fields by default', async() => {
 		await expect(VirtualDevicesCommand.run([])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
-		expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-			.toEqual(['label', 'deviceId'])
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(VirtualDevicesCommand),
+			expect.objectContaining({
+				listTableFieldDefinitions: ['label', 'deviceId'],
+			}),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+		)
 	})
 
 	test('include location and room with verbose flag', async() => {
 		await expect(VirtualDevicesCommand.run(['--verbose'])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
-		expect(outputListingMock.mock.calls[0][1].listTableFieldDefinitions)
-			.toEqual(['label', 'deviceId', 'location', 'room'])
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(VirtualDevicesCommand),
+			expect.objectContaining({
+				listTableFieldDefinitions: ['label', 'deviceId', 'location', 'room'],
+			}),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+		)
 	})
 
 	test('virtual devices uses location id in list', async() => {
-		outputListingMock.mockImplementationOnce(async (_command, _config, _idOrIndex, listFunction) => {
+		outputItemOrListMock.mockImplementationOnce(async (_command, _config, _idOrIndex, listFunction) => {
 			await listFunction()
 		})
 
 		await expect(VirtualDevicesCommand.run(['--location-id=location-id'])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
 		expect(listSpy).toHaveBeenCalledTimes(1)
 		expect(listSpy).toHaveBeenCalledWith(expect.objectContaining({
 			type: DeviceIntegrationType.VIRTUAL,
@@ -46,13 +60,13 @@ describe('VirtualDevicesCommand', () => {
 	})
 
 	test('virtual devices uses installed app id in list', async() => {
-		outputListingMock.mockImplementationOnce(async (_command, _config, _idOrIndex, listFunction) => {
+		outputItemOrListMock.mockImplementationOnce(async (_command, _config, _idOrIndex, listFunction) => {
 			await listFunction()
 		})
 
 		await expect(VirtualDevicesCommand.run(['--installed-app-id=installed-app-id'])).resolves.not.toThrow()
 
-		expect(outputListingMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
 		expect(listSpy).toHaveBeenCalledTimes(1)
 		expect(listSpy).toHaveBeenCalledWith(expect.objectContaining({
 			type: DeviceIntegrationType.VIRTUAL,

--- a/packages/cli/src/__tests__/lib/commands/capabilities-utils.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/capabilities-utils.test.ts
@@ -402,7 +402,7 @@ describe('convertToId', () => {
 describe('getIdFromUser', () => {
 	const promptMock = jest.mocked(inquirer.prompt)
 	const convertToIdSpy = jest.spyOn(capabilitiesUtil, 'convertToId')
-	const fieldInfo = {} as Sorting
+	const fieldInfo = {} as Sorting<CapabilitySummaryWithNamespace>
 
 	it('returns selected id with version', async () => {
 		promptMock.mockResolvedValueOnce({ idOrIndex: 'chosen-id' })
@@ -483,7 +483,7 @@ describe('translateToId', () => {
 	it('returns input if it is a `CapabilityId`', async () => {
 		const capabilityId = { id: 'capability-id', version: 1 }
 
-		expect(await translateToId('', capabilityId, listMock)).toBe(capabilityId)
+		expect(await translateToId('id', capabilityId, listMock)).toBe(capabilityId)
 
 		expect(listMock).toHaveBeenCalledTimes(0)
 	})
@@ -491,21 +491,21 @@ describe('translateToId', () => {
 	it('returns `CapabilityId` with input as id if input is a string', async () => {
 		const capabilityId = { id: 'capability-id', version: 1 }
 
-		expect(await translateToId('', capabilityId.id, listMock)).toStrictEqual(capabilityId)
+		expect(await translateToId('id', capabilityId.id, listMock)).toStrictEqual(capabilityId)
 
 		expect(listMock).toHaveBeenCalledTimes(0)
 	})
 
 	it('returns id when input is integer (index) and is in range', async () => {
-		expect(await translateToId('', '2', listMock)).toStrictEqual({ id: 'button', version: 1 })
+		expect(await translateToId('id', '2', listMock)).toStrictEqual({ id: 'button', version: 1 })
 
 		expect(listMock).toHaveBeenCalledTimes(1)
 		expect(listMock).toHaveBeenCalledWith()
 	})
 
 	it('throws error is out-of-range integer', async () => {
-		await expect(translateToId('', '0', listMock)).rejects.toThrow()
-		await expect(translateToId('', '7', listMock)).rejects.toThrow()
+		await expect(translateToId('id', '0', listMock)).rejects.toThrow()
+		await expect(translateToId('id', '7', listMock)).rejects.toThrow()
 	})
 })
 

--- a/packages/cli/src/commands/apps/oauth.ts
+++ b/packages/cli/src/commands/apps/oauth.ts
@@ -1,4 +1,4 @@
-import { APICommand, outputItem, outputListing } from '@smartthings/cli-lib'
+import { APICommand, outputItem, outputItemOrList } from '@smartthings/cli-lib'
 import { chooseApp, oauthTableFieldDefinitions } from '../../lib/commands/apps-util'
 
 
@@ -7,7 +7,7 @@ export default class AppOauthCommand extends APICommand<typeof AppOauthCommand.f
 
 	static flags = {
 		...APICommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 	}
 
 	static args = [{

--- a/packages/cli/src/commands/apps/register.ts
+++ b/packages/cli/src/commands/apps/register.ts
@@ -1,5 +1,5 @@
 import { AppType, PagedApp } from '@smartthings/core-sdk'
-import { APICommand, selectFromList, SelectingConfig } from '@smartthings/cli-lib'
+import { APICommand, selectFromList, SelectFromListConfig } from '@smartthings/cli-lib'
 import { inspect } from 'util'
 
 
@@ -14,7 +14,7 @@ export default class AppRegisterCommand extends APICommand<typeof AppRegisterCom
 	}]
 
 	async run(): Promise<void> {
-		const config: SelectingConfig<PagedApp> = {
+		const config: SelectFromListConfig<PagedApp> = {
 			primaryKeyName: 'appId',
 			sortKeyName: 'displayName',
 			listTableFieldDefinitions: ['displayName', 'appType', 'appId'],

--- a/packages/cli/src/commands/apps/settings.ts
+++ b/packages/cli/src/commands/apps/settings.ts
@@ -1,4 +1,4 @@
-import { APICommand, CustomCommonOutputProducer, outputItem, outputListing } from '@smartthings/cli-lib'
+import { APICommand, CustomCommonOutputProducer, outputItem, outputItemOrList } from '@smartthings/cli-lib'
 import { AppSettingsResponse } from '@smartthings/core-sdk'
 import { buildTableOutput, chooseApp } from '../../lib/commands/apps-util'
 
@@ -8,7 +8,7 @@ export default class AppSettingsCommand extends APICommand<typeof AppSettingsCom
 
 	static flags = {
 		...APICommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 	}
 
 	static args = [{

--- a/packages/cli/src/commands/capabilities.ts
+++ b/packages/cli/src/commands/capabilities.ts
@@ -1,9 +1,9 @@
 import { Flags } from '@oclif/core'
 
-import { Capability } from '@smartthings/core-sdk'
+import { Capability, CapabilitySummary } from '@smartthings/core-sdk'
 
 import {
-	APIOrganizationCommand, outputGenericListing, allOrganizationsFlags, forAllOrganizations,
+	APIOrganizationCommand, outputItemOrListGeneric, allOrganizationsFlags, forAllOrganizations, OutputItemOrListConfig,
 } from '@smartthings/cli-lib'
 
 import {
@@ -17,7 +17,7 @@ export default class CapabilitiesCommand extends APIOrganizationCommand<typeof C
 
 	static flags = {
 		...APIOrganizationCommand.flags,
-		...outputGenericListing.flags,
+		...outputItemOrListGeneric.flags,
 		...allOrganizationsFlags,
 		namespace: Flags.string({
 			char: 'n',
@@ -33,13 +33,14 @@ export default class CapabilitiesCommand extends APIOrganizationCommand<typeof C
 
 	async run(): Promise<void> {
 		const idOrIndex = this.args.version ? { id: this.args.id, version: this.args.version } : this.args.id
-		const config = {
+		const sortKeyName = 'id'
+		const config: OutputItemOrListConfig<Capability, CapabilitySummary> = {
 			primaryKeyName: 'id',
-			sortKeyName: 'id',
+			sortKeyName,
 			listTableFieldDefinitions: ['id', 'version', 'status'],
 			buildTableOutput: (data: Capability) => buildTableOutput(this.tableGenerator, data),
 		}
-		await outputGenericListing(this, config, idOrIndex,
+		await outputItemOrListGeneric(this, config, idOrIndex,
 			() => {
 				if (this.flags.standard) {
 					return getStandard(this.client)
@@ -50,6 +51,6 @@ export default class CapabilitiesCommand extends APIOrganizationCommand<typeof C
 				return getCustomByNamespace(this.client, this.flags.namespace)
 			},
 			(id: CapabilityId) => this.client.capabilities.get(id.id, id.version),
-			(idOrIndex, listFunction) => translateToId(config.sortKeyName, idOrIndex, listFunction))
+			(idOrIndex, listFunction) => translateToId(sortKeyName, idOrIndex, listFunction))
 	}
 }

--- a/packages/cli/src/commands/capabilities/namespaces.ts
+++ b/packages/cli/src/commands/capabilities/namespaces.ts
@@ -1,4 +1,6 @@
-import { APIOrganizationCommand, outputList } from '@smartthings/cli-lib'
+import { CapabilityNamespace } from '@smartthings/core-sdk'
+
+import { APIOrganizationCommand, outputList, OutputListConfig } from '@smartthings/cli-lib'
 
 
 export default class CapabilitiesListNamespacesCommand extends APIOrganizationCommand<typeof CapabilitiesListNamespacesCommand.flags> {
@@ -10,12 +12,11 @@ export default class CapabilitiesListNamespacesCommand extends APIOrganizationCo
 	}
 
 	async run(): Promise<void> {
-		const config = {
+		const config: OutputListConfig<CapabilityNamespace> = {
 			sortKeyName: 'name',
 			primaryKeyName: 'name',
 			listTableFieldDefinitions: ['name', 'ownerType', 'ownerId'],
 		}
-		await outputList(this, config,
-			() => this.client.capabilities.listNamespaces())
+		await outputList(this, config, () => this.client.capabilities.listNamespaces())
 	}
 }

--- a/packages/cli/src/commands/capabilities/presentation.ts
+++ b/packages/cli/src/commands/capabilities/presentation.ts
@@ -2,9 +2,9 @@ import { Flags } from '@oclif/core'
 
 import { CapabilityPresentation } from '@smartthings/core-sdk'
 
-import { APIOrganizationCommand, outputGenericListing, summarizedText, TableGenerator } from '@smartthings/cli-lib'
+import { APIOrganizationCommand, OutputItemOrListConfig, outputItemOrListGeneric, summarizedText, TableGenerator } from '@smartthings/cli-lib'
 
-import { CapabilityId, capabilityIdOrIndexInputArgs, getCustomByNamespace, translateToId } from '../../lib/commands/capabilities-util'
+import { CapabilityId, capabilityIdOrIndexInputArgs, CapabilitySummaryWithNamespace, getCustomByNamespace, translateToId } from '../../lib/commands/capabilities-util'
 
 
 export function buildTableOutput(tableGenerator: TableGenerator, presentation: CapabilityPresentation): string {
@@ -72,7 +72,7 @@ export default class PresentationsCommand extends APIOrganizationCommand<typeof 
 
 	static flags = {
 		...APIOrganizationCommand.flags,
-		...outputGenericListing.flags,
+		...outputItemOrListGeneric.flags,
 		namespace: Flags.string({
 			char: 'n',
 			description: 'a specific namespace to query; will use all by default',
@@ -85,15 +85,16 @@ export default class PresentationsCommand extends APIOrganizationCommand<typeof 
 		const idOrIndex = this.args.version
 			? { id: this.args.id, version: this.args.version }
 			: this.args.id
-		const config = {
+		const sortKeyName = 'id'
+		const config: OutputItemOrListConfig<CapabilityPresentation, CapabilitySummaryWithNamespace> = {
 			primaryKeyName: 'id',
-			sortKeyName: 'id',
+			sortKeyName,
 			listTableFieldDefinitions: ['id', 'version', 'status'],
 			buildTableOutput: (data: CapabilityPresentation) => buildTableOutput(this.tableGenerator, data),
 		}
-		await outputGenericListing(this, config, idOrIndex,
+		await outputItemOrListGeneric(this, config, idOrIndex,
 			() => getCustomByNamespace(this.client, this.flags.namespace),
 			(id: CapabilityId) =>  this.client.capabilities.getPresentation(id.id, id.version),
-			(idOrIndex, listFunction) => translateToId(config.sortKeyName, idOrIndex, listFunction))
+			(idOrIndex, listFunction) => translateToId(sortKeyName, idOrIndex, listFunction))
 	}
 }

--- a/packages/cli/src/commands/capabilities/translations.ts
+++ b/packages/cli/src/commands/capabilities/translations.ts
@@ -2,8 +2,8 @@ import { Flags } from '@oclif/core'
 
 import { CapabilityLocalization, DeviceProfileTranslations, LocaleReference } from '@smartthings/core-sdk'
 
-import { APIOrganizationCommand, ListingOutputConfig, outputListing, selectFromList,
-	SelectingConfig, TableGenerator } from '@smartthings/cli-lib'
+import { APIOrganizationCommand, OutputItemOrListConfig, outputItemOrList, selectFromList,
+	SelectFromListConfig, TableGenerator } from '@smartthings/cli-lib'
 
 import { CapabilityId, capabilityIdOrIndexInputArgs, CapabilitySummaryWithNamespace, getCustomByNamespace,
 	getIdFromUser, translateToId } from '../../lib/commands/capabilities-util'
@@ -50,7 +50,7 @@ export default class CapabilityTranslationsCommand extends APIOrganizationComman
 
 	static flags = {
 		...APIOrganizationCommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 		namespace: Flags.string({
 			char: 'n',
 			description: 'a specific namespace to query; will use all by default',
@@ -133,7 +133,7 @@ export default class CapabilityTranslationsCommand extends APIOrganizationComman
 	]
 
 	async run(): Promise<void> {
-		const capConfig: SelectingConfig<CapabilitySummaryWithNamespace> = {
+		const capConfig: SelectFromListConfig<CapabilitySummaryWithNamespace> = {
 			primaryKeyName: 'id',
 			sortKeyName: 'id',
 			listTableFieldDefinitions: ['id', 'version', 'status'],
@@ -180,14 +180,14 @@ export default class CapabilityTranslationsCommand extends APIOrganizationComman
 			promptMessage: 'Select a capability.',
 		})
 
-		const config: ListingOutputConfig<DeviceProfileTranslations, LocaleReference> = {
+		const config: OutputItemOrListConfig<DeviceProfileTranslations, LocaleReference> = {
 			primaryKeyName: 'tag',
 			sortKeyName: 'tag',
 			listTableFieldDefinitions: ['tag'],
 			buildTableOutput: data => buildTableOutput(this.tableGenerator, data),
 		}
 
-		await outputListing(this, config, preselectedTag,
+		await outputItemOrList(this, config, preselectedTag,
 			() => this.client.capabilities.listLocales(capabilityId.id, capabilityId.version),
 			tag => this.client.capabilities.getTranslations(capabilityId.id, capabilityId.version, tag),
 			true)

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,9 +1,19 @@
 import yaml from 'js-yaml'
 import { Flags } from '@oclif/core'
 
-import { buildOutputFormatter, calculateOutputFormat, IOFormat, outputItem, outputList,
-	outputListing, SmartThingsCommand, stringTranslateToId, TableFieldDefinition,
-	writeOutput } from '@smartthings/cli-lib'
+import {
+	buildOutputFormatter,
+	calculateOutputFormat,
+	IOFormat,
+	outputItem,
+	outputList,
+	outputItemOrList,
+	SmartThingsCommand,
+	stringTranslateToId,
+	TableFieldDefinition,
+	writeOutput,
+	OutputListConfig,
+} from '@smartthings/cli-lib'
 
 
 function reservedKey(key: string): boolean {
@@ -36,7 +46,7 @@ export default class ConfigCommand extends SmartThingsCommand<typeof ConfigComma
 
 	static flags = {
 		...SmartThingsCommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 		verbose: Flags.boolean({
 			description: 'Include additional data in table output',
 			char: 'v',
@@ -58,7 +68,7 @@ export default class ConfigCommand extends SmartThingsCommand<typeof ConfigComma
 			{ label: 'Definition', value: (item) => yaml.dump(item.data) },
 		]
 
-		const outputListConfig = {
+		const outputListConfig: OutputListConfig<ConfigItem> = {
 			primaryKeyName: 'name',
 			sortKeyName: 'name',
 			listTableFieldDefinitions,

--- a/packages/cli/src/commands/devicepreferences.ts
+++ b/packages/cli/src/commands/devicepreferences.ts
@@ -1,6 +1,6 @@
 import { Flags } from '@oclif/core'
 import { DevicePreference } from '@smartthings/core-sdk'
-import { APIOrganizationCommand, outputListing, allOrganizationsFlags, forAllOrganizations } from '@smartthings/cli-lib'
+import { APIOrganizationCommand, outputItemOrList, allOrganizationsFlags, forAllOrganizations, OutputItemOrListConfig } from '@smartthings/cli-lib'
 import { tableFieldDefinitions } from '../lib/commands/devicepreferences-util'
 
 
@@ -30,7 +30,7 @@ export default class DevicePreferencesCommand extends APIOrganizationCommand<typ
 
 	static flags = {
 		...APIOrganizationCommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 		...allOrganizationsFlags,
 		namespace: Flags.string({
 			char: 'n',
@@ -57,16 +57,16 @@ export default class DevicePreferencesCommand extends APIOrganizationCommand<typ
 	]
 
 	async run(): Promise<void> {
-		const config = {
+		const listTableFieldDefinitions = ['preferenceId', 'title', 'name', 'description', 'required', 'preferenceType']
+		const config: OutputItemOrListConfig<DevicePreference> = {
 			itemName: 'device preference',
 			primaryKeyName: 'preferenceId',
 			sortKeyName: 'preferenceId',
 			tableFieldDefinitions,
-			listTableFieldDefinitions: ['preferenceId', 'title', 'name', 'description',
-				'required', 'preferenceType'],
+			listTableFieldDefinitions,
 		}
 
-		await outputListing(this, config, this.args.idOrIndex,
+		await outputItemOrList(this, config, this.args.idOrIndex,
 			async () => {
 				if (this.flags.standard) {
 					return standardPreferences(this)
@@ -74,7 +74,7 @@ export default class DevicePreferencesCommand extends APIOrganizationCommand<typ
 					return this.client.devicePreferences.list(this.flags.namespace)
 				}
 				else if (this.flags['all-organizations']) {
-					config.listTableFieldDefinitions.push('organization')
+					listTableFieldDefinitions.push('organization')
 					return preferencesForAllOrganizations(this)
 				}
 				return customPreferences(this)

--- a/packages/cli/src/commands/devicepreferences/translations.ts
+++ b/packages/cli/src/commands/devicepreferences/translations.ts
@@ -1,4 +1,4 @@
-import { APIOrganizationCommand, ListingOutputConfig, outputListing } from '@smartthings/cli-lib'
+import { APIOrganizationCommand, OutputItemOrListConfig, outputItemOrList } from '@smartthings/cli-lib'
 import { LocaleReference, PreferenceLocalization } from '@smartthings/core-sdk'
 import { chooseDevicePreference } from '../../lib/commands/devicepreferences-util'
 import { tableFieldDefinitions } from '../../lib/commands/devicepreferences/translations-util'
@@ -9,7 +9,7 @@ export default class DevicePreferencesTranslationsCommand extends APIOrganizatio
 
 	static flags = {
 		...APIOrganizationCommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 	}
 
 	static args = [
@@ -31,14 +31,14 @@ $ smartthings devicepreferences:translations motionSensitivity ko`,
 	async run(): Promise<void> {
 		const preferenceId = await chooseDevicePreference(this, this.args.preferenceId)
 
-		const config: ListingOutputConfig<PreferenceLocalization, LocaleReference> = {
+		const config: OutputItemOrListConfig<PreferenceLocalization, LocaleReference> = {
 			primaryKeyName: 'tag',
 			sortKeyName: 'tag',
 			listTableFieldDefinitions: ['tag'],
 			tableFieldDefinitions,
 		}
 
-		await outputListing<PreferenceLocalization, LocaleReference>(this, config, this.args.tag,
+		await outputItemOrList<PreferenceLocalization, LocaleReference>(this, config, this.args.tag,
 			() => this.client.devicePreferences.listTranslations(preferenceId),
 			tag => this.client.devicePreferences.getTranslations(preferenceId, tag))
 	}

--- a/packages/cli/src/commands/deviceprofiles.ts
+++ b/packages/cli/src/commands/deviceprofiles.ts
@@ -6,10 +6,12 @@ import {
 	APIOrganizationCommand,
 	WithOrganization,
 	allOrganizationsFlags,
-	outputListing,
+	outputItemOrList,
 	forAllOrganizations,
 	TableFieldDefinition,
+	OutputItemOrListConfig,
 } from '@smartthings/cli-lib'
+
 import { buildTableOutput } from '../lib/commands/deviceprofiles-util'
 
 
@@ -18,7 +20,7 @@ export default class DeviceProfilesCommand extends APIOrganizationCommand<typeof
 
 	static flags = {
 		...APIOrganizationCommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 		...allOrganizationsFlags,
 		verbose: Flags.boolean({
 			description: 'include presentationId and manufacturerName in list output',
@@ -43,7 +45,7 @@ export default class DeviceProfilesCommand extends APIOrganizationCommand<typeof
 	static aliases = ['device-profiles']
 
 	async run(): Promise<void> {
-		const config = {
+		const config: OutputItemOrListConfig<DeviceProfile> = {
 			primaryKeyName: 'id',
 			sortKeyName: 'name',
 			listTableFieldDefinitions: ['name', 'status', 'id'] as TableFieldDefinition<DeviceProfile & WithOrganization>[],
@@ -59,7 +61,7 @@ export default class DeviceProfilesCommand extends APIOrganizationCommand<typeof
 			config.listTableFieldDefinitions.push({ label: 'Manufacturer Name', value: item => item.metadata?.mnmn ?? '' })
 		}
 
-		await outputListing(this, config, this.args.id,
+		await outputItemOrList(this, config, this.args.id,
 			() => this.flags['all-organizations']
 				? forAllOrganizations(this.client, (orgClient) => orgClient.deviceProfiles.list())
 				: this.client.deviceProfiles.list(),

--- a/packages/cli/src/commands/deviceprofiles/translations.ts
+++ b/packages/cli/src/commands/deviceprofiles/translations.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 
 import { DeviceProfileTranslations, LocaleReference } from '@smartthings/core-sdk'
 
-import { APIOrganizationCommand, ListingOutputConfig, outputListing } from '@smartthings/cli-lib'
+import { APIOrganizationCommand, OutputItemOrListConfig, outputItemOrList } from '@smartthings/cli-lib'
 import { chooseDeviceProfile } from '../../lib/commands/deviceprofiles-util'
 import { buildTableOutput } from '../../lib/commands/deviceprofiles/translations-util'
 
@@ -12,7 +12,7 @@ export default class DeviceProfileTranslationsCommand extends APIOrganizationCom
 
 	static flags = {
 		...APIOrganizationCommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 		verbose: Flags.boolean({
 			description: 'include list of locales in table output',
 			char: 'v',
@@ -88,13 +88,13 @@ export default class DeviceProfileTranslationsCommand extends APIOrganizationCom
 	async run(): Promise<void> {
 		const deviceProfileId = await chooseDeviceProfile(this, this.args.id, { verbose: this.flags.verbose, allowIndex: true })
 
-		const config: ListingOutputConfig<DeviceProfileTranslations, LocaleReference> = {
+		const config: OutputItemOrListConfig<DeviceProfileTranslations, LocaleReference> = {
 			primaryKeyName: 'tag',
 			sortKeyName: 'tag',
 			buildTableOutput: data => buildTableOutput(this.tableGenerator, data),
 			listTableFieldDefinitions: ['tag'],
 		}
-		await outputListing(this, config, this.args.tag,
+		await outputItemOrList(this, config, this.args.tag,
 			() => this.client.deviceProfiles.listLocales(deviceProfileId),
 			tag =>  this.client.deviceProfiles.getTranslations(deviceProfileId, tag))
 	}

--- a/packages/cli/src/commands/deviceprofiles/translations/delete.ts
+++ b/packages/cli/src/commands/deviceprofiles/translations/delete.ts
@@ -1,4 +1,6 @@
-import { APIOrganizationCommand, selectFromList } from '@smartthings/cli-lib'
+import { LocaleReference } from '@smartthings/core-sdk'
+
+import { APIOrganizationCommand, selectFromList, SelectFromListConfig } from '@smartthings/cli-lib'
 
 import { chooseDeviceProfile } from '../../../lib/commands/deviceprofiles-util'
 
@@ -46,7 +48,7 @@ export default class DeviceProfileTranslationsDeleteCommand extends APIOrganizat
 	async run(): Promise<void> {
 		const deviceProfileId = await chooseDeviceProfile(this, this.args.id)
 
-		const localeTagSelectConfig = {
+		const localeTagSelectConfig: SelectFromListConfig<LocaleReference> = {
 			primaryKeyName: 'tag',
 			sortKeyName: 'tag',
 			listTableFieldDefinitions: ['tag'],

--- a/packages/cli/src/commands/deviceprofiles/view.ts
+++ b/packages/cli/src/commands/deviceprofiles/view.ts
@@ -1,6 +1,6 @@
 import { DeviceProfile } from '@smartthings/core-sdk'
 
-import { APIOrganizationCommand, ListingOutputConfig, outputListing } from '@smartthings/cli-lib'
+import { APIOrganizationCommand, OutputItemOrListConfig, outputItemOrList } from '@smartthings/cli-lib'
 
 import { buildTableOutput, DeviceDefinition } from '../../lib/commands/deviceprofiles-util'
 import { prunePresentation } from '../../lib/commands/deviceprofiles/view-util'
@@ -11,7 +11,7 @@ export default class DeviceProfilesViewCommand extends APIOrganizationCommand<ty
 
 	static flags = {
 		...APIOrganizationCommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 	}
 
 	static args = [{
@@ -22,7 +22,7 @@ export default class DeviceProfilesViewCommand extends APIOrganizationCommand<ty
 	static aliases = ['device-profiles:view']
 
 	async run(): Promise<void> {
-		const config: ListingOutputConfig<DeviceDefinition, DeviceProfile> = {
+		const config: OutputItemOrListConfig<DeviceDefinition, DeviceProfile> = {
 			primaryKeyName: 'id',
 			sortKeyName: 'name',
 			buildTableOutput: data => buildTableOutput(this.tableGenerator, data),
@@ -42,7 +42,7 @@ export default class DeviceProfilesViewCommand extends APIOrganizationCommand<ty
 			return profile
 		}
 
-		await outputListing(this, config, this.args.id,
+		await outputItemOrList(this, config, this.args.id,
 			() => this.client.deviceProfiles.list(),
 			getDeviceProfileAndConfig)
 	}

--- a/packages/cli/src/commands/devices.ts
+++ b/packages/cli/src/commands/devices.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 
 import { Device, DeviceIntegrationType, DeviceGetOptions, DeviceListOptions } from '@smartthings/core-sdk'
 
-import { APICommand, outputListing, TableFieldDefinition, withLocationsAndRooms } from '@smartthings/cli-lib'
+import { APICommand, outputItemOrList, OutputItemOrListConfig, TableFieldDefinition, withLocationsAndRooms } from '@smartthings/cli-lib'
 
 import { buildTableOutput } from '../lib/commands/devices-util'
 
@@ -12,7 +12,7 @@ export default class DevicesCommand extends APICommand<typeof DevicesCommand.fla
 
 	static flags = {
 		...APICommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 		/* eslint-disable @typescript-eslint/naming-convention */
 		'location-id': Flags.string({
 			char: 'l',
@@ -39,11 +39,11 @@ export default class DevicesCommand extends APICommand<typeof DevicesCommand.fla
 			char: 'a',
 			description: 'filter results by installed app that created the device',
 		}),
-		'status': Flags.boolean({
+		status: Flags.boolean({
 			char: 's',
 			description: 'include attribute values in the response',
 		}),
-		'health': Flags.boolean({
+		health: Flags.boolean({
 			char: 'H',
 			description: 'include device health in response',
 		}),
@@ -78,7 +78,7 @@ export default class DevicesCommand extends APICommand<typeof DevicesCommand.fla
 			})
 		}
 
-		const config = {
+		const config: OutputItemOrListConfig<Device> = {
 			primaryKeyName: 'deviceId',
 			sortKeyName: 'label',
 			listTableFieldDefinitions,
@@ -100,7 +100,7 @@ export default class DevicesCommand extends APICommand<typeof DevicesCommand.fla
 			...deviceGetOptions,
 		}
 
-		await outputListing(this, config, this.args.id,
+		await outputItemOrList(this, config, this.args.id,
 			async () => {
 				const devices = await this.client.devices.list(deviceListOptions)
 				if (this.flags.verbose) {

--- a/packages/cli/src/commands/devices/capability-status.ts
+++ b/packages/cli/src/commands/devices/capability-status.ts
@@ -1,6 +1,6 @@
 import { CapabilityReference, CapabilityStatus } from '@smartthings/core-sdk'
 
-import { APICommand, chooseComponent, chooseDevice, formatAndWriteItem, selectFromList, stringTranslateToId,
+import { APICommand, chooseComponent, chooseDevice, formatAndWriteItem, selectFromList, SelectFromListConfig, stringTranslateToId,
 	TableGenerator } from '@smartthings/cli-lib'
 
 import { prettyPrintAttribute } from '../../lib/commands/devices-util'
@@ -54,7 +54,7 @@ export default class DeviceCapabilityStatusCommand extends APICommand<typeof Dev
 			this.error(`no capabilities found for component ${componentName} of device ${deviceId}`)
 		}
 
-		const config = {
+		const config: SelectFromListConfig<CapabilityReference> = {
 			itemName: 'capability',
 			primaryKeyName: 'id',
 			sortKeyName: 'id',

--- a/packages/cli/src/commands/installedapps.ts
+++ b/packages/cli/src/commands/installedapps.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 
 import { InstalledApp, InstalledAppListOptions } from '@smartthings/core-sdk'
 
-import { APICommand, outputListing, withLocations } from '@smartthings/cli-lib'
+import { APICommand, outputItemOrList, OutputItemOrListConfig, withLocations } from '@smartthings/cli-lib'
 import { InstalledAppWithLocation, listTableFieldDefinitions, tableFieldDefinitions } from '../lib/commands/installedapps-util'
 
 
@@ -11,7 +11,7 @@ export default class InstalledAppsCommand extends APICommand<typeof InstalledApp
 
 	static flags = {
 		...APICommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		'location-id': Flags.string({
 			char: 'l',
@@ -30,7 +30,7 @@ export default class InstalledAppsCommand extends APICommand<typeof InstalledApp
 	}]
 
 	async run(): Promise<void> {
-		const config = {
+		const config: OutputItemOrListConfig<InstalledApp, InstalledAppWithLocation> = {
 			primaryKeyName: 'installedAppId',
 			sortKeyName: 'displayName',
 			listTableFieldDefinitions,
@@ -44,7 +44,7 @@ export default class InstalledAppsCommand extends APICommand<typeof InstalledApp
 			locationId: this.flags['location-id'],
 		}
 
-		await outputListing<InstalledApp, InstalledAppWithLocation>(this, config, this.args.id,
+		await outputItemOrList<InstalledApp, InstalledAppWithLocation>(this, config, this.args.id,
 			async () => {
 				const apps = await this.client.installedApps.list(listOptions)
 				if (this.flags.verbose) {

--- a/packages/cli/src/commands/installedapps/delete.ts
+++ b/packages/cli/src/commands/installedapps/delete.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 
 import { InstalledApp, InstalledAppListOptions } from '@smartthings/core-sdk'
 
-import { selectFromList, APICommand, withLocations } from '@smartthings/cli-lib'
+import { selectFromList, APICommand, withLocations, SelectFromListConfig } from '@smartthings/cli-lib'
 
 
 export default class InstalledAppDeleteCommand extends APICommand<typeof InstalledAppDeleteCommand.flags> {
@@ -28,7 +28,7 @@ export default class InstalledAppDeleteCommand extends APICommand<typeof Install
 	}]
 
 	async run(): Promise<void> {
-		const config = {
+		const config: SelectFromListConfig<InstalledApp> = {
 			primaryKeyName: 'installedAppId',
 			sortKeyName: 'displayName',
 			listTableFieldDefinitions: ['displayName', 'installedAppType', 'installedAppStatus', 'installedAppId'],

--- a/packages/cli/src/commands/installedapps/rename.ts
+++ b/packages/cli/src/commands/installedapps/rename.ts
@@ -1,9 +1,9 @@
 import { Flags } from '@oclif/core'
 import inquirer from 'inquirer'
 
-import { InstalledAppListOptions } from '@smartthings/core-sdk'
+import { InstalledApp, InstalledAppListOptions } from '@smartthings/core-sdk'
 
-import { APICommand, formatAndWriteItem, selectFromList, withLocations } from '@smartthings/cli-lib'
+import { APICommand, formatAndWriteItem, FormatAndWriteItemConfig, selectFromList, SelectFromListConfig, withLocations } from '@smartthings/cli-lib'
 import { listTableFieldDefinitions, tableFieldDefinitions } from '../../lib/commands/installedapps-util'
 
 
@@ -37,7 +37,7 @@ export default class InstalledAppRenameCommand extends APICommand<typeof Install
 	]
 
 	async run(): Promise<void> {
-		const config = {
+		const config: SelectFromListConfig<InstalledApp> & FormatAndWriteItemConfig<InstalledApp> = {
 			itemName: 'installed app',
 			primaryKeyName: 'installedAppId',
 			sortKeyName: 'displayName',

--- a/packages/cli/src/commands/installedschema.ts
+++ b/packages/cli/src/commands/installedschema.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 
 import { InstalledSchemaApp, SmartThingsClient } from '@smartthings/core-sdk'
 
-import { APICommand, outputListing, TableFieldDefinition, withLocations } from '@smartthings/cli-lib'
+import { APICommand, OutputItemOrListConfig, outputItemOrList, TableFieldDefinition, withLocations } from '@smartthings/cli-lib'
 
 
 export type InstalledSchemaAppWithLocation = InstalledSchemaApp & { location?: string }
@@ -37,7 +37,7 @@ export default class InstalledSchemaAppsCommand extends APICommand<typeof Instal
 
 	static flags = {
 		...APICommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		'location-id': Flags.string({
 			char: 'l',
@@ -56,7 +56,7 @@ export default class InstalledSchemaAppsCommand extends APICommand<typeof Instal
 	}]
 
 	async run(): Promise<void> {
-		const config = {
+		const config: OutputItemOrListConfig<InstalledSchemaApp, InstalledSchemaAppWithLocation> = {
 			primaryKeyName: 'isaId',
 			sortKeyName: 'appName',
 			listTableFieldDefinitions,
@@ -66,7 +66,7 @@ export default class InstalledSchemaAppsCommand extends APICommand<typeof Instal
 			config.listTableFieldDefinitions.splice(3, 0, 'location')
 		}
 
-		await outputListing(this, config, this.args.id,
+		await outputItemOrList(this, config, this.args.id,
 			() => installedSchemaInstances(this.client, this.flags['location-id'], this.flags.verbose),
 			id => this.client.schema.getInstalledApp(id),
 		)

--- a/packages/cli/src/commands/installedschema/delete.ts
+++ b/packages/cli/src/commands/installedschema/delete.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 
 import { InstalledSchemaApp } from '@smartthings/core-sdk'
 
-import { APICommand, selectFromList } from '@smartthings/cli-lib'
+import { APICommand, selectFromList, SelectFromListConfig } from '@smartthings/cli-lib'
 
 import { installedSchemaInstances } from '../installedschema'
 
@@ -29,7 +29,7 @@ export default class InstalledSchemaAppDeleteCommand extends APICommand<typeof I
 	}]
 
 	async run(): Promise<void> {
-		const config = {
+		const config: SelectFromListConfig<InstalledSchemaApp> = {
 			primaryKeyName: 'isaId',
 			sortKeyName: 'appName',
 			listTableFieldDefinitions: ['appName', 'partnerName', 'partnerSTConnection', 'isaId'],

--- a/packages/cli/src/commands/locations.ts
+++ b/packages/cli/src/commands/locations.ts
@@ -1,6 +1,6 @@
 import { Location, LocationItem } from '@smartthings/core-sdk'
 
-import { APICommand, outputListing, selectFromList, stringTranslateToId } from '@smartthings/cli-lib'
+import { APICommand, outputItemOrList, OutputItemOrListConfig, selectFromList, SelectFromListConfig, stringTranslateToId } from '@smartthings/cli-lib'
 
 
 export const tableFieldDefinitions = [
@@ -13,8 +13,7 @@ export async function chooseLocation(
 		locationFromArg?: string,
 		autoChoose?: boolean,
 		allowIndex?: boolean): Promise<string> {
-
-	const config = {
+	const config: SelectFromListConfig<LocationItem> = {
 		itemName: 'location',
 		primaryKeyName: 'locationId',
 		sortKeyName: 'name',
@@ -38,7 +37,7 @@ export default class LocationsCommand extends APICommand<typeof LocationsCommand
 
 	static flags = {
 		...APICommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 	}
 
 	static args = [{
@@ -47,12 +46,12 @@ export default class LocationsCommand extends APICommand<typeof LocationsCommand
 	}]
 
 	async run(): Promise<void> {
-		const config = {
+		const config: OutputItemOrListConfig<Location, LocationItem> = {
 			primaryKeyName: 'locationId',
 			sortKeyName: 'name',
 			tableFieldDefinitions,
 		}
-		await outputListing<Location, LocationItem>(this, config, this.args.idOrIndex,
+		await outputItemOrList<Location, LocationItem>(this, config, this.args.idOrIndex,
 			() => this.client.locations.list(),
 			id => this.client.locations.get(id))
 	}

--- a/packages/cli/src/commands/locations/rooms.ts
+++ b/packages/cli/src/commands/locations/rooms.ts
@@ -1,5 +1,5 @@
 import { Flags } from '@oclif/core'
-import { APICommand, ListingOutputConfig, outputListing, withLocations } from '@smartthings/cli-lib'
+import { APICommand, OutputItemOrListConfig, outputItemOrList, withLocations } from '@smartthings/cli-lib'
 import { Room } from '@smartthings/core-sdk'
 import { getRoomsByLocation, RoomWithLocation, tableFieldDefinitions } from '../../lib/commands/locations/rooms-util'
 
@@ -18,7 +18,7 @@ export default class RoomsCommand extends APICommand<typeof RoomsCommand.flags> 
 			description: 'include location name in output',
 			char: 'v',
 		}),
-		...outputListing.flags,
+		...outputItemOrList.flags,
 	}
 
 	static args = [{
@@ -29,7 +29,7 @@ export default class RoomsCommand extends APICommand<typeof RoomsCommand.flags> 
 	static aliases = ['rooms']
 
 	async run(): Promise<void> {
-		const config: ListingOutputConfig<Room, RoomWithLocation> = {
+		const config: OutputItemOrListConfig<Room, RoomWithLocation> = {
 			primaryKeyName: 'roomId',
 			sortKeyName: 'name',
 			listTableFieldDefinitions: tableFieldDefinitions,
@@ -39,7 +39,7 @@ export default class RoomsCommand extends APICommand<typeof RoomsCommand.flags> 
 			config.listTableFieldDefinitions?.push('location')
 		}
 		const rooms = await getRoomsByLocation(this.client, this.flags['location-id'])
-		await outputListing(this, config, this.args.idOrIndex,
+		await outputItemOrList(this, config, this.args.idOrIndex,
 			async () => {
 				if (this.flags.verbose) {
 					return await withLocations(this.client, rooms)

--- a/packages/cli/src/commands/organizations.ts
+++ b/packages/cli/src/commands/organizations.ts
@@ -1,4 +1,4 @@
-import { APICommand, outputListing } from '@smartthings/cli-lib'
+import { APICommand, outputItemOrList, OutputItemOrListConfig } from '@smartthings/cli-lib'
 import { OrganizationResponse } from '@smartthings/core-sdk'
 
 
@@ -23,7 +23,7 @@ export default class OrganizationsCommand extends APICommand<typeof Organization
 
 	static flags = {
 		...APICommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 	}
 
 	static args = [{
@@ -32,14 +32,14 @@ export default class OrganizationsCommand extends APICommand<typeof Organization
 	}]
 
 	async run(): Promise<void> {
-		const config = {
+		const config: OutputItemOrListConfig<OrganizationResponse> = {
 			tableFieldDefinitions,
 			primaryKeyName: 'organizationId',
 			sortKeyName: 'name',
 			listTableFieldDefinitions: ['name', 'label', 'organizationId', 'isDefaultUserOrg'],
 		}
 
-		await outputListing(this, config, this.args.id,
+		await outputItemOrList(this, config, this.args.id,
 			() => this.client.organizations.list(),
 			id => this.client.organizations.get(id),
 		)

--- a/packages/cli/src/commands/rules.ts
+++ b/packages/cli/src/commands/rules.ts
@@ -1,8 +1,8 @@
 import { Flags } from '@oclif/core'
 
-import { APICommand, outputListing } from '@smartthings/cli-lib'
+import { APICommand, outputItemOrList, OutputItemOrListConfig } from '@smartthings/cli-lib'
 
-import { getRulesByLocation, getRuleWithLocation, tableFieldDefinitions } from '../lib/commands/rules-util'
+import { getRulesByLocation, getRuleWithLocation, RuleWithLocation, tableFieldDefinitions } from '../lib/commands/rules-util'
 
 
 export default class RulesCommand extends APICommand<typeof RulesCommand.flags> {
@@ -10,7 +10,7 @@ export default class RulesCommand extends APICommand<typeof RulesCommand.flags> 
 
 	static flags = {
 		...APICommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		'location-id': Flags.string({
 			char: 'l',
@@ -24,13 +24,13 @@ export default class RulesCommand extends APICommand<typeof RulesCommand.flags> 
 	}]
 
 	async run(): Promise<void> {
-		const config = {
+		const config: OutputItemOrListConfig<RuleWithLocation> = {
 			primaryKeyName: 'id',
 			sortKeyName: 'name',
 			listTableFieldDefinitions: ['name', 'id', 'locationId', 'locationName'],
 			tableFieldDefinitions,
 		}
-		await outputListing(this, config, this.args.idOrIndex,
+		await outputItemOrList(this, config, this.args.idOrIndex,
 			() => getRulesByLocation(this.client, this.flags['location-id']),
 			id => getRuleWithLocation(this.client, id, this.flags['location-id']),
 		)

--- a/packages/cli/src/commands/scenes.ts
+++ b/packages/cli/src/commands/scenes.ts
@@ -2,7 +2,8 @@ import { Flags } from '@oclif/core'
 
 import { SceneSummary, SceneListOptions } from '@smartthings/core-sdk'
 
-import { APICommand, outputListing } from '@smartthings/cli-lib'
+import { APICommand, outputItemOrList, OutputItemOrListConfig } from '@smartthings/cli-lib'
+
 import { tableFieldDefinitions } from '../lib/commands/scenes-util'
 
 
@@ -11,7 +12,7 @@ export default class ScenesCommand extends APICommand<typeof ScenesCommand.flags
 
 	static flags = {
 		...APICommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		'location-id': Flags.string({
 			char: 'l',
@@ -26,7 +27,7 @@ export default class ScenesCommand extends APICommand<typeof ScenesCommand.flags
 	}]
 
 	async run(): Promise<void> {
-		const config = {
+		const config: OutputItemOrListConfig<SceneSummary> = {
 			primaryKeyName: 'sceneId',
 			sortKeyName: 'sceneName',
 			tableFieldDefinitions,
@@ -35,7 +36,7 @@ export default class ScenesCommand extends APICommand<typeof ScenesCommand.flags
 			locationId: this.flags['location-id'],
 		}
 
-		await outputListing<SceneSummary, SceneSummary>(this, config, this.args.idOrIndex,
+		await outputItemOrList<SceneSummary, SceneSummary>(this, config, this.args.idOrIndex,
 			() => this.client.scenes.list(options),
 			id => this.client.scenes.get(id))
 	}

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -1,6 +1,8 @@
 import { Flags } from '@oclif/core'
 
-import { APICommand, outputListing } from '@smartthings/cli-lib'
+import { SchemaApp } from '@smartthings/core-sdk'
+
+import { APICommand, outputItemOrList, OutputItemOrListConfig } from '@smartthings/cli-lib'
 
 
 export default class SchemaCommand extends APICommand<typeof SchemaCommand.flags> {
@@ -8,7 +10,7 @@ export default class SchemaCommand extends APICommand<typeof SchemaCommand.flags
 
 	static flags = {
 		...APICommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 		verbose: Flags.boolean({
 			description: 'include ARN in output',
 			char: 'v',
@@ -21,7 +23,7 @@ export default class SchemaCommand extends APICommand<typeof SchemaCommand.flags
 	}]
 
 	async run(): Promise<void> {
-		const config = {
+		const config: OutputItemOrListConfig<SchemaApp> = {
 			tableFieldDefinitions: [
 				'appName', 'partnerName', 'endpointAppId', 'schemaType', 'hostingType',
 				'stClientId', 'oAuthAuthorizationUrl', 'oAuthTokenUrl', 'oAuthClientId',
@@ -41,7 +43,7 @@ export default class SchemaCommand extends APICommand<typeof SchemaCommand.flags
 			config.listTableFieldDefinitions.push('ARN/URL')
 		}
 
-		await outputListing(this, config, this.args.id,
+		await outputItemOrList(this, config, this.args.id,
 			async () => {
 				const schemaApps = await this.client.schema.list()
 				return schemaApps.map(app => {

--- a/packages/cli/src/commands/schema/delete.ts
+++ b/packages/cli/src/commands/schema/delete.ts
@@ -1,4 +1,6 @@
-import { APICommand, selectFromList } from '@smartthings/cli-lib'
+import { SchemaApp } from '@smartthings/core-sdk'
+
+import { APICommand, selectFromList, SelectFromListConfig } from '@smartthings/cli-lib'
 
 
 export default class SchemaAppDeleteCommand extends APICommand<typeof SchemaAppDeleteCommand.flags> {
@@ -12,7 +14,7 @@ export default class SchemaAppDeleteCommand extends APICommand<typeof SchemaAppD
 	}]
 
 	async run(): Promise<void> {
-		const config = {
+		const config: SelectFromListConfig<SchemaApp> = {
 			primaryKeyName: 'endpointAppId',
 			sortKeyName: 'appName',
 		}

--- a/packages/cli/src/commands/schema/regenerate.ts
+++ b/packages/cli/src/commands/schema/regenerate.ts
@@ -1,4 +1,5 @@
-import { APICommand, selectFromList, outputItem } from '@smartthings/cli-lib'
+import { APICommand, selectFromList, outputItem, SelectFromListConfig } from '@smartthings/cli-lib'
+import { SchemaApp } from '@smartthings/core-sdk'
 
 
 export default class SchemaAppRegenerateCommand extends APICommand<typeof SchemaAppRegenerateCommand.flags> {
@@ -15,7 +16,7 @@ export default class SchemaAppRegenerateCommand extends APICommand<typeof Schema
 	}]
 
 	async run(): Promise<void> {
-		const config = {
+		const config: SelectFromListConfig<SchemaApp> = {
 			primaryKeyName: 'endpointAppId',
 			sortKeyName: 'appName',
 		}

--- a/packages/cli/src/commands/schema/update.ts
+++ b/packages/cli/src/commands/schema/update.ts
@@ -1,8 +1,8 @@
 import { Flags, Errors } from '@oclif/core'
 
-import { SchemaAppRequest } from '@smartthings/core-sdk'
+import { SchemaApp, SchemaAppRequest } from '@smartthings/core-sdk'
 
-import { APICommand, inputItem, selectFromList, lambdaAuthFlags } from '@smartthings/cli-lib'
+import { APICommand, inputItem, selectFromList, lambdaAuthFlags, SelectFromListConfig } from '@smartthings/cli-lib'
 
 import { addSchemaPermission } from '../../lib/aws-utils'
 
@@ -25,7 +25,7 @@ export default class SchemaUpdateCommand extends APICommand<typeof SchemaUpdateC
 	}]
 
 	async run(): Promise<void> {
-		const config = {
+		const config: SelectFromListConfig<SchemaApp> = {
 			primaryKeyName: 'endpointAppId',
 			sortKeyName: 'appName',
 			listTableFieldDefinitions: ['appName', 'endpointAppId', 'hostingType'],

--- a/packages/cli/src/commands/virtualdevices.ts
+++ b/packages/cli/src/commands/virtualdevices.ts
@@ -1,14 +1,18 @@
 import { Flags } from '@oclif/core'
+
 import {
 	Device,
 	DeviceIntegrationType,
 	DeviceListOptions,
 } from '@smartthings/core-sdk'
+
 import {
 	APICommand,
-	outputListing,
+	outputItemOrList,
+	OutputItemOrListConfig,
 	withLocationsAndRooms,
 } from '@smartthings/cli-lib'
+
 import { buildTableOutput } from '../lib/commands/devices-util'
 
 
@@ -17,7 +21,7 @@ export default class VirtualDevicesCommand extends APICommand<typeof VirtualDevi
 
 	static flags = {
 		...APICommand.flags,
-		...outputListing.flags,
+		...outputItemOrList.flags,
 		/* eslint-disable @typescript-eslint/naming-convention */
 		'location-id': Flags.string({
 			char: 'l',
@@ -41,7 +45,7 @@ export default class VirtualDevicesCommand extends APICommand<typeof VirtualDevi
 	}]
 
 	async run(): Promise<void> {
-		const config = {
+		const config: OutputItemOrListConfig<Device> = {
 			primaryKeyName: 'deviceId',
 			sortKeyName: 'label',
 			listTableFieldDefinitions: ['label', 'deviceId'],
@@ -57,7 +61,7 @@ export default class VirtualDevicesCommand extends APICommand<typeof VirtualDevi
 			type: DeviceIntegrationType.VIRTUAL,
 		}
 
-		await outputListing(this, config, this.args.id,
+		await outputItemOrList(this, config, this.args.id,
 			async () => {
 				const devices = await this.client.devices.list(deviceListOptions)
 				if (this.flags.verbose) {

--- a/packages/cli/src/lib/commands/apps-util.ts
+++ b/packages/cli/src/lib/commands/apps-util.ts
@@ -1,5 +1,15 @@
-import { APICommand, ChooseOptions, chooseOptionsWithDefaults, selectFromList, SelectingConfig, stringTranslateToId, TableFieldDefinition, TableGenerator } from '@smartthings/cli-lib'
 import { AppResponse, AppSettingsResponse, PagedApp } from '@smartthings/core-sdk'
+
+import {
+	APICommand,
+	ChooseOptions,
+	chooseOptionsWithDefaults,
+	selectFromList,
+	SelectFromListConfig,
+	stringTranslateToId,
+	TableFieldDefinition,
+	TableGenerator,
+} from '@smartthings/cli-lib'
 
 
 const isWebhookSmartApp = (app: AppResponse): boolean => !!app.webhookSmartApp
@@ -37,7 +47,7 @@ export const oauthTableFieldDefinitions = ['clientName', 'scope', 'redirectUris'
 
 export async function chooseApp(command: APICommand<typeof APICommand.flags>, appFromArg?: string, options?: Partial<ChooseOptions>): Promise<string> {
 	const opts = chooseOptionsWithDefaults(options)
-	const config: SelectingConfig<AppResponse> = {
+	const config: SelectFromListConfig<PagedApp> = {
 		itemName: 'app',
 		primaryKeyName: 'appId',
 		sortKeyName: 'displayName',

--- a/packages/cli/src/lib/commands/capabilities-util.ts
+++ b/packages/cli/src/lib/commands/capabilities-util.ts
@@ -13,6 +13,7 @@ import {
 	APICommand,
 	ListDataFunction,
 	selectFromList,
+	SelectFromListConfig,
 	sort,
 	Sorting,
 	summarizedText,
@@ -175,7 +176,7 @@ export const convertToId = (itemIdOrIndex: string, list: CapabilitySummaryWithNa
 		return false
 	}
 }
-export const getIdFromUser = async (fieldInfo: Sorting, list: CapabilitySummaryWithNamespace[], promptMessage?: string): Promise<CapabilityId> => {
+export const getIdFromUser = async (fieldInfo: Sorting<CapabilitySummaryWithNamespace>, list: CapabilitySummaryWithNamespace[], promptMessage?: string): Promise<CapabilityId> => {
 	const idOrIndex: string = (await inquirer.prompt({
 		type: 'input',
 		name: 'idOrIndex',
@@ -198,10 +199,10 @@ export const getIdFromUser = async (fieldInfo: Sorting, list: CapabilitySummaryW
 	//    - if not, use the one there is
 	//    - if so, ask the user which one
 
-	return { 'id': inputId, 'version': 1 }
+	return { id: inputId, version: 1 }
 }
 
-export const translateToId = async (sortKeyName: string, idOrIndex: string | CapabilityId,
+export const translateToId = async (sortKeyName: Extract<keyof CapabilitySummaryWithNamespace, string>, idOrIndex: string | CapabilityId,
 		listFunction: ListDataFunction<CapabilitySummaryWithNamespace>): Promise<CapabilityId> => {
 	if (typeof idOrIndex !== 'string') {
 		return idOrIndex
@@ -228,7 +229,7 @@ export const chooseCapability = async (command: APICommand<typeof APICommand.fla
 	const preselectedId: CapabilityId | undefined = idFromArgs
 		? { id: idFromArgs, version: versionFromArgs ?? 1 }
 		: undefined
-	const config = {
+	const config: SelectFromListConfig<CapabilitySummaryWithNamespace> = {
 		itemName: 'capability',
 		primaryKeyName: 'id',
 		sortKeyName: 'id',
@@ -244,7 +245,7 @@ export const chooseCapability = async (command: APICommand<typeof APICommand.fla
 
 export const chooseCapabilityFiltered = async (command: APICommand<typeof APICommand.flags>,
 		promptMessage: string, filter: string): Promise<CapabilityId> => {
-	const config = {
+	const config: SelectFromListConfig<CapabilitySummaryWithNamespace> = {
 		itemName: 'capability',
 		primaryKeyName: 'id',
 		sortKeyName: 'id',

--- a/packages/cli/src/lib/commands/devicepreferences-util.ts
+++ b/packages/cli/src/lib/commands/devicepreferences-util.ts
@@ -1,5 +1,6 @@
-import { APICommand, selectFromList, TableFieldDefinition } from '@smartthings/cli-lib'
 import { DevicePreference } from '@smartthings/core-sdk'
+
+import { APICommand, selectFromList, SelectFromListConfig, TableFieldDefinition } from '@smartthings/cli-lib'
 
 
 export const tableFieldDefinitions: TableFieldDefinition<DevicePreference>[] = [
@@ -23,7 +24,7 @@ export const tableFieldDefinitions: TableFieldDefinition<DevicePreference>[] = [
 ]
 
 export async function chooseDevicePreference(command: APICommand<typeof APICommand.flags>, preselectedId?: string): Promise<string> {
-	const config = {
+	const config: SelectFromListConfig<DevicePreference> = {
 		itemName: 'device preference',
 		primaryKeyName: 'preferenceId',
 		sortKeyName: 'preferenceId',

--- a/packages/cli/src/lib/commands/deviceprofiles-util.ts
+++ b/packages/cli/src/lib/commands/deviceprofiles-util.ts
@@ -12,6 +12,7 @@ import {
 	ChooseOptions,
 	chooseOptionsWithDefaults,
 	selectFromList,
+	SelectFromListConfig,
 	stringTranslateToId,
 	summarizedText,
 	TableGenerator,
@@ -98,7 +99,7 @@ export const buildTableOutput = (tableGenerator: TableGenerator, data: DevicePro
 export const chooseDeviceProfile = async (command: APIOrganizationCommand<typeof APIOrganizationCommand.flags>,
 		deviceProfileFromArg?: string, options?: Partial<ChooseOptions>): Promise<string> => {
 	const opts = chooseOptionsWithDefaults(options)
-	const config = {
+	const config: SelectFromListConfig<DeviceProfile> = {
 		itemName: 'device profile',
 		primaryKeyName: 'id',
 		sortKeyName: 'name',

--- a/packages/cli/src/lib/commands/locations/rooms-util.ts
+++ b/packages/cli/src/lib/commands/locations/rooms-util.ts
@@ -1,6 +1,9 @@
 import { Errors } from '@oclif/core'
-import { APICommand, selectFromList } from '@smartthings/cli-lib'
+
 import { LocationItem, Room, SmartThingsClient } from '@smartthings/core-sdk'
+
+import { APICommand, selectFromList, SelectFromListConfig } from '@smartthings/cli-lib'
+
 import * as roomsUtil from './rooms-util'
 
 
@@ -33,7 +36,7 @@ export type RoomWithLocation = Room & {
 
 export async function chooseRoom(command: APICommand<typeof APICommand.flags>, locationId?: string, preselectedId?: string, autoChoose?: boolean): Promise<[string, string]> {
 	const rooms = await roomsUtil.getRoomsByLocation(command.client, locationId)
-	const config = {
+	const config: SelectFromListConfig<Room> = {
 		itemName: 'room',
 		primaryKeyName: 'roomId',
 		sortKeyName: 'name',

--- a/packages/cli/src/lib/commands/rules-util.ts
+++ b/packages/cli/src/lib/commands/rules-util.ts
@@ -2,7 +2,7 @@ import { Errors } from '@oclif/core'
 
 import { ActionExecutionResult, LocationItem, Rule, RuleExecutionResponse, SmartThingsClient } from '@smartthings/core-sdk'
 
-import { APICommand, selectFromList, summarizedText, TableFieldDefinition, TableGenerator } from '@smartthings/cli-lib'
+import { APICommand, selectFromList, SelectFromListConfig, summarizedText, TableFieldDefinition, TableGenerator } from '@smartthings/cli-lib'
 
 
 export const tableFieldDefinitions: TableFieldDefinition<Rule>[] = ['name', 'id',
@@ -55,7 +55,7 @@ export const getRuleWithLocation = async (client: SmartThingsClient, id: string,
 
 export const chooseRule = async (command: APICommand<typeof APICommand.flags>, promptMessage: string, locationId?: string,
 		preselectedId?: string): Promise<string> => {
-	const config = {
+	const config: SelectFromListConfig<RuleWithLocation> = {
 		primaryKeyName: 'id',
 		sortKeyName: 'name',
 		listTableFieldDefinitions: ['name', 'id', 'locationId', 'locationName'],

--- a/packages/cli/src/lib/commands/scenes-util.ts
+++ b/packages/cli/src/lib/commands/scenes-util.ts
@@ -1,4 +1,6 @@
-import { APICommand, selectFromList } from '@smartthings/cli-lib'
+import { SceneSummary } from '@smartthings/core-sdk'
+
+import { APICommand, selectFromList, SelectFromListConfig } from '@smartthings/cli-lib'
 
 
 export const tableFieldDefinitions = [
@@ -6,7 +8,7 @@ export const tableFieldDefinitions = [
 ]
 
 export async function chooseScene(command: APICommand<typeof APICommand.flags>, preselectedId?: string): Promise<string> {
-	const config = {
+	const config: SelectFromListConfig<SceneSummary> = {
 		itemName: 'scene',
 		primaryKeyName: 'sceneId',
 		sortKeyName: 'sceneName',
@@ -16,4 +18,3 @@ export async function chooseScene(command: APICommand<typeof APICommand.flags>, 
 		listItems: () => command.client.scenes.list(),
 	})
 }
-

--- a/packages/cli/src/lib/commands/virtualdevices-util.ts
+++ b/packages/cli/src/lib/commands/virtualdevices-util.ts
@@ -9,12 +9,20 @@ import {
 } from '@smartthings/core-sdk'
 
 import {
-	APICommand, APIOrganizationCommand, FileInputProcessor,
+	APICommand,
+	APIOrganizationCommand,
+	FileInputProcessor,
 	selectFromList,
+	SelectFromListConfig,
 } from '@smartthings/cli-lib'
 
 import { chooseDeviceProfile } from '../../lib/commands/deviceprofiles-util'
 
+
+export interface DevicePrototype {
+	name: string
+	id: string
+}
 
 export const locallyExecutingPrototypes = [
 	{ name: 'Switch', id: 'VIRTUAL_SWITCH' },
@@ -85,7 +93,7 @@ export async function chooseDeviceProfileDefinition(command: APIOrganizationComm
 }
 
 export async function chooseDevicePrototype(command: APICommand<typeof APICommand.flags>, preselectedId?: string): Promise<string> {
-	const config = {
+	const config: SelectFromListConfig<DevicePrototype> = {
 		itemName: 'device prototype',
 		primaryKeyName: 'id',
 		listTableFieldDefinitions: ['name', 'id'],
@@ -108,7 +116,7 @@ export const chooseComponent = async (command: APICommand<typeof APICommand.flag
 	let component
 	if (device.components) {
 
-		const config = {
+		const config: SelectFromListConfig<Component> = {
 			itemName: 'component',
 			primaryKeyName: 'id',
 			sortKeyName: 'id',
@@ -129,7 +137,7 @@ export const chooseComponent = async (command: APICommand<typeof APICommand.flag
 }
 
 export const chooseCapability = async (command: APICommand<typeof APICommand.flags>, component: Component): Promise<CapabilityReference> => {
-	const config = {
+	const config: SelectFromListConfig<CapabilityReference> = {
 		itemName: 'capability',
 		primaryKeyName: 'id',
 		sortKeyName: 'id',
@@ -151,7 +159,7 @@ export const chooseCapability = async (command: APICommand<typeof APICommand.fla
 export const chooseAttribute = async (command: APICommand<typeof APICommand.flags>, cap: CapabilityReference): Promise<CapabilityAttributeItem> => {
 	let attributeName
 	let attribute
-	const config = {
+	const config: SelectFromListConfig<CapabilityAttributeItem> = {
 		itemName: 'attribute',
 		primaryKeyName: 'attributeName',
 		sortKeyName: 'attributeName',
@@ -181,7 +189,7 @@ export const chooseUnit = async (command: APICommand<typeof APICommand.flags>, a
 	let unit
 	const units = attribute.schema.properties.unit?.enum
 	if (units) {
-		const config = {
+		const config: SelectFromListConfig<CapabilityUnitItem> = {
 			itemName: 'unit',
 			primaryKeyName: 'unit',
 			sortKeyName: 'unit',
@@ -202,7 +210,7 @@ export const chooseValue = async (command: APICommand<typeof APICommand.flags>, 
 	let value
 	const values = attribute.schema.properties.value.enum
 	if (values) {
-		const config = {
+		const config: SelectFromListConfig<CapabilityValueItem> = {
 			itemName: 'value',
 			primaryKeyName: 'value',
 			sortKeyName: 'value',

--- a/packages/lib/src/__tests__/basic-io.test.ts
+++ b/packages/lib/src/__tests__/basic-io.test.ts
@@ -1,6 +1,6 @@
 import { Errors } from '@oclif/core'
 
-import { inputAndOutputItem, inputItem, outputItem, outputList } from '../basic-io'
+import { inputAndOutputItem, inputItem, outputItem, outputList, OutputListConfig } from '../basic-io'
 import * as format from '../format'
 import { InputProcessor } from '../input'
 import * as inputBuilder from '../input-builder'
@@ -85,13 +85,13 @@ describe('basic-io', () => {
 	})
 
 	describe('outputList', () => {
-		it('gets data and calls formatAndWriteList', async () => {
-			const config = {
-				listTableFieldDefinitions: [],
-				primaryKeyName: 'num',
-				sortKeyName: 'str',
-			}
+		const config: OutputListConfig<SimpleType> = {
+			listTableFieldDefinitions: [],
+			primaryKeyName: 'num',
+			sortKeyName: 'str',
+		}
 
+		it('gets data and calls formatAndWriteList', async () => {
 			const getDataMock = jest.fn().mockResolvedValue(list)
 
 			const result = await outputList<SimpleType>(command, config, getDataMock)
@@ -102,12 +102,6 @@ describe('basic-io', () => {
 		})
 
 		it('passes includeIndex value on to formatAndWriteList', async () => {
-			const config = {
-				listTableFieldDefinitions: [],
-				primaryKeyName: 'num',
-				sortKeyName: 'str',
-			}
-
 			const getDataMock = jest.fn().mockResolvedValue(list)
 
 			const result = await outputList<SimpleType>(command, config, getDataMock, true)
@@ -118,12 +112,6 @@ describe('basic-io', () => {
 		})
 
 		it('passes forUserQuery value on to formatAndWriteList', async () => {
-			const config = {
-				listTableFieldDefinitions: [],
-				primaryKeyName: 'num',
-				sortKeyName: 'str',
-			}
-
 			const getDataMock = jest.fn().mockResolvedValue(list)
 
 			const result = await outputList<SimpleType>(command, config, getDataMock, false, true)

--- a/packages/lib/src/__tests__/command-util.test.ts
+++ b/packages/lib/src/__tests__/command-util.test.ts
@@ -1,10 +1,12 @@
 import inquirer from 'inquirer'
+import { Sorting } from '../basic-io'
 import {
 	ChooseOptions, chooseOptionsDefaults, chooseOptionsWithDefaults, convertToId,
 	isIndexArgument, itemName, pluralItemName, stringGetIdFromUser,
 	stringTranslateToId,
 } from '../command-util'
 import * as output from '../output'
+import { SimpleType } from './test-lib/simple-type'
 
 
 describe('command-util', () => {
@@ -43,11 +45,11 @@ describe('command-util', () => {
 		})
 	})
 
-	const item1 = { str: 'string-id-a', num: 5 }
-	const item2 = { str: 'string-id-b', num: 6 }
-	const item3 = { str: 'string-id-c', num: 7 }
+	const item1: SimpleType = { str: 'string-id-a', num: 5 }
+	const item2: SimpleType = { str: 'string-id-b', num: 6 }
+	const item3: SimpleType = { str: 'string-id-c', num: 7 }
 	const list = [item1, item2, item3]
-	const command = {
+	const config: Sorting<SimpleType> = {
 		primaryKeyName: 'str',
 		sortKeyName: 'num',
 	}
@@ -58,7 +60,7 @@ describe('command-util', () => {
 		it('simply returns undefined given undefined idOrIndex', async () => {
 			const listFunction = jest.fn()
 
-			const computedId = await stringTranslateToId(command, undefined, listFunction)
+			const computedId = await stringTranslateToId(config, undefined, listFunction)
 
 			expect(computedId).toBeUndefined()
 			expect(listFunction).toHaveBeenCalledTimes(0)
@@ -67,7 +69,7 @@ describe('command-util', () => {
 		it('simply returns id when not matching index argument', async () => {
 			const listFunction = jest.fn()
 
-			const computedId = await stringTranslateToId(command, 'id-not-index', listFunction)
+			const computedId = await stringTranslateToId(config, 'id-not-index', listFunction)
 
 			expect(computedId).toBe('id-not-index')
 			expect(listFunction).toHaveBeenCalledTimes(0)
@@ -78,7 +80,7 @@ describe('command-util', () => {
 			const sortSpy = jest.spyOn(output, 'sort')
 			sortSpy.mockReturnValue(list)
 
-			const computedId = await stringTranslateToId(command, '1', listFunction)
+			const computedId = await stringTranslateToId(config, '1', listFunction)
 
 			expect(computedId).toBe('string-id-a')
 
@@ -92,7 +94,7 @@ describe('command-util', () => {
 			const sortSpy = jest.spyOn(output, 'sort')
 			sortSpy.mockReturnValue(list)
 
-			await expect(stringTranslateToId(command, '4', listFunction))
+			await expect(stringTranslateToId(config, '4', listFunction))
 				.rejects.toThrow('invalid index 4 (enter an id or index between 1 and 3 inclusive)')
 
 			expect(listFunction).toHaveBeenCalledTimes(1)
@@ -105,7 +107,7 @@ describe('command-util', () => {
 			const sortSpy = jest.spyOn(output, 'sort')
 			sortSpy.mockReturnValue([{ num: 5 }])
 
-			await expect(stringTranslateToId(command, '1', listFunction))
+			await expect(stringTranslateToId(config, '1', listFunction))
 				.rejects.toThrow('did not find key str in data')
 
 			expect(listFunction).toHaveBeenCalledTimes(1)
@@ -118,7 +120,7 @@ describe('command-util', () => {
 			const sortSpy = jest.spyOn(output, 'sort')
 			sortSpy.mockReturnValue([{ str: 3, num: 5 }])
 
-			await expect(stringTranslateToId(command, '1', listFunction))
+			await expect(stringTranslateToId(config, '1', listFunction))
 				.rejects.toThrow('invalid type number for primary key str in {"str":3,"num":5}')
 
 			expect(listFunction).toHaveBeenCalledTimes(1)
@@ -156,7 +158,7 @@ describe('command-util', () => {
 		it('accepts id input from user', async () => {
 			promptSpy.mockResolvedValue({ itemIdOrIndex: 'string-id-a' })
 
-			const chosenId = await stringGetIdFromUser(command, list)
+			const chosenId = await stringGetIdFromUser(config, list)
 
 			expect(chosenId).toBe('string-id-a')
 
@@ -173,7 +175,7 @@ describe('command-util', () => {
 		it('validation returns error when unable to convert', async () => {
 			promptSpy.mockResolvedValue({ itemIdOrIndex: 'string-id-a' })
 
-			const chosenId = await stringGetIdFromUser(command, list)
+			const chosenId = await stringGetIdFromUser(config, list)
 
 			expect(chosenId).toBe('string-id-a')
 
@@ -190,13 +192,13 @@ describe('command-util', () => {
 		it('throws error when unable to convert entered value to a valid id', async () => {
 			promptSpy.mockResolvedValue({ itemIdOrIndex: 'invalid-id' })
 
-			await expect(stringGetIdFromUser(command, list)).rejects.toThrow('unable to convert invalid-id to id')
+			await expect(stringGetIdFromUser(config, list)).rejects.toThrow('unable to convert invalid-id to id')
 		})
 
 		it('handles non-default prompt', async () => {
 			promptSpy.mockResolvedValue({ itemIdOrIndex: 'string-id-a' })
 
-			const chosenId = await stringGetIdFromUser(command, list, 'give me an id')
+			const chosenId = await stringGetIdFromUser(config, list, 'give me an id')
 
 			expect(chosenId).toBe('string-id-a')
 

--- a/packages/lib/src/__tests__/format.test.ts
+++ b/packages/lib/src/__tests__/format.test.ts
@@ -1,4 +1,5 @@
-import { formatAndWriteItem, formatAndWriteList } from '../format'
+import { Naming } from '../basic-io'
+import { CommonListOutputProducer, formatAndWriteItem, formatAndWriteList } from '../format'
 import { IOFormat } from '../io-util'
 import * as output from '../output'
 import * as outputBuilder from '../output-builder'
@@ -220,7 +221,7 @@ describe('format', () => {
 		})
 
 		it('uses Sorting fields as a fallback', async () => {
-			const config = {
+			const config: CommonListOutputProducer<SimpleType> & Naming = {
 				primaryKeyName: 'num',
 				sortKeyName: 'str',
 			}

--- a/packages/lib/src/__tests__/listing-io.test.ts
+++ b/packages/lib/src/__tests__/listing-io.test.ts
@@ -1,6 +1,6 @@
 import * as basicIO from '../basic-io'
 import * as commandUtil from '../command-util'
-import { outputGenericListing, outputListing } from '../listing-io'
+import { OutputItemOrListConfig, outputItemOrListGeneric, outputItemOrList } from '../listing-io'
 import { buildMockCommand } from './test-lib/mock-command'
 import { SimpleType } from './test-lib/simple-type'
 
@@ -14,7 +14,7 @@ describe('listing-io', () => {
 			output: 'output.yaml',
 		},
 	}
-	const config = {
+	const config: OutputItemOrListConfig<SimpleType, SimpleType> = {
 		tableFieldDefinitions: [],
 		primaryKeyName: 'str',
 		sortKeyName: 'num',
@@ -26,11 +26,11 @@ describe('listing-io', () => {
 	const outputListSpy = jest.spyOn(basicIO, 'outputList')
 	const translateToId = jest.fn().mockResolvedValue('translated id')
 
-	describe('outputGenericListing', () => {
+	describe('outputItemOrListGeneric', () => {
 		it('calls outputItem when given idOrIndex', async () => {
 			outputItemSpy.mockResolvedValue(item)
 
-			await outputGenericListing<string, SimpleType, SimpleType>(command, config, 'id or index',
+			await outputItemOrListGeneric<string, SimpleType, SimpleType>(command, config, 'id or index',
 				listFunction, getFunction, translateToId, false)
 
 			expect(translateToId).toHaveBeenCalledTimes(1)
@@ -53,7 +53,7 @@ describe('listing-io', () => {
 		it('calls outputList when not given idOrIndex', async () => {
 			outputListSpy.mockResolvedValue(list)
 
-			await outputGenericListing<string, SimpleType, SimpleType>(command, config, undefined,
+			await outputItemOrListGeneric<string, SimpleType, SimpleType>(command, config, undefined,
 				listFunction, getFunction, translateToId)
 
 			expect(outputListSpy).toHaveBeenCalledTimes(1)
@@ -66,13 +66,13 @@ describe('listing-io', () => {
 		})
 	})
 
-	describe('outputListing', () => {
+	describe('outputItemOrList', () => {
 		const translateToIdSpy = jest.spyOn(commandUtil, 'stringTranslateToId').mockResolvedValue('id or index')
 
 		it('calls outputItem when given an id', async () => {
 			outputItemSpy.mockResolvedValue(item)
 
-			await outputListing(command, config, 'id or index', listFunction, getFunction)
+			await outputItemOrList(command, config, 'id or index', listFunction, getFunction)
 
 			expect(translateToIdSpy).toHaveBeenCalledTimes(1)
 			expect(translateToIdSpy).toHaveBeenCalledWith(config, 'id or index', listFunction)
@@ -93,7 +93,7 @@ describe('listing-io', () => {
 		it('calls outputList when not given idOrIndex', async () => {
 			outputListSpy.mockResolvedValue(list)
 
-			await outputListing(command, config, undefined, listFunction, getFunction, true)
+			await outputItemOrList(command, config, undefined, listFunction, getFunction, true)
 
 			expect(outputListSpy).toHaveBeenCalledTimes(1)
 			expect(outputListSpy).toHaveBeenCalledWith(command, config, listFunction, true)

--- a/packages/lib/src/command-util.ts
+++ b/packages/lib/src/command-util.ts
@@ -17,9 +17,9 @@ export function pluralItemName(command: Naming): string {
 	return command.pluralItemName ?? (command.itemName ? `${command.itemName}s` : 'items')
 }
 
-export async function stringTranslateToId<L>(config: Sorting & Naming, idOrIndex: string, listFunction: ListDataFunction<L>): Promise<string>
-export async function stringTranslateToId<L>(config: Sorting & Naming, idOrIndex: string | undefined, listFunction: ListDataFunction<L>): Promise<string | undefined>
-export async function stringTranslateToId<L>(config: Sorting & Naming, idOrIndex: string | undefined, listFunction: ListDataFunction<L>): Promise<string | undefined> {
+export async function stringTranslateToId<L extends object>(config: Sorting<L> & Naming, idOrIndex: string, listFunction: ListDataFunction<L>): Promise<string>
+export async function stringTranslateToId<L extends object>(config: Sorting<L> & Naming, idOrIndex: string | undefined, listFunction: ListDataFunction<L>): Promise<string | undefined>
+export async function stringTranslateToId<L extends object>(config: Sorting<L> & Naming, idOrIndex: string | undefined, listFunction: ListDataFunction<L>): Promise<string | undefined> {
 	if (!idOrIndex) {
 		return undefined
 	}
@@ -40,26 +40,21 @@ export async function stringTranslateToId<L>(config: Sorting & Naming, idOrIndex
 	if (!(primaryKeyName in matchingItem)) {
 		throw Error(`did not find key ${primaryKeyName} in data`)
 	}
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore
 	const pk = matchingItem[primaryKeyName]
 	if (typeof pk === 'string') {
 		return pk
 	}
-
 	throw Error(`invalid type ${typeof pk} for primary key` +
 		` ${primaryKeyName} in ${JSON.stringify(matchingItem)}`)
 }
 
-
-export function convertToId<L>(itemIdOrIndex: string, primaryKeyName: string, sortedList: L[]): string | false {
+export function convertToId<L>(itemIdOrIndex: string, primaryKeyName: Extract<keyof L, string>, sortedList: L[]): string | false {
 	if (itemIdOrIndex.length === 0) {
 		return false
 	}
 	const matchingItem = sortedList.find(item => {
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		return (primaryKeyName in item) && itemIdOrIndex === item[primaryKeyName]
+		const pk = item[primaryKeyName]
+		return typeof pk === 'string' && itemIdOrIndex === pk
 	})
 	if (matchingItem) {
 		return itemIdOrIndex
@@ -72,8 +67,6 @@ export function convertToId<L>(itemIdOrIndex: string, primaryKeyName: string, so
 	const index = Number.parseInt(itemIdOrIndex)
 
 	if (!Number.isNaN(index) && index > 0 && index <= sortedList.length) {
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
 		const pk = sortedList[index - 1][primaryKeyName]
 		if (typeof pk === 'string') {
 			return pk
@@ -84,7 +77,7 @@ export function convertToId<L>(itemIdOrIndex: string, primaryKeyName: string, so
 	return false
 }
 
-export async function stringGetIdFromUser<L>(fieldInfo: Sorting, list: L[], prompt?: string): Promise<string> {
+export async function stringGetIdFromUser<L extends object>(fieldInfo: Sorting<L>, list: L[], prompt?: string): Promise<string> {
 	const primaryKeyName = fieldInfo.primaryKeyName
 
 	const itemIdOrIndex: string = (await inquirer.prompt({

--- a/packages/lib/src/device-util.ts
+++ b/packages/lib/src/device-util.ts
@@ -2,7 +2,7 @@ import { Component, Device, DeviceListOptions } from '@smartthings/core-sdk'
 
 import { APICommand } from './api-command'
 import { ChooseOptions, chooseOptionsDefaults, stringTranslateToId } from './command-util'
-import { selectFromList, SelectingConfig } from './select'
+import { selectFromList, SelectFromListConfig } from './select'
 import { SmartThingsCommandInterface } from './smartthings-command'
 
 
@@ -14,7 +14,7 @@ export interface ChooseDeviceOptions extends ChooseOptions {
 export const chooseDevice = async (command: APICommand<typeof APICommand.flags>, deviceFromArg?: string,
 		options?: Partial<ChooseDeviceOptions>): Promise<string> => {
 	const opts = { ...chooseOptionsDefaults, ...options }
-	const config = {
+	const config: SelectFromListConfig<Device> = {
 		itemName: 'device',
 		primaryKeyName: 'deviceId',
 		sortKeyName: 'label',
@@ -34,7 +34,7 @@ export const chooseComponent = async (command: SmartThingsCommandInterface, comp
 		return 'main'
 	}
 
-	const config: SelectingConfig<Component> = {
+	const config: SelectFromListConfig<Component> = {
 		itemName: 'component',
 		primaryKeyName: 'id',
 		sortKeyName: 'id',

--- a/packages/lib/src/format.ts
+++ b/packages/lib/src/format.ts
@@ -20,8 +20,9 @@ export interface TableCommonListOutputProducer<L> {
 export interface CustomCommonListOutputProducer<L> {
 	buildListTableOutput(data: L[]): string
 }
-export type CommonListOutputProducer<L> = TableCommonListOutputProducer<L> | CustomCommonListOutputProducer<L> | Sorting
+export type CommonListOutputProducer<L extends object> = TableCommonListOutputProducer<L> | CustomCommonListOutputProducer<L> | Sorting<L>
 
+export type FormatAndWriteItemConfig<O> = CommonOutputProducer<O>
 /**
  * Format and output the given item.
  *
@@ -34,7 +35,7 @@ export type CommonListOutputProducer<L> = TableCommonListOutputProducer<L> | Cus
  *   input so the output can default to the input format.
  */
 export async function formatAndWriteItem<O>(command: SmartThingsCommandInterface,
-		config: CommonOutputProducer<O>, item: O, defaultIOFormat?: IOFormat): Promise<void> {
+		config: FormatAndWriteItemConfig<O>, item: O, defaultIOFormat?: IOFormat): Promise<void> {
 	const commonFormatter = 'buildTableOutput' in config
 		? (data: O) => config.buildTableOutput(data)
 		: itemTableFormatter<O>(command.tableGenerator, config.tableFieldDefinitions)
@@ -43,6 +44,7 @@ export async function formatAndWriteItem<O>(command: SmartThingsCommandInterface
 }
 formatAndWriteItem.flags = buildOutputFormatter.flags
 
+export type FormatAndWriteListConfig<L extends object> = CommonListOutputProducer<L> & Naming
 /**
  * Format and output the given list.
  *
@@ -55,8 +57,8 @@ formatAndWriteItem.flags = buildOutputFormatter.flags
  * @param forUserQuery Set this to true if you're displaying this to the user for a question. This
  *   will force output to stdout and skip the JSON/YAML formatters.
  */
-export async function formatAndWriteList<L>(command: SmartThingsCommandInterface,
-		config: CommonListOutputProducer<L> & Naming, list: L[], includeIndex = false,
+export async function formatAndWriteList<L extends object>(command: SmartThingsCommandInterface,
+		config: FormatAndWriteListConfig<L>, list: L[], includeIndex = false,
 		forUserQuery = false): Promise<void> {
 	let commonFormatter: OutputFormatter<L[]>
 	if (list.length === 0) {

--- a/packages/lib/src/listing-io.ts
+++ b/packages/lib/src/listing-io.ts
@@ -1,16 +1,13 @@
-import { IdTranslationFunction, ListDataFunction, LookupDataFunction, outputItem, outputList, Sorting } from './basic-io'
+import { IdTranslationFunction, ListDataFunction, LookupDataFunction, outputItem, OutputItemConfig, outputList, OutputListConfig } from './basic-io'
 import { stringTranslateToId } from './command-util'
-import { CommonOutputProducer } from './format'
 import { SmartThingsCommandInterface } from './smartthings-command'
-import { TableFieldDefinition } from './table-generator'
 
 
-export type ListingOutputConfig<O, L> = Sorting & CommonOutputProducer<O> & {
-	listTableFieldDefinitions?: TableFieldDefinition<L>[]
-}
-// TODO: rename both of these to something like outputItemOrList
-export async function outputGenericListing<ID, O, L>(command: SmartThingsCommandInterface,
-		config: ListingOutputConfig<O, L>, idOrIndex: ID | string | undefined,
+export type OutputItemOrListConfig<O extends object, L extends object = O> = OutputItemConfig<O> & OutputListConfig<L>
+
+// TODO: can probably combine these and use default type of string for ID if we put it last, similar to as was done for selectFromList
+export async function outputItemOrListGeneric<ID, O extends object, L extends object = O>(command: SmartThingsCommandInterface,
+		config: OutputItemOrListConfig<O, L>, idOrIndex: ID | string | undefined,
 		listFunction: ListDataFunction<L>, getFunction: LookupDataFunction<ID, O>,
 		translateToId: IdTranslationFunction<ID, L>, includeIndex = true): Promise<void> {
 	if (idOrIndex) {
@@ -20,13 +17,13 @@ export async function outputGenericListing<ID, O, L>(command: SmartThingsCommand
 		await outputList<L>(command, config, listFunction, includeIndex)
 	}
 }
-outputGenericListing.flags = outputList.flags
+outputItemOrListGeneric.flags = outputList.flags
 
-export async function outputListing<O, L>(command: SmartThingsCommandInterface,
-		config: ListingOutputConfig<O, L>,
+export async function outputItemOrList<O extends object, L extends object = O>(command: SmartThingsCommandInterface,
+		config: OutputItemOrListConfig<O, L>,
 		idOrIndex: string | undefined, listFunction: ListDataFunction<L>,
 		getFunction: LookupDataFunction<string, O>, includeIndex = true): Promise<void> {
-	return outputGenericListing<string, O, L>(command, config, idOrIndex, listFunction, getFunction,
+	return outputItemOrListGeneric<string, O, L>(command, config, idOrIndex, listFunction, getFunction,
 		(idOrIndex, listFunction) => stringTranslateToId(config, idOrIndex, listFunction), includeIndex)
 }
-outputListing.flags = outputGenericListing.flags
+outputItemOrList.flags = outputItemOrListGeneric.flags

--- a/packages/testlib/src/index.ts
+++ b/packages/testlib/src/index.ts
@@ -13,7 +13,7 @@ jest.mock('@smartthings/cli-lib', () => {
 		chooseOptionsWithDefaults: jest.fn(() => chooseOptionsDefaults),
 		stringTranslateToId: jest.fn(),
 		selectFromList: jest.fn(),
-		outputListing: jest.fn(),
+		outputItemOrList: jest.fn(),
 		inputAndOutputItem: jest.fn(),
 		inputItem: jest.fn(),
 		outputItem: jest.fn(),


### PR DESCRIPTION
* make the `Sorting` interface generic, dependent on the type of the object being sorted (this was the key to removing the need for the `ts-ignore` comments in `command-util.ts`)
  * changed type of `primaryKeyName` and `sortingKeyName` for `Sorting` interface to constrain them to string keys from the object being sorted
  * this also necessitated adding types to `config` instances throughout the CLI passed into these functions and a bit of other type-related updates to some commands
* add `extends object` constraint to objects handled by command helper functions
* rename `outputListing` to `outputItemOrList` and `outputListingGeneric` to `outputItemOrListGeneric` (updated note about renaming them to a note about combining them)
* update/add config types for command helper functions with consistent naming (`InputAndOutputItemConfig` for `inputAndOutputItem`, `FormatAndWriteItemConfig` for `formatAndWriteItem`, etc.)

<!-- Describe your pull request. -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
