### PR TITLE
refactor: clean up @ts-ignore in sort function

### DIFF
--- a/packages/lib/src/output.ts
+++ b/packages/lib/src/output.ts
@@ -5,17 +5,13 @@ import { SmartThingsCommandInterface } from './smartthings-command'
 import { TableFieldDefinition, TableGenerator } from './table-generator'
 
 
-export function sort<L>(list: L[], keyName?: string): L[] {
+export function sort<L extends object>(list: L[], keyName?: Extract<keyof L, string>): L[] {
 	if (!keyName) {
 		return list
 	}
 	return list.sort((a, b) => {
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		const av = a[keyName].toLowerCase()
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		const bv = b[keyName].toLowerCase()
+		const av = (a[keyName] as unknown as string).toLowerCase()
+		const bv = (b[keyName] as unknown as string).toLowerCase()
 		return av === bv ? 0 : av < bv ? -1 : 1
 	})
 }


### PR DESCRIPTION
<!-- Describe your pull request. -->

Restrict `keyName` to `sort` method to the one of the object's string keys so we don't need the `ts-ignore` comment.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
