### PR TITLE
ci: make installer jobs depend on github release

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -178,7 +178,7 @@ jobs:
           files: packages/cli/dist_bin/assets/*
 
   homebrew-formula:
-    needs: release
+    needs: [release, github-release]
 
     if: needs.release.outputs.cli-released == 'true'
 
@@ -205,7 +205,7 @@ jobs:
         formulae: smartthingscommunity/smartthings/smartthings
 
   windows-installer:
-    needs: [release, package]
+    needs: [release, package, github-release]
 
     if: needs.release.outputs.cli-released == 'true'
 


### PR DESCRIPTION
<!-- Describe your pull request. -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [ ] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
