### PR TITLE
fix: update libraries so edge plugin commands work again

### DIFF
--- a/.changeset/famous-mirrors-smash.md
+++ b/.changeset/famous-mirrors-smash.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+fix broken edge commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -3749,27 +3749,6 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/@smartthings/plugin-cli-edge": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/@smartthings/plugin-cli-edge/-/plugin-cli-edge-1.15.2.tgz",
-			"integrity": "sha512-jWYbXmVB1ZTxSmmKfU71V9VvOgKqQBseCLLeqbfLUf9+3VWhNY9uxpgG3hQThqBKcO60LpAqhhgkUPaEnhqecA==",
-			"dependencies": {
-				"@log4js-node/log4js-api": "^1.0.2",
-				"@oclif/core": "^1.13.10",
-				"@smartthings/cli-lib": "^1.0.0-beta.13",
-				"@smartthings/core-sdk": "^5.1.0",
-				"axios": "^0.21.4",
-				"inquirer": "^8.2.2",
-				"js-yaml": "^4.1.0",
-				"jszip": "^3.9.1",
-				"picomatch": "^2.3.1",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=12.18.1 <17",
-				"npm": ">=8"
-			}
-		},
 		"node_modules/@tootallnate/once": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -18649,7 +18628,7 @@
 				"@oclif/plugin-plugins": "^2.1.0",
 				"@smartthings/cli-lib": "^1.0.0-beta.14",
 				"@smartthings/core-sdk": "^5.1.1",
-				"@smartthings/plugin-cli-edge": "^1.15.2",
+				"@smartthings/plugin-cli-edge": "^1.15.3",
 				"aws-sdk": "^2.1175.0",
 				"inquirer": "^8.2.4",
 				"js-yaml": "^4.1.0",
@@ -18681,6 +18660,27 @@
 			},
 			"engines": {
 				"node": ">=16.14.2 <17",
+				"npm": ">=8"
+			}
+		},
+		"packages/cli/node_modules/@smartthings/plugin-cli-edge": {
+			"version": "1.15.3",
+			"resolved": "https://registry.npmjs.org/@smartthings/plugin-cli-edge/-/plugin-cli-edge-1.15.3.tgz",
+			"integrity": "sha512-GAhgVXFouFEp7c/5Mq8RMHRki9ChAG5nlbarEqCbnMfJY6J61qwy2XJRj8JSluL4aL1QyGWN0ki3fh8Pvuq6bw==",
+			"dependencies": {
+				"@log4js-node/log4js-api": "^1.0.2",
+				"@oclif/core": "^1.13.10",
+				"@smartthings/cli-lib": "^1.0.0-beta.14",
+				"@smartthings/core-sdk": "^5.1.1",
+				"axios": "^0.21.4",
+				"inquirer": "^8.2.4",
+				"js-yaml": "^4.1.0",
+				"jszip": "^3.9.1",
+				"picomatch": "^2.3.1",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=12.18.1 <17",
 				"npm": ">=8"
 			}
 		},
@@ -21818,7 +21818,7 @@
 				"@smartthings/cli-lib": "^1.0.0-beta.14",
 				"@smartthings/cli-testlib": "^1.0.0-beta.9",
 				"@smartthings/core-sdk": "^5.1.1",
-				"@smartthings/plugin-cli-edge": "^1.15.2",
+				"@smartthings/plugin-cli-edge": "^1.15.3",
 				"@types/inquirer": "^8.2.1",
 				"@types/jest": "^28.1.5",
 				"@types/js-yaml": "^4.0.5",
@@ -21841,6 +21841,25 @@
 				"ts-jest": "^28.0.6",
 				"ts-node": "^10.9.1",
 				"typescript": "^4.7.4"
+			},
+			"dependencies": {
+				"@smartthings/plugin-cli-edge": {
+					"version": "1.15.3",
+					"resolved": "https://registry.npmjs.org/@smartthings/plugin-cli-edge/-/plugin-cli-edge-1.15.3.tgz",
+					"integrity": "sha512-GAhgVXFouFEp7c/5Mq8RMHRki9ChAG5nlbarEqCbnMfJY6J61qwy2XJRj8JSluL4aL1QyGWN0ki3fh8Pvuq6bw==",
+					"requires": {
+						"@log4js-node/log4js-api": "^1.0.2",
+						"@oclif/core": "^1.13.10",
+						"@smartthings/cli-lib": "^1.0.0-beta.14",
+						"@smartthings/core-sdk": "^5.1.1",
+						"axios": "^0.21.4",
+						"inquirer": "^8.2.4",
+						"js-yaml": "^4.1.0",
+						"jszip": "^3.9.1",
+						"picomatch": "^2.3.1",
+						"tslib": "^2.3.1"
+					}
+				}
 			}
 		},
 		"@smartthings/cli-lib": {
@@ -21931,23 +21950,6 @@
 				"lodash.isstring": "^4.0.1",
 				"qs": "^6.10.3",
 				"sshpk": "^1.17.0"
-			}
-		},
-		"@smartthings/plugin-cli-edge": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/@smartthings/plugin-cli-edge/-/plugin-cli-edge-1.15.2.tgz",
-			"integrity": "sha512-jWYbXmVB1ZTxSmmKfU71V9VvOgKqQBseCLLeqbfLUf9+3VWhNY9uxpgG3hQThqBKcO60LpAqhhgkUPaEnhqecA==",
-			"requires": {
-				"@log4js-node/log4js-api": "^1.0.2",
-				"@oclif/core": "^1.13.10",
-				"@smartthings/cli-lib": "^1.0.0-beta.13",
-				"@smartthings/core-sdk": "^5.1.0",
-				"axios": "^0.21.4",
-				"inquirer": "^8.2.2",
-				"js-yaml": "^4.1.0",
-				"jszip": "^3.9.1",
-				"picomatch": "^2.3.1",
-				"tslib": "^2.3.1"
 			}
 		},
 		"@tootallnate/once": {

--- a/packages/cli/functional-tests/tests/edge_test.py
+++ b/packages/cli/functional-tests/tests/edge_test.py
@@ -3,6 +3,10 @@ from pexpect.popen_spawn import PopenSpawn
 
 def test_edge_plugin_is_installed_and_callable():
     process = PopenSpawn('smartthings edge --help')
+
     exit_status = process.wait()
 
     assert exit_status == 0
+
+    process.expect('edge:channels')
+    process.expect('edge:drivers')

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -72,7 +72,7 @@
 		"@oclif/plugin-plugins": "^2.1.0",
 		"@smartthings/cli-lib": "^1.0.0-beta.14",
 		"@smartthings/core-sdk": "^5.1.1",
-		"@smartthings/plugin-cli-edge": "^1.15.2",
+		"@smartthings/plugin-cli-edge": "^1.15.3",
 		"aws-sdk": "^2.1175.0",
 		"inquirer": "^8.2.4",
 		"js-yaml": "^4.1.0",


### PR DESCRIPTION
<!-- Describe your pull request. -->

Updated to most recent edge plugin so edge commands work again.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [ ] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
