### PR TITLE
fix: fixed bug in capability translation output

### DIFF
--- a/.changeset/seven-donuts-jam.md
+++ b/.changeset/seven-donuts-jam.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+fix - fixed bug in capability translation output

--- a/packages/cli/src/__tests__/commands/capabilities/translations.test.ts
+++ b/packages/cli/src/__tests__/commands/capabilities/translations.test.ts
@@ -1,0 +1,111 @@
+import { outputItemOrList, selectFromList } from '@smartthings/cli-lib'
+import CapabilityTranslationsCommand from '../../../commands/capabilities/translations'
+import { LocaleReference, CapabilitiesEndpoint } from '@smartthings/core-sdk'
+
+
+describe('CapabilityTranslationsCommand', () => {
+	const outputItemOrListMock = jest.mocked(outputItemOrList)
+	const selectFromListMock = jest.mocked(selectFromList).mockResolvedValue({ id: 'switch', version: 1 })
+	const locales = [{ tag: 'en' }, { tag: 'ko' }] as LocaleReference[]
+	const listSpy = jest.spyOn(CapabilitiesEndpoint.prototype, 'listLocales').mockResolvedValue(locales)
+	const tag = { tag: 'en' }
+	const getSpy = jest.spyOn(CapabilitiesEndpoint.prototype, 'getTranslations').mockResolvedValue(tag)
+
+	test('list without version', async() => {
+		outputItemOrListMock.mockImplementationOnce(async (_command, _config, _idOrIndex, listFunction) => {
+			await listFunction()
+		})
+
+		await expect(CapabilityTranslationsCommand.run(['switch'])).resolves.not.toThrow()
+
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(CapabilityTranslationsCommand),
+			expect.objectContaining({
+				listTableFieldDefinitions: ['tag'],
+			}),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+			true,
+		)
+		expect(listSpy).toHaveBeenCalledTimes(1)
+		expect(listSpy).toHaveBeenCalledWith('switch', 1)
+	})
+
+	test('list with version', async() => {
+		outputItemOrListMock.mockImplementationOnce(async (_command, _config, _idOrIndex, listFunction) => {
+			await listFunction()
+		})
+		selectFromListMock.mockResolvedValueOnce({ id: 'switch', version: 2 })
+
+		await expect(CapabilityTranslationsCommand.run(['switch', '2'])).resolves.not.toThrow()
+
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(CapabilityTranslationsCommand),
+			expect.objectContaining({
+				listTableFieldDefinitions: ['tag'],
+			}),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+			true,
+		)
+		expect(selectFromList).toHaveBeenCalledWith(
+			expect.any(CapabilityTranslationsCommand),
+			expect.any(Object),
+			expect.objectContaining({
+				preselectedId: { id: 'switch', version: '2' },
+			}),
+		)
+		expect(listSpy).toHaveBeenCalledTimes(1)
+		expect(listSpy).toHaveBeenCalledWith('switch', 2)
+	})
+
+	test('get with version', async() => {
+		outputItemOrListMock.mockImplementationOnce(async (_command, _config, _idOrIndex, listFunction, getFunction) => {
+			await getFunction('en')
+		})
+
+		await expect(CapabilityTranslationsCommand.run(['switch', '1', 'en'])).resolves.not.toThrow()
+
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(CapabilityTranslationsCommand),
+			expect.objectContaining({
+				listTableFieldDefinitions: ['tag'],
+			}),
+			'en',
+			expect.any(Function),
+			expect.any(Function),
+			true,
+		)
+
+		expect(getSpy).toHaveBeenCalledTimes(1)
+		expect(getSpy).toHaveBeenCalledWith('switch', 1, 'en')
+	})
+
+	test('get without version', async() => {
+		outputItemOrListMock.mockImplementationOnce(async (_command, _config, _idOrIndex, listFunction, getFunction) => {
+			await getFunction('ko')
+		})
+
+		await expect(CapabilityTranslationsCommand.run(['switch', 'ko'])).resolves.not.toThrow()
+
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(CapabilityTranslationsCommand),
+			expect.objectContaining({
+				listTableFieldDefinitions: ['tag'],
+			}),
+			'ko',
+			expect.any(Function),
+			expect.any(Function),
+			true,
+		)
+
+		expect(getSpy).toHaveBeenCalledTimes(1)
+		expect(getSpy).toHaveBeenCalledWith('switch', 1, 'ko')
+	})
+})

--- a/packages/cli/src/commands/capabilities/translations.ts
+++ b/packages/cli/src/commands/capabilities/translations.ts
@@ -67,68 +67,63 @@ export default class CapabilityTranslationsCommand extends APIOrganizationComman
 	]
 
 	static examples = [
-		'$ smartthings capabilities:translations',
-		'┌───┬─────────────────────────────┬─────────┬──────────┐',
-		'│ # │ Id                          │ Version │ Status   │',
-		'├───┼─────────────────────────────┼─────────┼──────────┤',
-		'│ 1 │ custom1.outputModulation    │ 1       │ proposed │',
-		'│ 2 │ custom1.outputVoltage       │ 1       │ proposed │',
+		'$ smartthings capabilities:translations\n' +
+		'┌───┬─────────────────────────────┬─────────┬──────────┐\n' +
+		'│ # │ Id                          │ Version │ Status   │\n' +
+		'├───┼─────────────────────────────┼─────────┼──────────┤\n' +
+		'│ 1 │ custom1.outputModulation    │ 1       │ proposed │\n' +
+		'│ 2 │ custom1.outputVoltage       │ 1       │ proposed │\n' +
 		'└───┴─────────────────────────────┴─────────┴──────────┘',
-		'? Select a capability. 1',
-		'┌───┬─────┐',
-		'│ # │ Tag │',
-		'├───┼─────┤',
-		'│ 1 │ en  │',
-		'│ 2 │ ko  │',
+		'? Select a capability. 1\n' +
+		'┌───┬─────┐\n' +
+		'│ # │ Tag │\n' +
+		'├───┼─────┤\n' +
+		'│ 1 │ en  │\n' +
+		'│ 2 │ ko  │\n' +
 		'└───┴─────┘',
-		'',
-		'outputModulation (master)$ st capabilities:translations -v',
-		'┌───┬─────────────────────────────┬─────────┬──────────┬────────────┐',
-		'│ # │ Id                          │ Version │ Status   │ Locales    │',
-		'├───┼─────────────────────────────┼─────────┼──────────┼────────────┤',
-		'│ 1 │ custom1.outputModulation    │ 1       │ proposed │ ko, en, es │',
-		'│ 2 │ custom1.outputVoltage       │ 1       │ proposed │ en         │',
+		'outputModulation (master)$ st capabilities:translations -v\n' +
+		'┌───┬─────────────────────────────┬─────────┬──────────┬────────────┐\n' +
+		'│ # │ Id                          │ Version │ Status   │ Locales    │\n' +
+		'├───┼─────────────────────────────┼─────────┼──────────┼────────────┤\n' +
+		'│ 1 │ custom1.outputModulation    │ 1       │ proposed │ ko, en, es │\n' +
+		'│ 2 │ custom1.outputVoltage       │ 1       │ proposed │ en         │\n' +
 		'└───┴─────────────────────────────┴─────────┴──────────┴────────────┘',
-		'? Select a capability. 1',
-		'┌───┬─────┐',
-		'│ # │ Tag │',
-		'├───┼─────┤',
-		'│ 1 │ en  │',
-		'│ 1 │ es  │',
-		'│ 2 │ ko  │',
+		'? Select a capability. 1\n' +
+		'┌───┬─────┐\n' +
+		'│ # │ Tag │\n' +
+		'├───┼─────┤\n' +
+		'│ 1 │ en  │\n' +
+		'│ 1 │ es  │\n' +
+		'│ 2 │ ko  │\n' +
 		'└───┴─────┘',
-		'',
-		'$ smartthings capabilities:translations 1',
-		'$ smartthings capabilities:translations custom1.outputModulation',
-		'┌───┬─────┐',
-		'│ # │ Tag │',
-		'├───┼─────┤',
-		'│ 1 │ en  │',
-		'│ 2 │ ko  │',
+		'$ smartthings capabilities:translations 1\n' +
+		'$ smartthings capabilities:translations custom1.outputModulation\n' +
+		'┌───┬─────┐\n' +
+		'│ # │ Tag │\n' +
+		'├───┼─────┤\n' +
+		'│ 1 │ en  │\n' +
+		'│ 2 │ ko  │\n' +
 		'└───┴─────┘',
-		'',
-		'$ smartthings capabilities:translations 1 1',
-		'$ smartthings capabilities:translations 1 en',
-		'$ smartthings capabilities:translations custom1.outputModulation 1 1',
-		'$ smartthings capabilities:translations custom1.outputModulation 1 en',
+		'$ smartthings capabilities:translations 1 1\n' +
+		'$ smartthings capabilities:translations 1 en\n' +
+		'$ smartthings capabilities:translations custom1.outputModulation 1 1\n' +
+		'$ smartthings capabilities:translations custom1.outputModulation 1 en\n' +
 		'$ smartthings capabilities:translations custom1.outputModulation en',
 		'Tag: en',
-		'',
-		'Attributes:',
-		'┌────────────────────────┬───────────────────┬────────────────────────────────┬────────────────────────────────────────────────────┐',
-		'│ Name                   │ Label             │ Description                    │ Template                                           │',
-		'├────────────────────────┼───────────────────┼────────────────────────────────┼────────────────────────────────────────────────────┤',
-		'│ outputModulation       │ Output Modulation │ Power supply output modulation │ The {{attribute}} of {{device.label}} is {{value}} │',
-		'│ outputModulation.50hz  │ 50 Hz             │                                │                                                    │',
-		'│ outputModulation.60hz  │ 60 Hz             │                                │                                                    │',
+		'Attributes:\n' +
+		'┌────────────────────────┬───────────────────┬────────────────────────────────┬────────────────────────────────────────────────────┐\n' +
+		'│ Name                   │ Label             │ Description                    │ Template                                           │\n' +
+		'├────────────────────────┼───────────────────┼────────────────────────────────┼────────────────────────────────────────────────────┤\n' +
+		'│ outputModulation       │ Output Modulation │ Power supply output modulation │ The {{attribute}} of {{device.label}} is {{value}} │\n' +
+		'│ outputModulation.50hz  │ 50 Hz             │                                │                                                    │\n' +
+		'│ outputModulation.60hz  │ 60 Hz             │                                │                                                    │\n' +
 		'└────────────────────────┴───────────────────┴────────────────────────────────┴────────────────────────────────────────────────────┘',
-		'',
-		'Commands:',
-		'┌──────────────────────────────────────┬───────────────────────┬──────────────────────────────────────────────────┐',
-		'│ Name                                 │ Label                 │ Description                                      │',
-		'├──────────────────────────────────────┼───────────────────────┼──────────────────────────────────────────────────┤',
-		'│ setOutputModulation                  │ Set Output Modulation │ Set the output modulation to the specified value │',
-		'│ setOutputModulation.outputModulation │ Output Modulation     │ The desired output modulation                    │',
+		'Commands\n' +
+		'┌──────────────────────────────────────┬───────────────────────┬──────────────────────────────────────────────────┐\n' +
+		'│ Name                                 │ Label                 │ Description                                      │\n' +
+		'├──────────────────────────────────────┼───────────────────────┼──────────────────────────────────────────────────┤\n' +
+		'│ setOutputModulation                  │ Set Output Modulation │ Set the output modulation to the specified value │\n' +
+		'│ setOutputModulation.outputModulation │ Output Modulation     │ The desired output modulation                    │\n' +
 		'└──────────────────────────────────────┴───────────────────────┴──────────────────────────────────────────────────┘',
 	]
 
@@ -155,11 +150,11 @@ export default class CapabilityTranslationsCommand extends APIOrganizationComman
 
 		let preselectedId: CapabilityId | undefined = undefined
 		let preselectedTag: string | undefined = undefined
-		if (this.argv.length === 3) {
+		if (this.args.tag) {
 			// capabilityId, capabilityVersion, tag
 			preselectedId = { id: this.args.id, version: this.args.version }
 			preselectedTag = this.args.tag
-		} else if (this.argv.length === 2) {
+		} else if (this.args.version) {
 			if (isNaN(this.args.id) && !isNaN(this.args.version)) {
 				// capabilityId, capabilityVersion, no tag specified
 				preselectedId = { id: this.args.id, version: this.args.version }

--- a/packages/cli/src/commands/capabilities/translations/create.ts
+++ b/packages/cli/src/commands/capabilities/translations/create.ts
@@ -18,50 +18,49 @@ export default class CapabilityTranslationsCreateCommand extends APIOrganization
 
 	static examples = [
 		'$ smartthings capabilities:translations:create custom1.outputModulation 1 -i en.yaml ',
-		'tag: en',
-		'label: Output Modulation',
-		'attributes:',
-		'  outputModulation:',
-		'    label: Output Modulation',
-		'    displayTemplate: \'The {{attribute}} of {{device.label}} is {{value}}\'',
-		'    i18n:',
-		'      value:',
-		'        50hz:',
-		'          label: 50 Hz',
-		'        60hz:',
-		'          label: 60 Hz',
-		'commands:',
-		'  setOutputModulation:',
-		'    label: Set Output Modulation',
-		'    arguments:',
-		'      outputModulation:',
+		'tag: en\n' +
+		'label: Output Modulation\n' +
+		'attributes:\n' +
+		'  outputModulation:\n' +
+		'    label: Output Modulation\n' +
+		'    displayTemplate: \'The {{attribute}} of {{device.label}} is {{value}}\'\n' +
+		'    i18n:\n' +
+		'      value:\n' +
+		'        50hz:\n' +
+		'          label: 50 Hz\n' +
+		'        60hz:\n' +
+		'          label: 60 Hz\n' +
+		'commands:\n' +
+		'  setOutputModulation:\n' +
+		'    label: Set Output Modulation\n' +
+		'    arguments:\n' +
+		'      outputModulation:\n' +
 		'        label: Output Modulation',
-		'',
 		'$ smartthings capabilities:translations:create -i en.yaml',
-		'┌───┬─────────────────────────────┬─────────┬──────────┐',
-		'│ # │ Id                          │ Version │ Status   │',
-		'├───┼─────────────────────────────┼─────────┼──────────┤',
-		'│ 1 │ custom1.outputModulation    │ 1       │ proposed │',
-		'│ 2 │ custom1.outputVoltage       │ 1       │ proposed │',
+		'┌───┬─────────────────────────────┬─────────┬──────────┐\n' +
+		'│ # │ Id                          │ Version │ Status   │\n' +
+		'├───┼─────────────────────────────┼─────────┼──────────┤\n' +
+		'│ 1 │ custom1.outputModulation    │ 1       │ proposed │\n' +
+		'│ 2 │ custom1.outputVoltage       │ 1       │ proposed │\n' +
 		'└───┴─────────────────────────────┴─────────┴──────────┘',
 		'? Enter id or index 1',
-		'tag: en',
-		'label: Output Modulation',
-		'attributes:',
-		'  outputModulation:',
-		'    label: Output Modulation',
-		'    displayTemplate: \'The {{attribute}} of {{device.label}} is {{value}}\'',
-		'    i18n:',
-		'      value:',
-		'        50hz:',
-		'          label: 50 Hz',
-		'        60hz:',
-		'          label: 60 Hz',
-		'commands:',
-		'  setOutputModulation:',
-		'    label: Set Output Modulation',
-		'    arguments:',
-		'      outputModulation:',
+		'tag: en\n' +
+		'label: Output Modulation\n' +
+		'attributes:\n' +
+		'  outputModulation:\n' +
+		'    label: Output Modulation\n' +
+		'    displayTemplate: \'The {{attribute}} of {{device.label}} is {{value}}\'\n' +
+		'    i18n:\n' +
+		'      value:\n' +
+		'        50hz:\n' +
+		'          label: 50 Hz\n' +
+		'        60hz:\n' +
+		'          label: 60 Hz\n' +
+		'commands:\n' +
+		'  setOutputModulation:\n' +
+		'    label: Set Output Modulation\n' +
+		'    arguments:\n' +
+		'      outputModulation:\n' +
 		'        label: Output Modulation',
 	]
 

--- a/packages/cli/src/commands/capabilities/translations/update.ts
+++ b/packages/cli/src/commands/capabilities/translations/update.ts
@@ -18,50 +18,49 @@ export default class CapabilityTranslationsUpdateCommand extends APIOrganization
 
 	static examples = [
 		'$ smartthings capabilities:translations:update custom1.outputModulation 1 -i en.yaml ',
-		'tag: en',
-		'label: Output Modulation',
-		'attributes:',
-		'  outputModulation:',
-		'    label: Output Modulation',
-		'    displayTemplate: \'The {{attribute}} of {{device.label}} is {{value}}\'',
-		'    i18n:',
-		'      value:',
-		'        50hz:',
-		'          label: 50 Hz',
-		'        60hz:',
-		'          label: 60 Hz',
-		'commands:',
-		'  setOutputModulation:',
-		'    label: Set Output Modulation',
-		'    arguments:',
-		'      outputModulation:',
+		'tag: en\n' +
+		'label: Output Modulation\n' +
+		'attributes:\n' +
+		'  outputModulation:\n' +
+		'    label: Output Modulation\n' +
+		'    displayTemplate: \'The {{attribute}} of {{device.label}} is {{value}}\'\n' +
+		'    i18n:\n' +
+		'      value:\n' +
+		'        50hz:\n' +
+		'          label: 50 Hz\n' +
+		'        60hz:\n' +
+		'          label: 60 Hz\n' +
+		'commands:\n' +
+		'  setOutputModulation:\n' +
+		'    label: Set Output Modulation\n' +
+		'    arguments:\n' +
+		'      outputModulation:\n' +
 		'        label: Output Modulation',
-		'',
 		'$ smartthings capabilities:translations:update -i en.yaml',
-		'┌───┬─────────────────────────────┬─────────┬──────────┐',
-		'│ # │ Id                          │ Version │ Status   │',
-		'├───┼─────────────────────────────┼─────────┼──────────┤',
-		'│ 1 │ custom1.outputModulation    │ 1       │ proposed │',
-		'│ 2 │ custom1.outputVoltage       │ 1       │ proposed │',
+		'┌───┬─────────────────────────────┬─────────┬──────────┐\n' +
+		'│ # │ Id                          │ Version │ Status   │\n' +
+		'├───┼─────────────────────────────┼─────────┼──────────┤\n' +
+		'│ 1 │ custom1.outputModulation    │ 1       │ proposed │\n' +
+		'│ 2 │ custom1.outputVoltage       │ 1       │ proposed │\n' +
 		'└───┴─────────────────────────────┴─────────┴──────────┘',
 		'? Enter id or index 1',
-		'tag: en',
-		'label: Output Modulation',
-		'attributes:',
-		'  outputModulation:',
-		'    label: Output Modulation',
-		'    displayTemplate: \'The {{attribute}} of {{device.label}} is {{value}}\'',
-		'    i18n:',
-		'      value:',
-		'        50hz:',
-		'          label: 50 Hz',
-		'        60hz:',
-		'          label: 60 Hz',
-		'commands:',
-		'  setOutputModulation:',
-		'    label: Set Output Modulation',
-		'    arguments:',
-		'      outputModulation:',
+		'tag: en\n' +
+		'label: Output Modulation\n' +
+		'attributes:\n' +
+		'  outputModulation:\n' +
+		'    label: Output Modulation\n' +
+		'    displayTemplate: \'The {{attribute}} of {{device.label}} is {{value}}\'\n' +
+		'    i18n:\n' +
+		'      value:\n' +
+		'        50hz:\n' +
+		'          label: 50 Hz\n' +
+		'        60hz:\n' +
+		'          label: 60 Hz\n' +
+		'commands:\n' +
+		'  setOutputModulation:\n' +
+		'    label: Set Output Modulation\n' +
+		'    arguments:\n' +
+		'      outputModulation:\n' +
 		'        label: Output Modulation',
 	]
 

--- a/packages/cli/src/commands/capabilities/translations/upsert.ts
+++ b/packages/cli/src/commands/capabilities/translations/upsert.ts
@@ -18,50 +18,49 @@ export default class CapabilityTranslationsUpsertCommand extends APIOrganization
 
 	static examples = [
 		'$ smartthings capabilities:translations:upsert custom1.outputModulation 1 -i en.yaml ',
-		'tag: en',
-		'label: Output Modulation',
-		'attributes:',
-		'  outputModulation:',
-		'    label: Output Modulation',
-		'    displayTemplate: \'The {{attribute}} of {{device.label}} is {{value}}\'',
-		'    i18n:',
-		'      value:',
-		'        50hz:',
-		'          label: 50 Hz',
-		'        60hz:',
-		'          label: 60 Hz',
-		'commands:',
-		'  setOutputModulation:',
-		'    label: Set Output Modulation',
-		'    arguments:',
-		'      outputModulation:',
+		'tag: en\n' +
+		'label: Output Modulation\n' +
+		'attributes:\n' +
+		'  outputModulation:\n' +
+		'    label: Output Modulation\n' +
+		'    displayTemplate: \'The {{attribute}} of {{device.label}} is {{value}}\'\n' +
+		'    i18n:\n' +
+		'      value:\n' +
+		'        50hz:\n' +
+		'          label: 50 Hz\n' +
+		'        60hz:\n' +
+		'          label: 60 Hz\n' +
+		'commands:\n' +
+		'  setOutputModulation:\n' +
+		'    label: Set Output Modulation\n' +
+		'    arguments:\n' +
+		'      outputModulation:\n' +
 		'        label: Output Modulation',
-		'',
 		'$ smartthings capabilities:translations:upsert -i en.yaml',
-		'┌───┬─────────────────────────────┬─────────┬──────────┐',
-		'│ # │ Id                          │ Version │ Status   │',
-		'├───┼─────────────────────────────┼─────────┼──────────┤',
-		'│ 1 │ custom1.outputModulation    │ 1       │ proposed │',
-		'│ 2 │ custom1.outputVoltage       │ 1       │ proposed │',
+		'┌───┬─────────────────────────────┬─────────┬──────────┐\n' +
+		'│ # │ Id                          │ Version │ Status   │\n' +
+		'├───┼─────────────────────────────┼─────────┼──────────┤\n' +
+		'│ 1 │ custom1.outputModulation    │ 1       │ proposed │\n' +
+		'│ 2 │ custom1.outputVoltage       │ 1       │ proposed │\n' +
 		'└───┴─────────────────────────────┴─────────┴──────────┘',
 		'? Enter id or index 1',
-		'tag: en',
-		'label: Output Modulation',
-		'attributes:',
-		'  outputModulation:',
-		'    label: Output Modulation',
-		'    displayTemplate: \'The {{attribute}} of {{device.label}} is {{value}}\'',
-		'    i18n:',
-		'      value:',
-		'        50hz:',
-		'          label: 50 Hz',
-		'        60hz:',
-		'          label: 60 Hz',
-		'commands:',
-		'  setOutputModulation:',
-		'    label: Set Output Modulation',
-		'    arguments:',
-		'      outputModulation:',
+		'tag: en\n' +
+		'label: Output Modulation\n' +
+		'attributes:\n' +
+		'  outputModulation:\n' +
+		'    label: Output Modulation\n' +
+		'    displayTemplate: \'The {{attribute}} of {{device.label}} is {{value}}\'\n' +
+		'    i18n:\n' +
+		'      value:\n' +
+		'        50hz:\n' +
+		'          label: 50 Hz\n' +
+		'        60hz:\n' +
+		'          label: 60 Hz\n' +
+		'commands:\n' +
+		'  setOutputModulation:\n' +
+		'    label: Set Output Modulation\n' +
+		'    arguments:\n' +
+		'      outputModulation:\n' +
 		'        label: Output Modulation',
 	]
 


### PR DESCRIPTION
Fixed bug where capability translations were not output correctly in json and yaml formats

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
