### PR TITLE
refactor: move installedschema utilities into -util file

### DIFF
--- a/packages/cli/src/__tests__/lib/commands/installeddschema-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/installeddschema-util.test.ts
@@ -1,0 +1,84 @@
+import { InstalledSchemaApp, LocationsEndpoint, SchemaEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
+
+import { withLocations } from '@smartthings/cli-lib'
+
+import { installedSchemaInstances } from '../../../lib/commands/installedschema-util'
+
+
+describe('installedSchemaInstances', () => {
+	const listMock = jest.fn()
+	const locations = {
+		list: listMock,
+	} as unknown as LocationsEndpoint
+	const installedAppsMock = jest.fn()
+	const schema = {
+		installedApps: installedAppsMock,
+	} as unknown as SchemaEndpoint
+	const client = {
+		locations,
+		schema,
+	} as SmartThingsClient
+
+	const withLocationsMock = jest.mocked(withLocations)
+
+	const installedApp1 = { appName: 'Installed App 1', locationId: 'location-id-1' } as InstalledSchemaApp
+	const installedApp2 = { appName: 'Installed App 2', locationId: 'location-id-1' } as InstalledSchemaApp
+	const installedApp3 = { appName: 'Installed App 3', locationId: 'location-id-2' } as InstalledSchemaApp
+
+	it('returns installed apps for specified locations', async () => {
+		installedAppsMock.mockResolvedValueOnce([installedApp1])
+
+		expect(await installedSchemaInstances(client, ['location-id'], false)).toStrictEqual([installedApp1])
+
+		expect(listMock).toHaveBeenCalledTimes(0)
+		expect(installedAppsMock).toHaveBeenCalledTimes(1)
+		expect(installedAppsMock).toHaveBeenCalledWith('location-id')
+		expect(withLocationsMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('returns installed apps for all locations when no locations specified', async () => {
+		listMock.mockResolvedValueOnce([{ locationId: 'location-id-1' }, { locationId: 'location-id-2' }])
+		installedAppsMock.mockResolvedValueOnce([installedApp1, installedApp2])
+		installedAppsMock.mockResolvedValueOnce([installedApp3])
+
+		expect(await installedSchemaInstances(client, undefined, false))
+			.toStrictEqual([installedApp1, installedApp2, installedApp3])
+
+		expect(listMock).toHaveBeenCalledTimes(1)
+		expect(listMock).toHaveBeenCalledWith()
+		expect(installedAppsMock).toHaveBeenCalledTimes(2)
+		expect(installedAppsMock).toHaveBeenCalledWith('location-id-1')
+		expect(installedAppsMock).toHaveBeenCalledWith('location-id-2')
+		expect(withLocationsMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('returns installed apps for all locations when no locations specified via empty array', async () => {
+		listMock.mockResolvedValueOnce([{ locationId: 'location-id-1' }, { locationId: 'location-id-2' }])
+		installedAppsMock.mockResolvedValueOnce([installedApp1, installedApp2])
+		installedAppsMock.mockResolvedValueOnce([installedApp3])
+
+		expect(await installedSchemaInstances(client, [], false))
+			.toStrictEqual([installedApp1, installedApp2, installedApp3])
+
+		expect(listMock).toHaveBeenCalledTimes(1)
+		expect(listMock).toHaveBeenCalledWith()
+		expect(installedAppsMock).toHaveBeenCalledTimes(2)
+		expect(installedAppsMock).toHaveBeenCalledWith('location-id-1')
+		expect(installedAppsMock).toHaveBeenCalledWith('location-id-2')
+		expect(withLocationsMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('returns installed apps with locations when verbose is specified', async () => {
+		const installedApp1WithLocation = { ...installedApp1, location: 'Location 1' }
+		installedAppsMock.mockResolvedValueOnce([installedApp1])
+		withLocationsMock.mockResolvedValueOnce([installedApp1WithLocation])
+
+		expect(await installedSchemaInstances(client, ['location-id'], true)).toStrictEqual([installedApp1WithLocation])
+
+		expect(listMock).toHaveBeenCalledTimes(0)
+		expect(installedAppsMock).toHaveBeenCalledTimes(1)
+		expect(installedAppsMock).toHaveBeenCalledWith('location-id')
+		expect(withLocationsMock).toHaveBeenCalledTimes(1)
+		expect(withLocationsMock).toHaveBeenCalledWith(client, [installedApp1])
+	})
+})

--- a/packages/cli/src/commands/installedschema.ts
+++ b/packages/cli/src/commands/installedschema.ts
@@ -1,36 +1,16 @@
 import { Flags } from '@oclif/core'
 
-import { InstalledSchemaApp, SmartThingsClient } from '@smartthings/core-sdk'
+import { InstalledSchemaApp } from '@smartthings/core-sdk'
 
-import { APICommand, OutputItemOrListConfig, outputItemOrList, TableFieldDefinition, withLocations } from '@smartthings/cli-lib'
+import { APICommand, OutputItemOrListConfig, outputItemOrList } from '@smartthings/cli-lib'
 
+import {
+	InstalledSchemaAppWithLocation,
+	installedSchemaInstances,
+	listTableFieldDefinitions,
+	tableFieldDefinitions,
+} from '../lib/commands/installedschema-util'
 
-export type InstalledSchemaAppWithLocation = InstalledSchemaApp & { location?: string }
-
-export const listTableFieldDefinitions = ['appName', 'partnerName', 'partnerSTConnection', 'isaId']
-export const tableFieldDefinitions: TableFieldDefinition<InstalledSchemaApp>[] = [
-	'appName', 'isaId', 'partnerName', 'partnerSTConnection', 'locationId',
-	'icon', 'icon2x', 'icon3x',
-]
-
-export async function installedSchemaInstances(client: SmartThingsClient, locationIds: string[], verbose: boolean): Promise<InstalledSchemaAppWithLocation[]> {
-	if (!locationIds) {
-		locationIds = (await client.locations.list()).map(it => it.locationId)
-	}
-
-	const installedApps = (await Promise.all(locationIds.map(async (locationId) => {
-		try {
-			return (await client.schema.installedApps(locationId))
-		} catch(e) {
-			return []
-		}
-	}))).flat()
-
-	if (verbose) {
-		return await withLocations(client, installedApps)
-	}
-	return installedApps
-}
 
 export default class InstalledSchemaAppsCommand extends APICommand<typeof InstalledSchemaAppsCommand.flags> {
 	static description = 'get a specific schema connector instance or a list of instances'
@@ -62,8 +42,10 @@ export default class InstalledSchemaAppsCommand extends APICommand<typeof Instal
 			listTableFieldDefinitions,
 			tableFieldDefinitions,
 		}
+
 		if (this.flags.verbose) {
 			config.listTableFieldDefinitions.splice(3, 0, 'location')
+			config.tableFieldDefinitions.splice(5, 0, 'location')
 		}
 
 		await outputItemOrList(this, config, this.args.id,

--- a/packages/cli/src/commands/installedschema/delete.ts
+++ b/packages/cli/src/commands/installedschema/delete.ts
@@ -4,7 +4,7 @@ import { InstalledSchemaApp } from '@smartthings/core-sdk'
 
 import { APICommand, selectFromList, SelectFromListConfig } from '@smartthings/cli-lib'
 
-import { installedSchemaInstances } from '../installedschema'
+import { installedSchemaInstances } from '../../lib/commands/installedschema-util'
 
 
 export default class InstalledSchemaAppDeleteCommand extends APICommand<typeof InstalledSchemaAppDeleteCommand.flags> {

--- a/packages/cli/src/lib/commands/installedschema-util.ts
+++ b/packages/cli/src/lib/commands/installedschema-util.ts
@@ -1,0 +1,24 @@
+import { InstalledSchemaApp, SmartThingsClient } from '@smartthings/core-sdk'
+
+import { TableFieldDefinition, withLocations, WithNamedLocation } from '@smartthings/cli-lib'
+
+
+export type InstalledSchemaAppWithLocation = InstalledSchemaApp & { location?: string }
+
+export const listTableFieldDefinitions = ['appName', 'partnerName', 'partnerSTConnection', 'isaId']
+export const tableFieldDefinitions: TableFieldDefinition<InstalledSchemaApp>[] = [
+	'appName', 'isaId', 'partnerName', 'partnerSTConnection', 'locationId',
+	'icon', 'icon2x', 'icon3x',
+]
+
+export const installedSchemaInstances = async (client: SmartThingsClient, locationIds: string[] | undefined, verbose: boolean): Promise<(InstalledSchemaApp & WithNamedLocation)[]> => {
+	// We accept and handle undefined locationIds because that's what we get from oclif even
+	// though the type is just `string[]`.
+	if (!locationIds || locationIds.length == 0) {
+		locationIds = (await client.locations.list()).map(it => it.locationId)
+	}
+
+	const installedApps = (await Promise.all(locationIds.map(locationId => client.schema.installedApps(locationId)))).flat()
+
+	return verbose ? await withLocations(client, installedApps) : installedApps
+}


### PR DESCRIPTION
<!-- Describe your pull request. -->

moved installedschema utilities into -util file

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
