### PR TITLE
feat: support verbose flag for installedapps and installedschema commands with single item

### DIFF
--- a/.changeset/stupid-jeans-grab.md
+++ b/.changeset/stupid-jeans-grab.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+include location name for installedapps and installedschema when querying a single item in verbose mode

--- a/.changeset/wise-baboons-build.md
+++ b/.changeset/wise-baboons-build.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli-lib": patch
+---
+
+added `withLocation` function to add location information to single item (similar to `withLocations` for multiple items)

--- a/packages/cli/src/__tests__/commands/installedapps.test.ts
+++ b/packages/cli/src/__tests__/commands/installedapps.test.ts
@@ -1,5 +1,7 @@
-import { outputItemOrList, withLocations, WithNamedLocation } from '@smartthings/cli-lib'
 import { InstalledApp, InstalledAppsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
+
+import { outputItemOrList, withLocation, withLocations, WithNamedLocation } from '@smartthings/cli-lib'
+
 import InstalledAppsCommand from '../../commands/installedapps'
 import { listTableFieldDefinitions, tableFieldDefinitions } from '../../lib/commands/installedapps-util'
 
@@ -16,6 +18,7 @@ describe('InstalledAppsCommand', () => {
 	const listSpy = jest.spyOn(InstalledAppsEndpoint.prototype, 'list').mockImplementation()
 
 	const outputItemOrListMock = jest.mocked(outputItemOrList)
+	const withLocationMock = jest.mocked(withLocation)
 	const withLocationsMock = jest.mocked(withLocations)
 
 	it('calls outputItemOrList with correct config', async () => {
@@ -80,13 +83,13 @@ describe('InstalledAppsCommand', () => {
 		await expect(InstalledAppsCommand.run(['--verbose'])).resolves.not.toThrow()
 
 		expect(outputItemOrListMock).toBeCalledWith(
-			expect.anything(),
+			expect.any(InstalledAppsCommand),
 			expect.objectContaining({
-				listTableFieldDefinitions: expect.arrayContaining(['location']),
+				listTableFieldDefinitions: expect.arrayContaining(['locationId', 'location']),
 			}),
 			undefined,
-			expect.anything(),
-			expect.anything(),
+			expect.any(Function),
+			expect.any(Function),
 		)
 
 		const expectedList = [MOCK_INSTALLED_APP_WITH_LOCATION]
@@ -102,5 +105,31 @@ describe('InstalledAppsCommand', () => {
 			expect.any(SmartThingsClient),
 			MOCK_INSTALLED_APP_LIST,
 		)
+	})
+
+	it('includes location name when verbose flag is used for a single app', async () => {
+		await expect(InstalledAppsCommand.run(['--verbose', 'installed-app-id-from-arg'])).resolves.not.toThrow()
+
+		expect(outputItemOrListMock).toBeCalledWith(
+			expect.any(InstalledAppsCommand),
+			expect.objectContaining({
+				tableFieldDefinitions: expect.arrayContaining(['location']),
+			}),
+			'installed-app-id-from-arg',
+			expect.any(Function),
+			expect.any(Function),
+		)
+
+		getSpy.mockResolvedValueOnce(MOCK_INSTALLED_APP)
+		withLocationMock.mockResolvedValueOnce(MOCK_INSTALLED_APP_WITH_LOCATION)
+
+		const getFunction = outputItemOrListMock.mock.calls[0][4]
+
+		await expect(getFunction('installed-app-id')).resolves.toBe(MOCK_INSTALLED_APP_WITH_LOCATION)
+
+		expect(getSpy).toBeCalledTimes(1)
+		expect(getSpy).toBeCalledWith('installed-app-id')
+		expect(withLocationMock).toBeCalledTimes(1)
+		expect(withLocationMock).toBeCalledWith(expect.any(SmartThingsClient), MOCK_INSTALLED_APP)
 	})
 })

--- a/packages/cli/src/__tests__/commands/installedschema.test.ts
+++ b/packages/cli/src/__tests__/commands/installedschema.test.ts
@@ -1,0 +1,139 @@
+import { SchemaApp, SchemaEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
+
+import { outputItemOrList, withLocation } from '@smartthings/cli-lib'
+
+import InstalledSchemaAppsCommand from '../../commands/installedschema'
+import { installedSchemaInstances } from '../../lib/commands/installedschema-util'
+
+
+jest.mock('../../lib/commands/installedschema-util', () => {
+	const originalLib = jest.requireActual('../../lib/commands/installedschema-util')
+
+	return {
+		...originalLib,
+		installedSchemaInstances: jest.fn(),
+	}
+})
+
+describe('InstalledSchemaAppsCommand', () => {
+	const outputItemOrListMock = jest.mocked(outputItemOrList)
+	const withLocationMock = jest.mocked(withLocation)
+
+	const getInstalledAppSpy = jest.spyOn(SchemaEndpoint.prototype, 'getInstalledApp').mockImplementation()
+
+	const installedSchemaInstancesMock = jest.mocked(installedSchemaInstances)
+
+	const schemaApp = { appName: 'A Schema App' } as SchemaApp
+	const schemaApps = [schemaApp]
+	const schemaAppWithLocation = { ...schemaApp, location: 'Location Name' }
+
+	it('lists schema apps', async () => {
+		await expect(InstalledSchemaAppsCommand.run([])).resolves.not.toThrow()
+
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(InstalledSchemaAppsCommand),
+			expect.objectContaining({
+				primaryKeyName: 'isaId',
+				listTableFieldDefinitions: expect.not.arrayContaining(['location']),
+				tableFieldDefinitions: expect.not.arrayContaining(['location']),
+			}),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+		)
+
+		installedSchemaInstancesMock.mockResolvedValueOnce(schemaApps)
+
+		const listFunction = outputItemOrListMock.mock.calls[0][3]
+
+		expect(await listFunction()).toBe(schemaApps)
+
+		expect(installedSchemaInstancesMock).toHaveBeenCalledTimes(1)
+		expect(installedSchemaInstancesMock)
+			.toHaveBeenCalledWith(expect.any(SmartThingsClient), undefined, undefined)
+	})
+
+	it('includes location with verbose flag', async () => {
+		await expect(InstalledSchemaAppsCommand.run(['--verbose'])).resolves.not.toThrow()
+
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(InstalledSchemaAppsCommand),
+			expect.objectContaining({
+				primaryKeyName: 'isaId',
+				listTableFieldDefinitions: expect.arrayContaining(['locationId', 'location']),
+				tableFieldDefinitions: expect.arrayContaining(['locationId', 'location']),
+			}),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+		)
+
+		installedSchemaInstancesMock.mockResolvedValueOnce(schemaApps)
+
+		const listFunction = outputItemOrListMock.mock.calls[0][3]
+
+		expect(await listFunction()).toBe(schemaApps)
+
+		expect(installedSchemaInstancesMock).toHaveBeenCalledTimes(1)
+		expect(installedSchemaInstancesMock)
+			.toHaveBeenCalledWith(expect.any(SmartThingsClient), undefined, true)
+	})
+
+	it('displays single schema app', async () => {
+		await expect(InstalledSchemaAppsCommand.run(['id-from-command-line'])).resolves.not.toThrow()
+
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(InstalledSchemaAppsCommand),
+			expect.objectContaining({
+				primaryKeyName: 'isaId',
+				listTableFieldDefinitions: expect.not.arrayContaining(['location']),
+				tableFieldDefinitions: expect.not.arrayContaining(['location']),
+			}),
+			'id-from-command-line',
+			expect.any(Function),
+			expect.any(Function),
+		)
+
+		getInstalledAppSpy.mockResolvedValueOnce(schemaApp)
+
+		const getFunction = outputItemOrListMock.mock.calls[0][4]
+
+		expect(await getFunction('installed-app-id')).toBe(schemaApp)
+
+		expect(getInstalledAppSpy).toHaveBeenCalledTimes(1)
+		expect(getInstalledAppSpy).toHaveBeenCalledWith('installed-app-id')
+		expect(withLocationMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('includes location with verbose flag for single app', async () => {
+		await expect(InstalledSchemaAppsCommand.run(['--verbose', 'id-from-command-line'])).resolves.not.toThrow()
+
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(InstalledSchemaAppsCommand),
+			expect.objectContaining({
+				primaryKeyName: 'isaId',
+				listTableFieldDefinitions: expect.arrayContaining(['locationId', 'location']),
+				tableFieldDefinitions: expect.arrayContaining(['locationId', 'location']),
+			}),
+			'id-from-command-line',
+			expect.any(Function),
+			expect.any(Function),
+		)
+
+		getInstalledAppSpy.mockResolvedValueOnce(schemaApp)
+		withLocationMock.mockResolvedValue(schemaAppWithLocation)
+
+		const getFunction = outputItemOrListMock.mock.calls[0][4]
+
+		expect(await getFunction('installed-app-id')).toBe(schemaAppWithLocation)
+
+		expect(getInstalledAppSpy).toHaveBeenCalledTimes(1)
+		expect(getInstalledAppSpy).toHaveBeenCalledWith('installed-app-id')
+		expect(withLocationMock).toHaveBeenCalledTimes(1)
+		expect(withLocationMock).toHaveBeenCalledWith(expect.any(SmartThingsClient), schemaApp)
+	})
+})

--- a/packages/cli/src/lib/commands/installedapps-util.ts
+++ b/packages/cli/src/lib/commands/installedapps-util.ts
@@ -2,8 +2,6 @@ import { TableFieldDefinition } from '@smartthings/cli-lib'
 import { InstalledApp } from '@smartthings/core-sdk'
 
 
-export type InstalledAppWithLocation = InstalledApp & { location?: string }
-
 export const listTableFieldDefinitions = ['displayName', 'installedAppType', 'installedAppStatus', 'installedAppId']
 
 export const tableFieldDefinitions: TableFieldDefinition<InstalledApp>[] = [

--- a/packages/cli/src/lib/commands/installedschema-util.ts
+++ b/packages/cli/src/lib/commands/installedschema-util.ts
@@ -3,8 +3,6 @@ import { InstalledSchemaApp, SmartThingsClient } from '@smartthings/core-sdk'
 import { TableFieldDefinition, withLocations, WithNamedLocation } from '@smartthings/cli-lib'
 
 
-export type InstalledSchemaAppWithLocation = InstalledSchemaApp & { location?: string }
-
 export const listTableFieldDefinitions = ['appName', 'partnerName', 'partnerSTConnection', 'isaId']
 export const tableFieldDefinitions: TableFieldDefinition<InstalledSchemaApp>[] = [
 	'appName', 'isaId', 'partnerName', 'partnerSTConnection', 'locationId',

--- a/packages/testlib/src/index.ts
+++ b/packages/testlib/src/index.ts
@@ -19,6 +19,7 @@ jest.mock('@smartthings/cli-lib', () => {
 		outputItem: jest.fn(),
 		resetManagedConfig: jest.fn(),
 		formatAndWriteItem: jest.fn(),
+		withLocation: jest.fn(),
 		withLocations: jest.fn(),
 		withLocationsAndRooms: jest.fn(),
 		yamlExists: jest.fn(),


### PR DESCRIPTION
* added `withLocation` to add location to a single item (matches/uses `withLocations` which does the same for a list)
* support verbose flag for installedapps and installedschema commands with single item
* added tests for installedschema command
* removed `InstalledAppWithLocation` and `InstalledSchemaAppWithLocation` in favor of `WithNamedLocation`

<!-- Describe your pull request. -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
