### PR TITLE
feat: add support for removing managed config values

### DIFF
--- a/.changeset/two-emus-study.md
+++ b/.changeset/two-emus-study.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli-lib": patch
+---
+
+added support for removing managed config values

--- a/packages/testlib/src/index.ts
+++ b/packages/testlib/src/index.ts
@@ -29,6 +29,7 @@ jest.mock('@smartthings/cli-lib', () => {
 		calculateOutputFormat: jest.fn(),
 		writeOutput: jest.fn(),
 		buildOutputFormatter: jest.fn(),
+		resetManagedConfigKey: jest.fn(),
 	}
 })
 


### PR DESCRIPTION
<!-- Describe your pull request. -->

Added support for removing managed config values. This will be used by the edge plugin when deleting a channel. Draft pull request for that here:

https://github.com/SmartThingsCommunity/edge-cli-plugin/pull/59

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ x I have added tests to cover my changes
