### PR TITLE
refactor: update rooms and rules to use standard WithNamedLocation instead of special objects

### DIFF
--- a/packages/cli/src/__tests__/commands/locations/rooms.test.ts
+++ b/packages/cli/src/__tests__/commands/locations/rooms.test.ts
@@ -1,10 +1,18 @@
-import { outputItemOrList, withLocations } from '@smartthings/cli-lib'
-import { RoomsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
+import { Room, RoomsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
+
+import { outputItemOrList, withLocations, WithNamedLocation } from '@smartthings/cli-lib'
+
 import RoomsCommand from '../../../commands/locations/rooms'
-import { getRoomsByLocation, RoomWithLocation } from '../../../lib/commands/locations/rooms-util'
+import { getRoomsByLocation } from '../../../lib/commands/locations/rooms-util'
 
 
-jest.mock('../../../lib/commands/locations/rooms-util')
+jest.mock('../../../lib/commands/locations/rooms-util', () => {
+	const originalLib = jest.requireActual('../../../lib/commands/locations/rooms-util')
+	return {
+		...originalLib,
+		getRoomsByLocation: jest.fn(),
+	}
+})
 
 describe('RoomsCommand', () => {
 	const roomId = 'roomId'
@@ -35,11 +43,11 @@ describe('RoomsCommand', () => {
 	})
 
 	it('returns rooms in list function', async () => {
-		const roomList: RoomWithLocation[] = [
+		const roomList: (Room & WithNamedLocation)[] = [
 			{
 				locationId: locationId,
 				roomId: roomId,
-				locationName: 'test',
+				location: 'test',
 			},
 		]
 		mockGetRoomsByLocation.mockResolvedValueOnce(roomList)
@@ -53,11 +61,11 @@ describe('RoomsCommand', () => {
 	})
 
 	it('calls correct get endpoint when room id is found', async () => {
-		const roomList: RoomWithLocation[] = [
+		const roomList: (Room & WithNamedLocation)[] = [
 			{
 				locationId: locationId,
 				roomId: roomId,
-				locationName: 'test',
+				location: 'test',
 			},
 		]
 		mockGetRoomsByLocation.mockResolvedValueOnce(roomList)
@@ -84,11 +92,11 @@ describe('RoomsCommand', () => {
 	})
 
 	it('throws error when room id is not found', async () => {
-		const roomList: RoomWithLocation[] = [
+		const roomList: (Room & WithNamedLocation)[] = [
 			{
 				locationId: locationId,
 				roomId: 'notFound',
-				locationName: 'test',
+				location: 'test',
 			},
 		]
 		mockGetRoomsByLocation.mockResolvedValueOnce(roomList)

--- a/packages/cli/src/__tests__/commands/rules.test.ts
+++ b/packages/cli/src/__tests__/commands/rules.test.ts
@@ -1,15 +1,15 @@
-import { outputItemOrList } from '@smartthings/cli-lib'
-import { SmartThingsClient } from '@smartthings/core-sdk'
+import { outputItemOrList, WithNamedLocation } from '@smartthings/cli-lib'
+import { Rule, SmartThingsClient } from '@smartthings/core-sdk'
 
 import RulesCommand from '../../commands/rules'
-import { getRulesByLocation, getRuleWithLocation, RuleWithLocation } from '../../lib/commands/rules-util'
+import { getRulesByLocation, getRuleWithLocation } from '../../lib/commands/rules-util'
 
 
 jest.mock('../../lib/commands/rules-util')
 
 describe('RulesCommand', () => {
 	const outputItemOrListMock = jest.mocked(outputItemOrList)
-	const ruleWithLocation = { id: 'rule-id' } as RuleWithLocation
+	const ruleWithLocation = { id: 'rule-id' } as Rule & WithNamedLocation
 	const rulesList = [ruleWithLocation]
 	const getRulesByLocationMock = jest.mocked(getRulesByLocation).mockResolvedValue(rulesList)
 	const getRuleWithLocationMock = jest.mocked(getRuleWithLocation).mockResolvedValue(ruleWithLocation)
@@ -21,7 +21,7 @@ describe('RulesCommand', () => {
 		expect(outputItemOrListMock).toHaveBeenCalledWith(expect.any(RulesCommand),
 			expect.objectContaining({
 				primaryKeyName: 'id',
-				listTableFieldDefinitions: expect.arrayContaining(['name', 'id', 'locationId', 'locationName']),
+				listTableFieldDefinitions: expect.arrayContaining(['name', 'id', 'locationId', 'location']),
 			}),
 			undefined, expect.any(Function), expect.any(Function))
 
@@ -38,7 +38,7 @@ describe('RulesCommand', () => {
 		expect(outputItemOrListMock).toHaveBeenCalledWith(expect.any(RulesCommand),
 			expect.objectContaining({
 				primaryKeyName: 'id',
-				listTableFieldDefinitions: expect.arrayContaining(['name', 'id', 'locationId', 'locationName']),
+				listTableFieldDefinitions: expect.arrayContaining(['name', 'id', 'locationId', 'location']),
 			}),
 			'cmd-line-rule-id', expect.any(Function), expect.any(Function))
 
@@ -56,7 +56,7 @@ describe('RulesCommand', () => {
 		expect(outputItemOrListMock).toHaveBeenCalledWith(expect.any(RulesCommand),
 			expect.objectContaining({
 				primaryKeyName: 'id',
-				listTableFieldDefinitions: expect.arrayContaining(['name', 'id', 'locationId', 'locationName']),
+				listTableFieldDefinitions: expect.arrayContaining(['name', 'id', 'locationId', 'location']),
 			}),
 			undefined, expect.any(Function), expect.any(Function))
 

--- a/packages/cli/src/__tests__/commands/rules/delete.test.ts
+++ b/packages/cli/src/__tests__/commands/rules/delete.test.ts
@@ -1,13 +1,15 @@
-import { RulesEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
+import { Rule, RulesEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
+
+import { WithNamedLocation } from '@smartthings/cli-lib'
 
 import RulesDeleteCommand from '../../../commands/rules/delete'
-import { chooseRule, getRuleWithLocation, RuleWithLocation } from '../../../lib/commands/rules-util'
+import { chooseRule, getRuleWithLocation } from '../../../lib/commands/rules-util'
 
 
 jest.mock('../../../lib/commands/rules-util')
 
 describe('RulesDeleteCommand', () => {
-	const ruleWithLocation = { locationId: 'location-id' } as RuleWithLocation
+	const ruleWithLocation = { locationId: 'location-id' } as Rule & WithNamedLocation
 	const chooseRuleMock = jest.mocked(chooseRule)
 	const getRuleWithLocationMock = jest.mocked(getRuleWithLocation).mockResolvedValue(ruleWithLocation)
 

--- a/packages/cli/src/__tests__/commands/rules/execute.test.ts
+++ b/packages/cli/src/__tests__/commands/rules/execute.test.ts
@@ -1,16 +1,16 @@
-import { RulesEndpoint, RuleExecutionResponse, SmartThingsClient } from '@smartthings/core-sdk'
+import { RulesEndpoint, RuleExecutionResponse, SmartThingsClient, Rule } from '@smartthings/core-sdk'
 
-import { CustomCommonOutputProducer, DefaultTableGenerator, formatAndWriteItem } from '@smartthings/cli-lib'
+import { CustomCommonOutputProducer, DefaultTableGenerator, formatAndWriteItem, WithNamedLocation } from '@smartthings/cli-lib'
 
 import RulesExecuteCommand from '../../../commands/rules/execute'
-import { buildExecuteResponseTableOutput, chooseRule, getRuleWithLocation, RuleWithLocation }
+import { buildExecuteResponseTableOutput, chooseRule, getRuleWithLocation }
 	from '../../../lib/commands/rules-util'
 
 
 jest.mock('../../../lib/commands/rules-util')
 
 describe('RulesExecuteCommand', () => {
-	const ruleWithLocation = { locationId: 'location-id' } as RuleWithLocation
+	const ruleWithLocation = { locationId: 'location-id' } as Rule & WithNamedLocation
 	const chooseRuleMock = jest.mocked(chooseRule)
 	const getRuleWithLocationMock = jest.mocked(getRuleWithLocation).mockResolvedValue(ruleWithLocation)
 	const buildExecuteResponseTableOutputMock = jest.mocked(buildExecuteResponseTableOutput)

--- a/packages/cli/src/__tests__/commands/rules/update.test.ts
+++ b/packages/cli/src/__tests__/commands/rules/update.test.ts
@@ -1,8 +1,8 @@
 import { Rule, RuleRequest, RulesEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
 
-import { inputAndOutputItem } from '@smartthings/cli-lib'
+import { inputAndOutputItem, WithNamedLocation } from '@smartthings/cli-lib'
 
-import { chooseRule, getRuleWithLocation, RuleWithLocation } from '../../../lib/commands/rules-util'
+import { chooseRule, getRuleWithLocation } from '../../../lib/commands/rules-util'
 import RulesUpdateCommand from '../../../commands/rules/update'
 
 
@@ -16,7 +16,7 @@ jest.mock('../../../lib/commands/rules-util', () => {
 
 describe('RulesUpdateCommand', () => {
 	const inputAndOutputItemMock = jest.mocked(inputAndOutputItem)
-	const ruleWithLocation = { locationId: 'location-id' } as RuleWithLocation
+	const ruleWithLocation = { locationId: 'location-id' } as Rule & WithNamedLocation
 	const chooseRuleMock = jest.mocked(chooseRule)
 	const getRuleWithLocationMock = jest.mocked(getRuleWithLocation).mockResolvedValue(ruleWithLocation)
 

--- a/packages/cli/src/__tests__/lib/commands/locations/rooms-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/locations/rooms-util.test.ts
@@ -1,8 +1,11 @@
+import { Config } from '@oclif/core'
+
 import { Location, LocationsEndpoint, NoOpAuthenticator, Room, RoomsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
+
+import { APICommand, selectFromList } from '@smartthings/cli-lib'
+
 import { getRoomsByLocation, chooseRoom } from '../../../../lib/commands/locations/rooms-util'
 import * as roomsUtil from '../../../../lib/commands/locations/rooms-util'
-import { Config } from '@oclif/core'
-import { APICommand, selectFromList } from '@smartthings/cli-lib'
 
 
 describe('rooms-util', () => {
@@ -24,9 +27,9 @@ describe('rooms-util', () => {
 			await expect(getRoomsByLocation(testClient, locationId)).rejects.toThrow(forbiddenError)
 		})
 
-		it('returns rooms with locationName added', async () => {
+		it('returns rooms with location added', async () => {
 			const location: Location = {
-				locationId: locationId,
+				locationId,
 				name: 'test',
 				timeZoneId: '',
 				backgroundImage: '',
@@ -35,8 +38,8 @@ describe('rooms-util', () => {
 			}
 			const rooms: Room[] = [
 				{
-					locationId: locationId,
-					roomId: roomId,
+					locationId,
+					roomId,
 				},
 			]
 
@@ -46,7 +49,7 @@ describe('rooms-util', () => {
 			const roomsWithLocations = await getRoomsByLocation(testClient, locationId)
 
 			expect(roomsWithLocations[0]).toEqual(expect.objectContaining(rooms[0]))
-			expect(roomsWithLocations[0].locationName).toBe(location.name)
+			expect(roomsWithLocations[0].location).toBe(location.name)
 		})
 	})
 

--- a/packages/cli/src/__tests__/lib/commands/rules-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/rules-util.test.ts
@@ -1,9 +1,11 @@
 import { Rule, RuleAction, RuleExecutionResponse, SmartThingsClient } from '@smartthings/core-sdk'
 
-import { APICommand, selectFromList, TableGenerator } from '@smartthings/cli-lib'
+import { APICommand, selectFromList, TableGenerator, WithNamedLocation } from '@smartthings/cli-lib'
 
 import {
-	chooseRule, getRulesByLocation, getRuleWithLocation, RuleWithLocation,
+	chooseRule,
+	getRulesByLocation,
+	getRuleWithLocation,
 	tableFieldDefinitions,
 } from '../../../lib/commands/rules-util'
 import * as rulesUtil from '../../../lib/commands/rules-util'
@@ -14,8 +16,8 @@ describe('rules-util', () => {
 	const location2 = { locationId: 'location-id-2', name: 'location-name-2' }
 	const rule1 = { id: 'rule-id-1', name: 'rule-name-1' }
 	const rule2 = { id: 'rule-id-2', name: 'rule-name-2' }
-	const rule1WithLocation = { ...rule1, locationId: 'location-id-1', locationName: 'location-name-1' } as RuleWithLocation
-	const rule2WithLocation = { ...rule2, locationId: 'location-id-2', locationName: 'location-name-2' } as RuleWithLocation
+	const rule1WithLocation = { ...rule1, locationId: 'location-id-1', location: 'location-name-1' } as Rule & WithNamedLocation
+	const rule2WithLocation = { ...rule2, locationId: 'location-id-2', location: 'location-name-2' } as Rule & WithNamedLocation
 
 	const locations = {
 		get: jest.fn(),
@@ -150,11 +152,11 @@ describe('rules-util', () => {
 			}),
 		)
 
-		const ruleWithLocation = { locationId: 'location-id' } as RuleWithLocation
+		const ruleWithLocation = { locationId: 'location-id' } as Rule & WithNamedLocation
 		const rulesList = [ruleWithLocation]
 		const listItems = selectFromListMock.mock.calls[0][2].listItems
 		const getRulesByLocationMock = (getRulesByLocation as
-			jest.Mock<Promise<RuleWithLocation[]>, [SmartThingsClient, string | undefined]>)
+			jest.Mock<Promise<(Rule & WithNamedLocation)[]>, [SmartThingsClient, string | undefined]>)
 			.mockResolvedValue(rulesList)
 
 		expect(await listItems()).toBe(rulesList)

--- a/packages/cli/src/commands/rules.ts
+++ b/packages/cli/src/commands/rules.ts
@@ -1,8 +1,10 @@
 import { Flags } from '@oclif/core'
 
-import { APICommand, outputItemOrList, OutputItemOrListConfig } from '@smartthings/cli-lib'
+import { Rule } from '@smartthings/core-sdk'
 
-import { getRulesByLocation, getRuleWithLocation, RuleWithLocation, tableFieldDefinitions } from '../lib/commands/rules-util'
+import { APICommand, outputItemOrList, OutputItemOrListConfig, WithNamedLocation } from '@smartthings/cli-lib'
+
+import { getRulesByLocation, getRuleWithLocation, tableFieldDefinitions } from '../lib/commands/rules-util'
 
 
 export default class RulesCommand extends APICommand<typeof RulesCommand.flags> {
@@ -24,10 +26,10 @@ export default class RulesCommand extends APICommand<typeof RulesCommand.flags> 
 	}]
 
 	async run(): Promise<void> {
-		const config: OutputItemOrListConfig<RuleWithLocation> = {
+		const config: OutputItemOrListConfig<Rule & WithNamedLocation> = {
 			primaryKeyName: 'id',
 			sortKeyName: 'name',
-			listTableFieldDefinitions: ['name', 'id', 'locationId', 'locationName'],
+			listTableFieldDefinitions: ['name', 'id', 'locationId', 'location'],
 			tableFieldDefinitions,
 		}
 		await outputItemOrList(this, config, this.args.idOrIndex,


### PR DESCRIPTION
Removed `RoomWithLocation` and `RuleWithLocation` in favor of using `WithNamedLocation` interface used elsewhere.

<!-- Describe your pull request. -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
