### PR TITLE
fix: remove "-id" suffix from flags for consistency

### DIFF
--- a/.changeset/early-zoos-speak.md
+++ b/.changeset/early-zoos-speak.md
@@ -1,0 +1,6 @@
+---
+"@smartthings/cli": patch
+"@smartthings/cli-lib": patch
+---
+
+IMPORTANT: removed `-id` suffix from command line flags that had them for consistency

--- a/packages/cli/src/__tests__/commands/apps/authorize.test.ts
+++ b/packages/cli/src/__tests__/commands/apps/authorize.test.ts
@@ -35,7 +35,7 @@ describe('AppsAuthorizeCommand', () => {
 
 	it('calls addPermission with statement-id flag', async () => {
 		const statementId = 'statementId'
-		await expect(AppsAuthorizeCommand.run([arn, `--statement-id=${statementId}`])).resolves.not.toThrow()
+		await expect(AppsAuthorizeCommand.run([arn, `--statement=${statementId}`])).resolves.not.toThrow()
 
 		expect(mockAddPermission).toBeCalledWith(arn, undefined, statementId)
 		expect(logSpy).toBeCalledWith(success)

--- a/packages/cli/src/__tests__/commands/apps/create.test.ts
+++ b/packages/cli/src/__tests__/commands/apps/create.test.ts
@@ -126,7 +126,7 @@ describe('AppCreateCommand', () => {
 		})
 
 		const statementId = 'statementId'
-		await expect(AppCreateCommand.run(['--authorize', `--statement-id=${statementId}`])).resolves.not.toThrow()
+		await expect(AppCreateCommand.run(['--authorize', `--statement=${statementId}`])).resolves.not.toThrow()
 
 		expect(addPermission).toBeCalledWith(arn, undefined, statementId)
 	})

--- a/packages/cli/src/__tests__/commands/apps/update.test.ts
+++ b/packages/cli/src/__tests__/commands/apps/update.test.ts
@@ -136,7 +136,7 @@ describe('AppUpdateCommand', () => {
 		})
 
 		const statementId = 'statementId'
-		await expect(AppUpdateCommand.run(['--authorize', `--statement-id=${statementId}`])).resolves.not.toThrow()
+		await expect(AppUpdateCommand.run(['--authorize', `--statement=${statementId}`])).resolves.not.toThrow()
 
 		expect(addPermission).toBeCalledWith(arn, undefined, statementId)
 	})

--- a/packages/cli/src/__tests__/commands/installedapps.test.ts
+++ b/packages/cli/src/__tests__/commands/installedapps.test.ts
@@ -61,7 +61,7 @@ describe('InstalledAppsCommand', () => {
 	})
 
 	it('accepts location-id flag to filter list', async () => {
-		await expect(InstalledAppsCommand.run(['--location-id=locationId'])).resolves.not.toThrow()
+		await expect(InstalledAppsCommand.run(['--location=locationId'])).resolves.not.toThrow()
 
 		let listFunction = outputItemOrListMock.mock.calls[0][3]
 		await listFunction()

--- a/packages/cli/src/__tests__/commands/locations/rooms.test.ts
+++ b/packages/cli/src/__tests__/commands/locations/rooms.test.ts
@@ -122,7 +122,7 @@ describe('RoomsCommand', () => {
 	})
 
 	it('takes a specific locationId to query via flags', async () => {
-		await expect(RoomsCommand.run([`--location-id=${locationId}`])).resolves.not.toThrow()
+		await expect(RoomsCommand.run([`--location=${locationId}`])).resolves.not.toThrow()
 
 		expect(mockGetRoomsByLocation).toBeCalledWith(expect.any(SmartThingsClient), locationId)
 		mockGetRoomsByLocation.mockClear()

--- a/packages/cli/src/__tests__/commands/locations/rooms/create.test.ts
+++ b/packages/cli/src/__tests__/commands/locations/rooms/create.test.ts
@@ -35,7 +35,7 @@ describe('RoomsCreateCommand', () => {
 	})
 
 	it('takes a specific locationId to query via flags', async () => {
-		await expect(RoomsCreateCommand.run([`--location-id=${locationId}`])).resolves.not.toThrow()
+		await expect(RoomsCreateCommand.run([`--location=${locationId}`])).resolves.not.toThrow()
 
 		expect(mockChooseLocation).toBeCalledWith(expect.any(RoomsCreateCommand), locationId)
 		mockChooseLocation.mockClear()

--- a/packages/cli/src/__tests__/commands/locations/rooms/delete.test.ts
+++ b/packages/cli/src/__tests__/commands/locations/rooms/delete.test.ts
@@ -33,7 +33,7 @@ describe('RoomsDeleteCommand', () => {
 	})
 
 	it('takes a specific locationId to query via flags', async () => {
-		await expect(RoomsDeleteCommand.run([`--location-id=${locationId}`])).resolves.not.toThrow()
+		await expect(RoomsDeleteCommand.run([`--location=${locationId}`])).resolves.not.toThrow()
 
 		expect(mockChooseRoom).toBeCalledWith(expect.any(RoomsDeleteCommand), locationId, undefined)
 		mockChooseRoom.mockClear()

--- a/packages/cli/src/__tests__/commands/locations/rooms/update.test.ts
+++ b/packages/cli/src/__tests__/commands/locations/rooms/update.test.ts
@@ -44,7 +44,7 @@ describe('RoomsUpdateCommand', () => {
 	})
 
 	it('takes a specific locationId to query via flags', async () => {
-		await expect(RoomsUpdateCommand.run([`--location-id=${locationId}`])).resolves.not.toThrow()
+		await expect(RoomsUpdateCommand.run([`--location=${locationId}`])).resolves.not.toThrow()
 
 		expect(mockChooseRoom).toBeCalledWith(expect.any(RoomsUpdateCommand), locationId, undefined)
 		mockChooseRoom.mockClear()

--- a/packages/cli/src/__tests__/commands/rules.test.ts
+++ b/packages/cli/src/__tests__/commands/rules.test.ts
@@ -50,7 +50,7 @@ describe('RulesCommand', () => {
 	})
 
 	it('passes location id from command line', async () => {
-		await expect(RulesCommand.run(['--location-id', 'cmd-line-location-id'])).resolves.not.toThrow()
+		await expect(RulesCommand.run(['--location', 'cmd-line-location-id'])).resolves.not.toThrow()
 
 		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
 		expect(outputItemOrListMock).toHaveBeenCalledWith(expect.any(RulesCommand),

--- a/packages/cli/src/__tests__/commands/rules/create.test.ts
+++ b/packages/cli/src/__tests__/commands/rules/create.test.ts
@@ -38,7 +38,7 @@ describe('RulesCreateCommand', () => {
 	it('uses location specified on command line', async () => {
 		chooseLocationMock.mockResolvedValue('chosen-location-id')
 
-		await expect(RulesCreateCommand.run(['--location-id', 'cmd-line-location-id'])).resolves.not.toThrow()
+		await expect(RulesCreateCommand.run(['--location', 'cmd-line-location-id'])).resolves.not.toThrow()
 
 		expect(chooseLocationMock).toHaveBeenCalledTimes(1)
 		expect(chooseLocationMock).toHaveBeenCalledWith(expect.any(RulesCreateCommand), 'cmd-line-location-id')

--- a/packages/cli/src/__tests__/commands/rules/delete.test.ts
+++ b/packages/cli/src/__tests__/commands/rules/delete.test.ts
@@ -54,7 +54,7 @@ describe('RulesDeleteCommand', () => {
 		chooseRuleMock.mockResolvedValueOnce('chosen-rule-id')
 		getRuleWithLocationMock.mockResolvedValue(ruleWithLocation)
 
-		await expect(RulesDeleteCommand.run(['--location-id', 'cmd-line-location-id'])).resolves.not.toThrow()
+		await expect(RulesDeleteCommand.run(['--location', 'cmd-line-location-id'])).resolves.not.toThrow()
 
 		expect(chooseRuleMock).toHaveBeenCalledTimes(1)
 		expect(chooseRuleMock).toHaveBeenCalledWith(expect.any(RulesDeleteCommand),

--- a/packages/cli/src/__tests__/commands/rules/execute.test.ts
+++ b/packages/cli/src/__tests__/commands/rules/execute.test.ts
@@ -70,7 +70,7 @@ describe('RulesExecuteCommand', () => {
 		chooseRuleMock.mockResolvedValueOnce('chosen-rule-id')
 		getRuleWithLocationMock.mockResolvedValue(ruleWithLocation)
 
-		await expect(RulesExecuteCommand.run(['--location-id', 'cmd-line-location-id'])).resolves.not.toThrow()
+		await expect(RulesExecuteCommand.run(['--location', 'cmd-line-location-id'])).resolves.not.toThrow()
 
 		expect(chooseRuleMock).toHaveBeenCalledTimes(1)
 		expect(chooseRuleMock).toHaveBeenCalledWith(expect.any(RulesExecuteCommand),

--- a/packages/cli/src/__tests__/commands/rules/update.test.ts
+++ b/packages/cli/src/__tests__/commands/rules/update.test.ts
@@ -65,7 +65,7 @@ describe('RulesUpdateCommand', () => {
 	it('uses location id from command line', async () => {
 		chooseRuleMock.mockResolvedValueOnce('chosen-rule-id')
 
-		await expect(RulesUpdateCommand.run(['--location-id', 'cmd-line-location-id'])).resolves.not.toThrow()
+		await expect(RulesUpdateCommand.run(['--location', 'cmd-line-location-id'])).resolves.not.toThrow()
 
 		expect(chooseRuleMock).toHaveBeenCalledTimes(1)
 		expect(chooseRuleMock).toHaveBeenCalledWith(expect.any(RulesUpdateCommand),

--- a/packages/cli/src/__tests__/commands/scenes.test.ts
+++ b/packages/cli/src/__tests__/commands/scenes.test.ts
@@ -46,7 +46,7 @@ describe('ScenesCommand', () => {
 	})
 
 	it('uses one location from command line', async () => {
-		await expect(ScenesCommand.run(['--location-id="cmd-line-location-id"'])).resolves.not.toThrow()
+		await expect(ScenesCommand.run(['--location="cmd-line-location-id"'])).resolves.not.toThrow()
 
 		expect(mockListing).toHaveBeenCalledTimes(1)
 		expect(mockListing).toHaveBeenCalledWith(
@@ -60,7 +60,7 @@ describe('ScenesCommand', () => {
 	})
 
 	it('uses multiple locations from command line', async () => {
-		await expect(ScenesCommand.run(['--location-id="cmd-line-location-id" --l="cmd-line-location-id-2"'])).resolves.not.toThrow()
+		await expect(ScenesCommand.run(['--location="cmd-line-location-id" --l="cmd-line-location-id-2"'])).resolves.not.toThrow()
 
 		expect(mockListing).toHaveBeenCalledTimes(1)
 		expect(mockListing).toHaveBeenCalledWith(

--- a/packages/cli/src/__tests__/commands/schema/authorize.test.ts
+++ b/packages/cli/src/__tests__/commands/schema/authorize.test.ts
@@ -26,7 +26,7 @@ describe('SchemaAppAuthorizeCommand', () => {
 	})
 
 	it('passes statement-id flag to addSchemaPermission', async () => {
-		await expect(SchemaAppAuthorizeCommand.run(['ARN', '--statement-id=statementId'])).resolves.not.toThrow()
+		await expect(SchemaAppAuthorizeCommand.run(['ARN', '--statement=statementId'])).resolves.not.toThrow()
 
 		expect(addSchemaPermissionMock).toBeCalledWith('ARN', undefined, 'statementId')
 	})

--- a/packages/cli/src/__tests__/commands/schema/create.test.ts
+++ b/packages/cli/src/__tests__/commands/schema/create.test.ts
@@ -122,7 +122,7 @@ describe('SchemaAppCreateCommand', () => {
 
 	it('passes statement-id flag to addSchemaPermission', async () => {
 		const statementId = 'statementId'
-		await expect(SchemaAppCreateCommand.run(['--authorize', `--statement-id=${statementId}`])).resolves.not.toThrow()
+		await expect(SchemaAppCreateCommand.run(['--authorize', `--statement=${statementId}`])).resolves.not.toThrow()
 
 		const schemaAppRequest = {
 			appName: 'schemaApp',

--- a/packages/cli/src/__tests__/commands/virtualdevices.test.ts
+++ b/packages/cli/src/__tests__/commands/virtualdevices.test.ts
@@ -49,7 +49,7 @@ describe('VirtualDevicesCommand', () => {
 			await listFunction()
 		})
 
-		await expect(VirtualDevicesCommand.run(['--location-id=location-id'])).resolves.not.toThrow()
+		await expect(VirtualDevicesCommand.run(['--location=location-id'])).resolves.not.toThrow()
 
 		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
 		expect(listSpy).toHaveBeenCalledTimes(1)
@@ -64,7 +64,7 @@ describe('VirtualDevicesCommand', () => {
 			await listFunction()
 		})
 
-		await expect(VirtualDevicesCommand.run(['--installed-app-id=installed-app-id'])).resolves.not.toThrow()
+		await expect(VirtualDevicesCommand.run(['--installed-app=installed-app-id'])).resolves.not.toThrow()
 
 		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
 		expect(listSpy).toHaveBeenCalledTimes(1)

--- a/packages/cli/src/__tests__/commands/virtualdevices/create-standard.test.ts
+++ b/packages/cli/src/__tests__/commands/virtualdevices/create-standard.test.ts
@@ -62,8 +62,8 @@ describe('VirtualDeviceStandardCreateCommand', () => {
 
 		await expect(VirtualDeviceCreateStandardCommand.run([
 			'--name=NewDeviceName',
-			'--location-id=new-location-id',
-			'--room-id=new-room-id',
+			'--location=new-location-id',
+			'--room=new-room-id',
 		])).resolves.not.toThrow()
 
 		expect(createSpy).toBeCalledWith(expectedCreateRequest)
@@ -97,8 +97,8 @@ describe('VirtualDeviceStandardCreateCommand', () => {
 
 		await expect(VirtualDeviceCreateStandardCommand.run([
 			'--name=DeviceName',
-			'--location-id=location-id',
-			'--room-id=room-id',
+			'--location=location-id',
+			'--room=room-id',
 			'--prototype=VIRTUAL_SWITCH',
 		])).resolves.not.toThrow()
 

--- a/packages/cli/src/__tests__/commands/virtualdevices/create.test.ts
+++ b/packages/cli/src/__tests__/commands/virtualdevices/create.test.ts
@@ -61,8 +61,8 @@ describe('VirtualDeviceCreateCommand', () => {
 
 		await expect(VirtualDeviceCreateCommand.run([
 			'--name=NewDeviceName',
-			'--location-id=new-location-id',
-			'--room-id=new-room-id',
+			'--location=new-location-id',
+			'--room=new-room-id',
 		])).resolves.not.toThrow()
 
 		expect(mockInputAndOutputItem).toBeCalledWith(
@@ -102,9 +102,9 @@ describe('VirtualDeviceCreateCommand', () => {
 
 		await expect(VirtualDeviceCreateCommand.run([
 			'--name=DeviceName',
-			'--location-id=location-id',
-			'--room-id=room-id',
-			'--device-profile-id=device-profile-id',
+			'--location=location-id',
+			'--room=room-id',
+			'--device-profile=device-profile-id',
 		])).resolves.not.toThrow()
 
 		expect(mockChooseDeviceName).toBeCalledWith(expect.any(VirtualDeviceCreateCommand), 'DeviceName')
@@ -143,8 +143,8 @@ describe('VirtualDeviceCreateCommand', () => {
 
 		await expect(VirtualDeviceCreateCommand.run([
 			'--name=DeviceName',
-			'--location-id=location-id',
-			'--room-id=room-id',
+			'--location=location-id',
+			'--room=room-id',
 			'--device-profile-file=device-profile-filename',
 		])).resolves.not.toThrow()
 

--- a/packages/cli/src/commands/apps/authorize.ts
+++ b/packages/cli/src/commands/apps/authorize.ts
@@ -25,13 +25,13 @@ export default class AppsAuthorizeCommand extends SmartThingsCommand<typeof Apps
 		'',
 		'$ aws lambda add-permission --region us-east-1 \\',
 		'    --function-name arn:aws:lambda:us-east-1:1234567890:function:your-test-app \\',
-		'    --statement-id smartthings --principal 906037444270 --action lambda:InvokeFunction',
+		'    --statement smartthings --principal 906037444270 --action lambda:InvokeFunction',
 		'',
 		'It requires your machine to be configured to run the AWS CLI',
 	]
 
 	async run(): Promise<void> {
-		const message = await addPermission(this.args.arn, this.flags.principal, this.flags['statement-id'])
+		const message = await addPermission(this.args.arn, this.flags.principal, this.flags.statement)
 		this.log(message)
 	}
 }

--- a/packages/cli/src/commands/apps/create.ts
+++ b/packages/cli/src/commands/apps/create.ts
@@ -24,7 +24,7 @@ export default class AppCreateCommand extends APICommand<typeof AppCreateCommand
 				if (data.lambdaSmartApp) {
 					if (data.lambdaSmartApp.functions) {
 						const requests = data.lambdaSmartApp.functions.map((functionArn) => {
-							return addPermission(functionArn, this.flags.principal, this.flags['statement-id'])
+							return addPermission(functionArn, this.flags.principal, this.flags.statement)
 						})
 						await Promise.all(requests)
 					}

--- a/packages/cli/src/commands/apps/update.ts
+++ b/packages/cli/src/commands/apps/update.ts
@@ -30,7 +30,7 @@ export default class AppUpdateCommand extends APICommand<typeof AppUpdateCommand
 				if (data.lambdaSmartApp) {
 					if (data.lambdaSmartApp.functions) {
 						const requests = data.lambdaSmartApp.functions.map((it) => {
-							return addPermission(it, this.flags.principal, this.flags['statement-id'])
+							return addPermission(it, this.flags.principal, this.flags.statement)
 						})
 						await Promise.all(requests)
 					}

--- a/packages/cli/src/commands/devices.ts
+++ b/packages/cli/src/commands/devices.ts
@@ -13,8 +13,7 @@ export default class DevicesCommand extends APICommand<typeof DevicesCommand.fla
 	static flags = {
 		...APICommand.flags,
 		...outputItemOrList.flags,
-		/* eslint-disable @typescript-eslint/naming-convention */
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'filter results by location',
 			multiple: true,
@@ -24,18 +23,20 @@ export default class DevicesCommand extends APICommand<typeof DevicesCommand.fla
 			description: 'filter results by capability',
 			multiple: true,
 		}),
+		// eslint-disable-next-line @typescript-eslint/naming-convention
 		'capabilities-mode': Flags.string({
 			char: 'C',
 			description: 'Treat capability filter query params as a logical "or" or "and" with a default of "and".',
 			dependsOn: ['capability'],
 			options: ['and', 'or'],
 		}),
-		'device-id': Flags.string({
+		device: Flags.string({
 			char: 'd',
 			description: 'filter results by device',
 			multiple: true,
 		}),
-		'installed-app-id': Flags.string({
+		// eslint-disable-next-line @typescript-eslint/naming-convention
+		'installed-app': Flags.string({
 			char: 'a',
 			description: 'filter results by installed app that created the device',
 		}),
@@ -47,7 +48,6 @@ export default class DevicesCommand extends APICommand<typeof DevicesCommand.fla
 			char: 'H',
 			description: 'include device health in response',
 		}),
-		/* eslint-enable @typescript-eslint/naming-convention */
 		type: Flags.string({
 			description: 'filter results by device type',
 			options: Object.values(DeviceIntegrationType),
@@ -92,9 +92,9 @@ export default class DevicesCommand extends APICommand<typeof DevicesCommand.fla
 		const deviceListOptions: DeviceListOptions = {
 			capability: this.flags.capability,
 			capabilitiesMode: this.flags['capabilities-mode'] === 'or' ? 'or' : 'and',
-			locationId: this.flags['location-id'],
-			deviceId: this.flags['device-id'],
-			installedAppId: this.flags['installed-app-id'],
+			locationId: this.flags.location,
+			deviceId: this.flags.device,
+			installedAppId: this.flags['installed-app'],
 			type: this.flags.type as DeviceIntegrationType[] | undefined,
 			includeHealth: this.flags.health,
 			...deviceGetOptions,

--- a/packages/cli/src/commands/installedapps.ts
+++ b/packages/cli/src/commands/installedapps.ts
@@ -12,8 +12,7 @@ export default class InstalledAppsCommand extends APICommand<typeof InstalledApp
 	static flags = {
 		...APICommand.flags,
 		...outputItemOrList.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'filter results by location',
 			multiple: true,
@@ -46,7 +45,7 @@ export default class InstalledAppsCommand extends APICommand<typeof InstalledApp
 
 		const installedApps = async (): Promise<(InstalledApp & WithNamedLocation)[]> => {
 			const listOptions: InstalledAppListOptions = {
-				locationId: this.flags['location-id'],
+				locationId: this.flags.location,
 			}
 			const apps = await this.client.installedApps.list(listOptions)
 			if (this.flags.verbose) {

--- a/packages/cli/src/commands/installedapps/delete.ts
+++ b/packages/cli/src/commands/installedapps/delete.ts
@@ -10,8 +10,7 @@ export default class InstalledAppDeleteCommand extends APICommand<typeof Install
 
 	static flags = {
 		...APICommand.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'filter results by location',
 			multiple: true,
@@ -38,7 +37,7 @@ export default class InstalledAppDeleteCommand extends APICommand<typeof Install
 		}
 
 		const listOptions: InstalledAppListOptions = {
-			locationId: this.flags['location-id'],
+			locationId: this.flags.location,
 		}
 
 		const id = await selectFromList<InstalledApp>(this, config, {

--- a/packages/cli/src/commands/installedapps/rename.ts
+++ b/packages/cli/src/commands/installedapps/rename.ts
@@ -13,8 +13,7 @@ export default class InstalledAppRenameCommand extends APICommand<typeof Install
 	static flags = {
 		...APICommand.flags,
 		...formatAndWriteItem.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'filter results by location',
 			multiple: true,
@@ -48,7 +47,7 @@ export default class InstalledAppRenameCommand extends APICommand<typeof Install
 			config.listTableFieldDefinitions.splice(3, 0, 'location')
 		}
 		const listOptions: InstalledAppListOptions = {
-			locationId: this.flags['location-id'],
+			locationId: this.flags.location,
 		}
 
 		const id = await selectFromList(this, config, {

--- a/packages/cli/src/commands/installedschema.ts
+++ b/packages/cli/src/commands/installedschema.ts
@@ -17,8 +17,7 @@ export default class InstalledSchemaAppsCommand extends APICommand<typeof Instal
 	static flags = {
 		...APICommand.flags,
 		...outputItemOrList.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'filter results by location',
 			multiple: true,
@@ -52,7 +51,7 @@ export default class InstalledSchemaAppsCommand extends APICommand<typeof Instal
 			this.flags.verbose ? async app => withLocation(this.client, await app) : app => app
 
 		await outputItemOrList(this, config, this.args.id,
-			() => installedSchemaInstances(this.client, this.flags['location-id'], this.flags.verbose),
+			() => installedSchemaInstances(this.client, this.flags.location, this.flags.verbose),
 			id => verboseInstalledApp(this.client.schema.getInstalledApp(id)),
 		)
 	}

--- a/packages/cli/src/commands/installedschema/delete.ts
+++ b/packages/cli/src/commands/installedschema/delete.ts
@@ -12,8 +12,7 @@ export default class InstalledSchemaAppDeleteCommand extends APICommand<typeof I
 
 	static flags = {
 		...APICommand.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'filter results by location',
 			multiple: true,
@@ -40,7 +39,7 @@ export default class InstalledSchemaAppDeleteCommand extends APICommand<typeof I
 
 		const id = await selectFromList<InstalledSchemaApp>(this, config, {
 			preselectedId: this.args.id,
-			listItems: () => installedSchemaInstances(this.client, this.flags['location-id'], this.flags.verbose),
+			listItems: () => installedSchemaInstances(this.client, this.flags.location, this.flags.verbose),
 			promptMessage: 'Select an installed schema app to delete.',
 		})
 		await this.client.schema.deleteInstalledApp(id)

--- a/packages/cli/src/commands/locations/rooms.ts
+++ b/packages/cli/src/commands/locations/rooms.ts
@@ -12,8 +12,7 @@ export default class RoomsCommand extends APICommand<typeof RoomsCommand.flags> 
 
 	static flags = {
 		...APICommand.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'a specific location to query',
 		}),
@@ -42,7 +41,7 @@ export default class RoomsCommand extends APICommand<typeof RoomsCommand.flags> 
 			config.listTableFieldDefinitions = tableFieldDefinitionsWithLocationName
 			config.tableFieldDefinitions = tableFieldDefinitionsWithLocationName
 		}
-		const rooms = await getRoomsByLocation(this.client, this.flags['location-id'])
+		const rooms = await getRoomsByLocation(this.client, this.flags.location)
 		await outputItemOrList(this, config, this.args.idOrIndex,
 			async () => rooms,
 			async id => {

--- a/packages/cli/src/commands/locations/rooms/create.ts
+++ b/packages/cli/src/commands/locations/rooms/create.ts
@@ -11,8 +11,7 @@ export default class RoomsCreateCommand extends APICommand<typeof RoomsCreateCom
 	static flags = {
 		...APICommand.flags,
 		...inputAndOutputItem.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'a specific location to query',
 		}),
@@ -21,7 +20,7 @@ export default class RoomsCreateCommand extends APICommand<typeof RoomsCreateCom
 	static aliases = ['rooms:create']
 
 	async run(): Promise<void> {
-		const locationId = await chooseLocation(this, this.flags['location-id'])
+		const locationId = await chooseLocation(this, this.flags.location)
 		const config: CommonOutputProducer<Room> = { tableFieldDefinitions }
 		await inputAndOutputItem<RoomRequest, Room>(this, config,
 			(_, room) => this.client.rooms.create(room, locationId))

--- a/packages/cli/src/commands/locations/rooms/delete.ts
+++ b/packages/cli/src/commands/locations/rooms/delete.ts
@@ -8,8 +8,7 @@ export default class RoomsDeleteCommand extends APICommand<typeof RoomsDeleteCom
 
 	static flags = {
 		...APICommand.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'a specific location to query',
 		}),
@@ -23,7 +22,7 @@ export default class RoomsDeleteCommand extends APICommand<typeof RoomsDeleteCom
 	static aliases = ['rooms:delete']
 
 	async run(): Promise<void> {
-		const [roomId, locationId] = await chooseRoom(this, this.flags['location-id'], this.args.id)
+		const [roomId, locationId] = await chooseRoom(this, this.flags.location, this.args.id)
 		await this.client.rooms.delete(roomId, locationId)
 		this.log(`room ${roomId} deleted`)
 	}

--- a/packages/cli/src/commands/locations/rooms/update.ts
+++ b/packages/cli/src/commands/locations/rooms/update.ts
@@ -10,8 +10,7 @@ export default class RoomsUpdateCommand extends APICommand<typeof RoomsUpdateCom
 	static flags = {
 		...APICommand.flags,
 		...inputAndOutputItem.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'a specific location to query',
 		}),
@@ -25,7 +24,7 @@ export default class RoomsUpdateCommand extends APICommand<typeof RoomsUpdateCom
 	static aliases = ['rooms:update']
 
 	async run(): Promise<void> {
-		const [roomId, locationId] = await chooseRoom(this, this.flags['location-id'], this.args.id)
+		const [roomId, locationId] = await chooseRoom(this, this.flags.location, this.args.id)
 		const config: CommonOutputProducer<Room> = { tableFieldDefinitions }
 		await inputAndOutputItem<RoomRequest, Room>(this, config,
 			(_, data) => this.client.rooms.update(roomId, data, locationId))

--- a/packages/cli/src/commands/presentation/device-config/generate.ts
+++ b/packages/cli/src/commands/presentation/device-config/generate.ts
@@ -17,7 +17,7 @@ export default class GeneratePresentationCommand extends APICommand<typeof Gener
 			description: 'generate from legacy DTH id instead of a profile id',
 		}),
 		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'type-shard-id': Flags.string({
+		'type-shard': Flags.string({
 			description: 'data management shard Id where the device type resides, ' +
 				'only useful for legacy DTH type integrations',
 		}),
@@ -33,8 +33,8 @@ export default class GeneratePresentationCommand extends APICommand<typeof Gener
 		const extraParams: HttpClientParams = {}
 		if (this.flags.dth) {
 			extraParams.typeIntegration = 'dth'
-			if (this.args['type-shard-id']) {
-				extraParams.typeShareId = this.args['type-shard-id']
+			if (this.flags['type-shard']) {
+				extraParams.typeShareId = this.flags['type-shard']
 			}
 		}
 		this.logger.debug(`extraParams = ${JSON.stringify(extraParams)}`)

--- a/packages/cli/src/commands/rules.ts
+++ b/packages/cli/src/commands/rules.ts
@@ -13,8 +13,7 @@ export default class RulesCommand extends APICommand<typeof RulesCommand.flags> 
 	static flags = {
 		...APICommand.flags,
 		...outputItemOrList.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'a specific location to query',
 		}),
@@ -33,8 +32,8 @@ export default class RulesCommand extends APICommand<typeof RulesCommand.flags> 
 			tableFieldDefinitions,
 		}
 		await outputItemOrList(this, config, this.args.idOrIndex,
-			() => getRulesByLocation(this.client, this.flags['location-id']),
-			id => getRuleWithLocation(this.client, id, this.flags['location-id']),
+			() => getRulesByLocation(this.client, this.flags.location),
+			id => getRuleWithLocation(this.client, id, this.flags.location),
 		)
 	}
 }

--- a/packages/cli/src/commands/rules/create.ts
+++ b/packages/cli/src/commands/rules/create.ts
@@ -14,15 +14,14 @@ export default class RulesCreateCommand extends APICommand<typeof RulesCreateCom
 	static flags = {
 		...APICommand.flags,
 		...inputAndOutputItem.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'a specific location to query',
 		}),
 	}
 
 	async run(): Promise<void> {
-		const locationId = await chooseLocation(this, this.flags['location-id'])
+		const locationId = await chooseLocation(this, this.flags.location)
 
 		await inputAndOutputItem<RuleRequest, Rule>(this, { tableFieldDefinitions },
 			(_, rule) => this.client.rules.create(rule, locationId))

--- a/packages/cli/src/commands/rules/delete.ts
+++ b/packages/cli/src/commands/rules/delete.ts
@@ -10,8 +10,7 @@ export default class RulesDeleteCommand extends APICommand<typeof RulesDeleteCom
 
 	static flags = {
 		...APICommand.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'a specific location to query',
 		}),
@@ -23,10 +22,10 @@ export default class RulesDeleteCommand extends APICommand<typeof RulesDeleteCom
 	}]
 
 	async run(): Promise<void> {
-		const ruleId = await chooseRule(this, 'Select a rule to delete.', this.flags['location-id'], this.args.id)
+		const ruleId = await chooseRule(this, 'Select a rule to delete.', this.flags.location, this.args.id)
 
-		const locationId = this.flags['location-id']
-			?? (await getRuleWithLocation(this.client, ruleId, this.flags['location-id'])).locationId
+		const locationId = this.flags.location
+			?? (await getRuleWithLocation(this.client, ruleId, this.flags.location)).locationId
 
 		await this.client.rules.delete(ruleId, locationId)
 		this.log(`Rule ${ruleId} deleted.`)

--- a/packages/cli/src/commands/rules/execute.ts
+++ b/packages/cli/src/commands/rules/execute.ts
@@ -13,8 +13,7 @@ export default class RulesExecuteCommand extends APICommand<typeof RulesExecuteC
 	static flags = {
 		...APICommand.flags,
 		...formatAndWriteItem.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'a specific location to query',
 		}),
@@ -34,10 +33,10 @@ export default class RulesExecuteCommand extends APICommand<typeof RulesExecuteC
 	]
 
 	async run(): Promise<void> {
-		const ruleId = await chooseRule(this, 'Select a rule to execute.', this.flags['location-id'], this.args.id)
+		const ruleId = await chooseRule(this, 'Select a rule to execute.', this.flags.location, this.args.id)
 
-		const locationId = this.flags['location-id']
-			?? (await getRuleWithLocation(this.client, ruleId, this.flags['location-id'])).locationId
+		const locationId = this.flags.location
+			?? (await getRuleWithLocation(this.client, ruleId, this.flags.location)).locationId
 
 		const result = await this.client.rules.execute(ruleId, locationId)
 		await formatAndWriteItem<RuleExecutionResponse>(this,

--- a/packages/cli/src/commands/rules/update.ts
+++ b/packages/cli/src/commands/rules/update.ts
@@ -13,8 +13,7 @@ export default class RulesUpdateCommand extends APICommand<typeof RulesUpdateCom
 	static flags = {
 		...APICommand.flags,
 		...inputAndOutputItem.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'a specific location to query',
 		}),
@@ -26,11 +25,11 @@ export default class RulesUpdateCommand extends APICommand<typeof RulesUpdateCom
 	}]
 
 	async run(): Promise<void> {
-		const id = await chooseRule(this, 'Select a rule to update.', this.flags['location-id'], this.args.id)
+		const id = await chooseRule(this, 'Select a rule to update.', this.flags.location, this.args.id)
 
 		await inputAndOutputItem<RuleRequest, Rule>(this, { tableFieldDefinitions },
 			async (_, data) => {
-				const rule = await getRuleWithLocation(this.client, id, this.flags['location-id'])
+				const rule = await getRuleWithLocation(this.client, id, this.flags.location)
 				return this.client.rules.update(id, data, rule.locationId)
 			})
 	}

--- a/packages/cli/src/commands/scenes.ts
+++ b/packages/cli/src/commands/scenes.ts
@@ -13,8 +13,7 @@ export default class ScenesCommand extends APICommand<typeof ScenesCommand.flags
 	static flags = {
 		...APICommand.flags,
 		...outputItemOrList.flags,
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'a specific location to query',
 			multiple: true,
@@ -33,7 +32,7 @@ export default class ScenesCommand extends APICommand<typeof ScenesCommand.flags
 			tableFieldDefinitions,
 		}
 		const options: SceneListOptions = {
-			locationId: this.flags['location-id'],
+			locationId: this.flags.location,
 		}
 
 		await outputItemOrList<SceneSummary, SceneSummary>(this, config, this.args.idOrIndex,

--- a/packages/cli/src/commands/schema/authorize.ts
+++ b/packages/cli/src/commands/schema/authorize.ts
@@ -24,13 +24,13 @@ export default class SchemaAppAuthorizeCommand extends SmartThingsCommand<typeof
 		'',
 		'$ aws lambda add-permission --region us-east-1 \\',
 		'    --function-name arn:aws:lambda:us-east-1:1234567890:function:your-test-app \\',
-		'    --statement-id smartthings --principal 148790070172 --action lambda:InvokeFunction',
+		'    --statement smartthings --principal 148790070172 --action lambda:InvokeFunction',
 		'',
 		'It requires your machine to be configured to run the AWS CLI',
 	]
 
 	async run(): Promise<void> {
-		const message = await addSchemaPermission(this.args.arn, this.flags.principal, this.flags['statement-id'])
+		const message = await addSchemaPermission(this.args.arn, this.flags.principal, this.flags.statement)
 		this.log(message)
 	}
 }

--- a/packages/cli/src/commands/schema/create.ts
+++ b/packages/cli/src/commands/schema/create.ts
@@ -25,7 +25,7 @@ export default class SchemaAppCreateCommand extends APICommand<typeof SchemaAppC
 			if (this.flags.authorize) {
 				if (data.hostingType === 'lambda') {
 					const principal = this.flags.principal ?? SCHEMA_AWS_PRINCIPAL
-					const statementId = this.flags['statement-id']
+					const statementId = this.flags.statement
 
 					if (data.lambdaArn) {
 						await addSchemaPermission(data.lambdaArn, principal, statementId)

--- a/packages/cli/src/commands/schema/update.ts
+++ b/packages/cli/src/commands/schema/update.ts
@@ -39,16 +39,16 @@ export default class SchemaUpdateCommand extends APICommand<typeof SchemaUpdateC
 		if (this.flags.authorize) {
 			if (request.hostingType === 'lambda') {
 				if (request.lambdaArn) {
-					await addSchemaPermission(request.lambdaArn, this.flags.principal, this.flags['statement-id'])
+					await addSchemaPermission(request.lambdaArn, this.flags.principal, this.flags.statement)
 				}
 				if (request.lambdaArnAP) {
-					await addSchemaPermission(request.lambdaArnAP, this.flags.principal, this.flags['statement-id'])
+					await addSchemaPermission(request.lambdaArnAP, this.flags.principal, this.flags.statement)
 				}
 				if (request.lambdaArnCN) {
-					await addSchemaPermission(request.lambdaArnCN, this.flags.principal, this.flags['statement-id'])
+					await addSchemaPermission(request.lambdaArnCN, this.flags.principal, this.flags.statement)
 				}
 				if (request.lambdaArnEU) {
-					await addSchemaPermission(request.lambdaArnEU, this.flags.principal, this.flags['statement-id'])
+					await addSchemaPermission(request.lambdaArnEU, this.flags.principal, this.flags.statement)
 				}
 			} else {
 				throw Error('Authorization is not applicable to WebHook schema connectors')

--- a/packages/cli/src/commands/virtualdevices.ts
+++ b/packages/cli/src/commands/virtualdevices.ts
@@ -22,17 +22,16 @@ export default class VirtualDevicesCommand extends APICommand<typeof VirtualDevi
 	static flags = {
 		...APICommand.flags,
 		...outputItemOrList.flags,
-		/* eslint-disable @typescript-eslint/naming-convention */
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'filter results by location',
 			multiple: true,
 		}),
-		'installed-app-id': Flags.string({
+		// eslint-disable-next-line @typescript-eslint/naming-convention
+		'installed-app': Flags.string({
 			char: 'a',
 			description: 'filter results by installed app that created the device',
 		}),
-		/* eslint-enable @typescript-eslint/naming-convention */
 		verbose: Flags.boolean({
 			description: 'include location name in output',
 			char: 'v',
@@ -56,8 +55,8 @@ export default class VirtualDevicesCommand extends APICommand<typeof VirtualDevi
 		}
 
 		const deviceListOptions: DeviceListOptions = {
-			locationId: this.flags['location-id'],
-			installedAppId: this.flags['installed-app-id'],
+			locationId: this.flags.location,
+			installedAppId: this.flags['installed-app'],
 			type: DeviceIntegrationType.VIRTUAL,
 		}
 

--- a/packages/cli/src/commands/virtualdevices/create-standard.ts
+++ b/packages/cli/src/commands/virtualdevices/create-standard.ts
@@ -29,8 +29,8 @@ export default class VirtualDeviceCreateStandardCommand extends APICommand<typeo
 		'$ smartthings virtualdevices:create-standard \\                          # using command line parameters for everything\n' +
 		'>    --name="My Second Device" \\ \n' +
 		'>    --prototype=VIRTUAL_SWITCH \\ \n' +
-		'>    --location-id=95bdd473-4498-42fc-b932-974d6e5c236e \\ \n' +
-		'>    --room-id=c7266cb7-7dcc-4958-8bc4-4288f5b50e1b',
+		'>    --location=95bdd473-4498-42fc-b932-974d6e5c236e \\ \n' +
+		'>    --room=c7266cb7-7dcc-4958-8bc4-4288f5b50e1b',
 	]
 
 	static flags = {
@@ -40,16 +40,14 @@ export default class VirtualDeviceCreateStandardCommand extends APICommand<typeo
 			char: 'N',
 			description: 'name of the device to be created',
 		}),
-		/* eslint-disable @typescript-eslint/naming-convention */
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'location into which device should be created',
 		}),
-		'room-id': Flags.string({
+		room: Flags.string({
 			char: 'R',
 			description: 'the room to put the device into',
 		}),
-		/* eslint-enable @typescript-eslint/naming-convention */
 		prototype: Flags.string({
 			char: 'T',
 			description: 'standard device prototype, e.g. VIRTUAL_SWITCH or VIRTUAL_DIMMER_SWITCH',
@@ -72,11 +70,11 @@ export default class VirtualDeviceCreateStandardCommand extends APICommand<typeo
 		if (flags.name) {
 			data.name = flags.name
 		}
-		if (flags['location-id']) {
-			data.owner.ownerId = flags['location-id']
+		if (flags.location) {
+			data.owner.ownerId = flags.location
 		}
-		if (flags['room-id']) {
-			data.roomId = flags['room-id']
+		if (flags.room) {
+			data.roomId = flags.room
 		}
 		return data
 	}
@@ -84,8 +82,8 @@ export default class VirtualDeviceCreateStandardCommand extends APICommand<typeo
 	async getInputFromUser(): Promise<VirtualDeviceStandardCreateRequest> {
 		const name = await chooseDeviceName(this, this.flags.name)
 		const prototype = await chooseDevicePrototype(this, this.flags['prototype'])
-		const locationId = await chooseLocation(this, this.flags['location-id'], true)
-		const [roomId] = await chooseRoom(this, locationId, this.flags['room-id'], true)
+		const locationId = await chooseLocation(this, this.flags.location, true)
+		const [roomId] = await chooseRoom(this, locationId, this.flags.room, true)
 
 		if (name && prototype && locationId) {
 			return {

--- a/packages/cli/src/commands/virtualdevices/create.ts
+++ b/packages/cli/src/commands/virtualdevices/create.ts
@@ -29,9 +29,9 @@ export default class VirtualDeviceCreateCommand extends APIOrganizationCommand<t
 		'$ smartthings virtualdevices:create -N "My Device" -i data.yml # using file request body with "My Device" for the name',
 		'$ smartthings virtualdevices:create \\                          # using command line parameters for everything\n' +
 		'>    --name="My Second Device" \\ \n' +
-		'>    --device-profile-id=7633ef68-6433-47ab-89c3-deb04b8b0d61 \\ \n' +
-		'>    --location-id=95bdd473-4498-42fc-b932-974d6e5c236e \\ \n' +
-		'>    --room-id=c7266cb7-7dcc-4958-8bc4-4288f5b50e1b',
+		'>    --device-profile=7633ef68-6433-47ab-89c3-deb04b8b0d61 \\ \n' +
+		'>    --location=95bdd473-4498-42fc-b932-974d6e5c236e \\ \n' +
+		'>    --room=c7266cb7-7dcc-4958-8bc4-4288f5b50e1b',
 		'$ smartthings virtualdevices:create -f profile.yml             # using a device profile and prompting for the remaining values',
 	]
 
@@ -42,16 +42,16 @@ export default class VirtualDeviceCreateCommand extends APIOrganizationCommand<t
 			char: 'N',
 			description: 'name of the device to be created',
 		}),
-		/* eslint-disable @typescript-eslint/naming-convention */
-		'location-id': Flags.string({
+		location: Flags.string({
 			char: 'l',
 			description: 'location into which device should be created',
 		}),
-		'room-id': Flags.string({
+		room: Flags.string({
 			char: 'R',
 			description: 'the room to put the device into',
 		}),
-		'device-profile-id': Flags.string({
+		/* eslint-disable @typescript-eslint/naming-convention */
+		'device-profile': Flags.string({
 			char: 'P',
 			description: 'the device profile ID',
 		}),
@@ -78,11 +78,11 @@ export default class VirtualDeviceCreateCommand extends APIOrganizationCommand<t
 		if (flags.name) {
 			data.name = flags.name
 		}
-		if (flags['location-id']) {
-			data.owner.ownerId = flags['location-id']
+		if (flags.location) {
+			data.owner.ownerId = flags.location
 		}
-		if (flags['room-id']) {
-			data.roomId = flags['room-id']
+		if (flags.room) {
+			data.roomId = flags.room
 		}
 		return data
 	}
@@ -90,9 +90,9 @@ export default class VirtualDeviceCreateCommand extends APIOrganizationCommand<t
 	async getInputFromUser(): Promise<VirtualDeviceCreateRequest> {
 		const name = await chooseDeviceName(this, this.flags.name)
 		const { deviceProfileId, deviceProfile } = await chooseDeviceProfileDefinition(this,
-			this.flags['device-profile-id'], this.flags['device-profile-file'])
-		const locationId = await chooseLocation(this, this.flags['location-id'], true)
-		const [roomId] = await chooseRoom(this, locationId, this.flags['room-id'], true)
+			this.flags['device-profile'], this.flags['device-profile-file'])
+		const locationId = await chooseLocation(this, this.flags.location, true)
+		const [roomId] = await chooseRoom(this, locationId, this.flags.room, true)
 
 		if (name && locationId && (deviceProfileId || deviceProfile)) {
 			return {

--- a/packages/lib/src/common-flags.ts
+++ b/packages/lib/src/common-flags.ts
@@ -5,8 +5,7 @@ export const lambdaAuthFlags = {
 	principal: Flags.string({
 		description: 'use this principal instead of the default when authorizing lambda functions',
 	}),
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	'statement-id': Flags.string({
+	statement: Flags.string({
 		description: 'use this statement id instead of the default when authorizing lambda functions',
 	}),
 }


### PR DESCRIPTION
<!-- Describe your pull request. -->

Removed "-id" suffix from command line flags that use it. Most of these are changing `--location-id` to `--location` but there are a few others mixed in.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
