### PR TITLE
docs: remove reference to long gone "logging" config key

### DIFF
--- a/packages/cli/doc/configuration.md
+++ b/packages/cli/doc/configuration.md
@@ -12,7 +12,7 @@ following location:
 
 It's possible to define multiple profiles with different configurations.
 
-* Top-level keys other than the special `logging` key define these profiles.
+* Top-level keys define these profiles.
 * The default profile is simply named "default" and will be used unless otherwise
 specified. Most users can simply put their configuration options here.
 * To choose a different profile you can either set the SMARTTHINGS_PROFILE


### PR DESCRIPTION
<!-- Describe your pull request. -->

Minor doc fix. We have long since been using a separate config file for logging.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
