### PR TITLE
fix: add forgotten changeset for testlib

### DIFF
--- a/.changeset/gorgeous-knives-yell.md
+++ b/.changeset/gorgeous-knives-yell.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli-testlib": patch
+---
+
+include resetManagedConfigKey in mocked functions


### PR DESCRIPTION
<!-- Describe your pull request. -->

`@smartthings/cli-testlib` didn't get published even though it was changed because I had forgotten to include it in the changeset.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [ ] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
