### PR TITLE
refactor: update table generator types for more compile-time type checking

### DIFF
--- a/.changeset/long-tigers-hug.md
+++ b/.changeset/long-tigers-hug.md
@@ -1,0 +1,7 @@
+---
+"@smartthings/plugin-cli-edge": patch
+"@smartthings/cli-lib": patch
+"@smartthings/cli-testlib": patch
+---
+
+refactored `TableGenerator` interface and supporting code

--- a/package-lock.json
+++ b/package-lock.json
@@ -3741,9 +3741,9 @@
 			"link": true
 		},
 		"node_modules/@smartthings/core-sdk": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-5.1.1.tgz",
-			"integrity": "sha512-BYSsMoxRyhFvDvLFy2bgix50KkufyDxOFDd1VtBlcWbePHE7tF7RHwnjjXWqEmraDQDb2a4fCCIaWQ5W21CkXw==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-5.1.2.tgz",
+			"integrity": "sha512-MrbXmkRQ9cmLetMIRByNB+U4PsdZk24ISNFtzF8XqBgMviVkl7cBBAY4Raj0xR1PK/G17mVocoNnV4MjTwzLVw==",
 			"dependencies": {
 				"async-mutex": "^0.3.2",
 				"axios": "^0.21.4",
@@ -18599,7 +18599,7 @@
 				"@oclif/plugin-not-found": "^2.3.1",
 				"@oclif/plugin-plugins": "^2.1.0",
 				"@smartthings/cli-lib": "^1.0.0-beta.16",
-				"@smartthings/core-sdk": "^5.1.1",
+				"@smartthings/core-sdk": "^5.1.2",
 				"@smartthings/plugin-cli-edge": "^2.0.0-beta.2",
 				"aws-sdk": "^2.1175.0",
 				"inquirer": "^8.2.4",
@@ -18644,7 +18644,7 @@
 				"@log4js-node/log4js-api": "^1.0.2",
 				"@oclif/core": "^1.16.3",
 				"@smartthings/cli-lib": "^1.0.0-beta.16",
-				"@smartthings/core-sdk": "^5.1.1",
+				"@smartthings/core-sdk": "^5.1.2",
 				"axios": "^0.21.4",
 				"inquirer": "^8.2.4",
 				"js-yaml": "^4.1.0",
@@ -18689,7 +18689,7 @@
 			"dependencies": {
 				"@log4js-node/log4js-api": "^1.0.2",
 				"@oclif/core": "^1.16.3",
-				"@smartthings/core-sdk": "^5.1.1",
+				"@smartthings/core-sdk": "^5.1.2",
 				"@types/eventsource": "^1.1.9",
 				"axios": "^0.21.4",
 				"chalk": "^4.1.2",
@@ -18754,7 +18754,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smartthings/cli-lib": "^1.0.0-beta.14",
-				"@smartthings/core-sdk": "^5.1.1"
+				"@smartthings/core-sdk": "^5.1.2"
 			},
 			"devDependencies": {
 				"@types/jest": "^28.1.5",
@@ -21823,7 +21823,7 @@
 				"@oclif/plugin-plugins": "^2.1.0",
 				"@smartthings/cli-lib": "^1.0.0-beta.16",
 				"@smartthings/cli-testlib": "^1.0.0-beta.10",
-				"@smartthings/core-sdk": "^5.1.1",
+				"@smartthings/core-sdk": "^5.1.2",
 				"@smartthings/plugin-cli-edge": "^2.0.0-beta.2",
 				"@types/inquirer": "^8.2.1",
 				"@types/jest": "^28.1.5",
@@ -21855,7 +21855,7 @@
 			"requires": {
 				"@log4js-node/log4js-api": "^1.0.2",
 				"@oclif/core": "^1.16.3",
-				"@smartthings/core-sdk": "^5.1.1",
+				"@smartthings/core-sdk": "^5.1.2",
 				"@types/eventsource": "^1.1.9",
 				"@types/express": "^4.17.13",
 				"@types/inquirer": "^8.2.1",
@@ -21908,7 +21908,7 @@
 			"version": "file:packages/testlib",
 			"requires": {
 				"@smartthings/cli-lib": "^1.0.0-beta.14",
-				"@smartthings/core-sdk": "^5.1.1",
+				"@smartthings/core-sdk": "^5.1.2",
 				"@types/jest": "^28.1.5",
 				"@types/js-yaml": "^4.0.5",
 				"@types/node": "^16.11.44",
@@ -21927,9 +21927,9 @@
 			}
 		},
 		"@smartthings/core-sdk": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-5.1.1.tgz",
-			"integrity": "sha512-BYSsMoxRyhFvDvLFy2bgix50KkufyDxOFDd1VtBlcWbePHE7tF7RHwnjjXWqEmraDQDb2a4fCCIaWQ5W21CkXw==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-5.1.2.tgz",
+			"integrity": "sha512-MrbXmkRQ9cmLetMIRByNB+U4PsdZk24ISNFtzF8XqBgMviVkl7cBBAY4Raj0xR1PK/G17mVocoNnV4MjTwzLVw==",
 			"requires": {
 				"async-mutex": "^0.3.2",
 				"axios": "^0.21.4",
@@ -21947,7 +21947,7 @@
 				"@oclif/core": "^1.16.3",
 				"@smartthings/cli-lib": "^1.0.0-beta.16",
 				"@smartthings/cli-testlib": "^1.0.0-beta.10",
-				"@smartthings/core-sdk": "^5.1.1",
+				"@smartthings/core-sdk": "^5.1.2",
 				"@types/cli-table": "^0.3.0",
 				"@types/eventsource": "^1.1.8",
 				"@types/inquirer": "^8.2.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -76,7 +76,7 @@
 		"@oclif/plugin-not-found": "^2.3.1",
 		"@oclif/plugin-plugins": "^2.1.0",
 		"@smartthings/cli-lib": "^1.0.0-beta.16",
-		"@smartthings/core-sdk": "^5.1.1",
+		"@smartthings/core-sdk": "^5.1.2",
 		"@smartthings/plugin-cli-edge": "^2.0.0-beta.2",
 		"aws-sdk": "^2.1175.0",
 		"inquirer": "^8.2.4",

--- a/packages/cli/src/__tests__/commands/devices.test.ts
+++ b/packages/cli/src/__tests__/commands/devices.test.ts
@@ -121,7 +121,7 @@ describe('DevicesCommand', () => {
 			expect(outputItemOrListMock).toHaveBeenCalledWith(
 				expect.any(DevicesCommand),
 				expect.objectContaining({
-					listTableFieldDefinitions: ['label', 'name', 'type', { label: 'Health', prop: 'healthState.state' }, 'deviceId'],
+					listTableFieldDefinitions: ['label', 'name', 'type', { label: 'Health', path: 'healthState.state' }, 'deviceId'],
 				}),
 				undefined,
 				expect.any(Function),

--- a/packages/cli/src/__tests__/lib/commands/devices-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/devices-util.test.ts
@@ -306,7 +306,7 @@ describe('devices-util', () => {
 			expect(tablePushMock).toHaveBeenCalledTimes(8)
 			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
 			expect(buildTableFromItemMock).toHaveBeenCalledWith(app,
-				['installedAppId', 'externalId', { prop: 'profile.id', label: 'Profile Id' }])
+				['installedAppId', 'externalId', { path: 'profile.id', label: 'Profile Id' }])
 		})
 
 		it('includes ble info', () => {

--- a/packages/cli/src/__tests__/lib/commands/rules-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/rules-util.test.ts
@@ -187,7 +187,7 @@ describe('rules-util', () => {
 				['executionId', 'id', 'result'])
 			expect(buildTableFromListMock).toHaveBeenCalledTimes(1)
 			expect(buildTableFromListMock).toHaveBeenCalledWith(executeResponse.actions,
-				expect.arrayContaining(['actionId', 'location.locationId']))
+				expect.arrayContaining(['actionId', { path: 'location.locationId' }]))
 		})
 
 		it('leaves out actions table when there are no actions', () => {

--- a/packages/cli/src/commands/apps/oauth/generate.ts
+++ b/packages/cli/src/commands/apps/oauth/generate.ts
@@ -1,6 +1,6 @@
-import { GenerateAppOAuthRequest } from '@smartthings/core-sdk'
-import { APICommand, inputAndOutputItem } from '@smartthings/cli-lib'
-import { chooseApp, oauthTableFieldDefinitions } from '../../../lib/commands/apps-util'
+import { GenerateAppOAuthRequest, GenerateAppOAuthResponse } from '@smartthings/core-sdk'
+import { APICommand, inputAndOutputItem, InputAndOutputItemConfig, TableFieldDefinition } from '@smartthings/cli-lib'
+import { chooseApp } from '../../../lib/commands/apps-util'
 
 
 export default class AppOauthGenerateCommand extends APICommand<typeof AppOauthGenerateCommand.flags> {
@@ -18,8 +18,17 @@ export default class AppOauthGenerateCommand extends APICommand<typeof AppOauthG
 
 	async run(): Promise<void> {
 		const appId = await chooseApp(this, this.args.id)
-		await inputAndOutputItem(this,
-			{ tableFieldDefinitions: oauthTableFieldDefinitions.concat('oauthClientId', 'oauthClientSecret') },
+		const tableFieldDefinitions: TableFieldDefinition<GenerateAppOAuthResponse>[] = [
+			{ path: 'oauthClientDetails.clientName' },
+			{ path: 'oauthClientDetails.scope' },
+			{ path: 'oauthClientDetails.redirectUris' },
+			'oauthClientId',
+			'oauthClientSecret',
+		]
+		const config: InputAndOutputItemConfig<GenerateAppOAuthResponse> = {
+			tableFieldDefinitions,
+		}
+		await inputAndOutputItem(this, config,
 			(_, data: GenerateAppOAuthRequest) => this.client.apps.regenerateOauth(appId, data))
 	}
 }

--- a/packages/cli/src/commands/capabilities.ts
+++ b/packages/cli/src/commands/capabilities.ts
@@ -1,13 +1,23 @@
 import { Flags } from '@oclif/core'
 
-import { Capability, CapabilitySummary } from '@smartthings/core-sdk'
+import { Capability } from '@smartthings/core-sdk'
 
 import {
-	APIOrganizationCommand, outputItemOrListGeneric, allOrganizationsFlags, forAllOrganizations, OutputItemOrListConfig,
+	APIOrganizationCommand,
+	outputItemOrListGeneric,
+	allOrganizationsFlags,
+	forAllOrganizations,
+	OutputItemOrListConfig,
+	WithOrganization,
 } from '@smartthings/cli-lib'
 
 import {
-	buildTableOutput, CapabilityId, capabilityIdOrIndexInputArgs, getCustomByNamespace, getStandard,
+	buildTableOutput,
+	CapabilityId,
+	capabilityIdOrIndexInputArgs,
+	CapabilitySummaryWithNamespace,
+	getCustomByNamespace,
+	getStandard,
 	translateToId,
 } from '../lib/commands/capabilities-util'
 
@@ -34,22 +44,23 @@ export default class CapabilitiesCommand extends APIOrganizationCommand<typeof C
 	async run(): Promise<void> {
 		const idOrIndex = this.args.version ? { id: this.args.id, version: this.args.version } : this.args.id
 		const sortKeyName = 'id'
-		const config: OutputItemOrListConfig<Capability, CapabilitySummary> = {
+		const config: OutputItemOrListConfig<Capability, CapabilitySummaryWithNamespace & WithOrganization> = {
 			primaryKeyName: 'id',
 			sortKeyName,
 			listTableFieldDefinitions: ['id', 'version', 'status'],
 			buildTableOutput: (data: Capability) => buildTableOutput(this.tableGenerator, data),
 		}
+		const listItems = (): Promise<(CapabilitySummaryWithNamespace & WithOrganization)[]> => {
+			if (this.flags.standard) {
+				return getStandard(this.client)
+			} else if (this.flags['all-organizations']) {
+				config.listTableFieldDefinitions.push('organization')
+				return forAllOrganizations(this.client, orgClient => getCustomByNamespace(orgClient, this.flags.namespace))
+			}
+			return getCustomByNamespace(this.client, this.flags.namespace)
+		}
 		await outputItemOrListGeneric(this, config, idOrIndex,
-			() => {
-				if (this.flags.standard) {
-					return getStandard(this.client)
-				} else if (this.flags['all-organizations']) {
-					config.listTableFieldDefinitions.push('organization')
-					return forAllOrganizations(this.client, orgClient => getCustomByNamespace(orgClient, this.flags.namespace))
-				}
-				return getCustomByNamespace(this.client, this.flags.namespace)
-			},
+			listItems,
 			(id: CapabilityId) => this.client.capabilities.get(id.id, id.version),
 			(idOrIndex, listFunction) => translateToId(sortKeyName, idOrIndex, listFunction))
 	}

--- a/packages/cli/src/commands/capabilities/translations.ts
+++ b/packages/cli/src/commands/capabilities/translations.ts
@@ -3,7 +3,7 @@ import { Flags } from '@oclif/core'
 import { CapabilityLocalization, DeviceProfileTranslations, LocaleReference } from '@smartthings/core-sdk'
 
 import { APIOrganizationCommand, OutputItemOrListConfig, outputItemOrList, selectFromList,
-	SelectFromListConfig, TableGenerator } from '@smartthings/cli-lib'
+	SelectFromListConfig, TableGenerator, WithLocales } from '@smartthings/cli-lib'
 
 import { CapabilityId, capabilityIdOrIndexInputArgs, CapabilitySummaryWithNamespace, getCustomByNamespace,
 	getIdFromUser, translateToId } from '../../lib/commands/capabilities-util'
@@ -42,7 +42,7 @@ export function buildTableOutput(tableGenerator: TableGenerator, data: Capabilit
 	return result
 }
 
-export type CapabilitySummaryWithLocales = CapabilitySummaryWithNamespace & { locales?: string }
+export type CapabilitySummaryWithLocales = CapabilitySummaryWithNamespace & WithLocales
 
 export default class CapabilityTranslationsCommand extends APIOrganizationCommand<typeof CapabilityTranslationsCommand.flags> {
 
@@ -128,9 +128,9 @@ export default class CapabilityTranslationsCommand extends APIOrganizationComman
 	]
 
 	async run(): Promise<void> {
-		const capConfig: SelectFromListConfig<CapabilitySummaryWithNamespace> = {
+		const primaryKeyName = 'id'
+		const capConfig: SelectFromListConfig<CapabilitySummaryWithLocales> = {
 			primaryKeyName: 'id',
-			sortKeyName: 'id',
 			listTableFieldDefinitions: ['id', 'version', 'status'],
 		}
 		if (this.flags.verbose) {
@@ -160,15 +160,15 @@ export default class CapabilityTranslationsCommand extends APIOrganizationComman
 				preselectedId = { id: this.args.id, version: this.args.version }
 			} else {
 				// capability id or index, no capability version specified, tag specified
-				preselectedId = await translateToId(capConfig.primaryKeyName, this.args.id, listItems)
+				preselectedId = await translateToId(primaryKeyName, this.args.id, listItems)
 				preselectedTag = this.args.version
 			}
 		} else {
 			// capability id or index, no tag specified
-			preselectedId = await translateToId(capConfig.primaryKeyName, this.args.id, listItems)
+			preselectedId = await translateToId(primaryKeyName, this.args.id, listItems)
 		}
 
-		const capabilityId = await selectFromList(this, capConfig, {
+		const capabilityId = await selectFromList<CapabilitySummaryWithLocales, CapabilityId>(this, capConfig, {
 			preselectedId,
 			listItems,
 			getIdFromUser,

--- a/packages/cli/src/commands/devicepreferences.ts
+++ b/packages/cli/src/commands/devicepreferences.ts
@@ -1,6 +1,17 @@
 import { Flags } from '@oclif/core'
+
 import { DevicePreference } from '@smartthings/core-sdk'
-import { APIOrganizationCommand, outputItemOrList, allOrganizationsFlags, forAllOrganizations, OutputItemOrListConfig } from '@smartthings/cli-lib'
+
+import {
+	APIOrganizationCommand,
+	outputItemOrList,
+	allOrganizationsFlags,
+	forAllOrganizations,
+	OutputItemOrListConfig,
+	TableFieldDefinition,
+	WithOrganization,
+} from '@smartthings/cli-lib'
+
 import { tableFieldDefinitions } from '../lib/commands/devicepreferences-util'
 
 
@@ -57,8 +68,9 @@ export default class DevicePreferencesCommand extends APIOrganizationCommand<typ
 	]
 
 	async run(): Promise<void> {
-		const listTableFieldDefinitions = ['preferenceId', 'title', 'name', 'description', 'required', 'preferenceType']
-		const config: OutputItemOrListConfig<DevicePreference> = {
+		const listTableFieldDefinitions: TableFieldDefinition<DevicePreference & WithOrganization>[] =
+			['preferenceId', 'title', 'name', 'description', 'required', 'preferenceType']
+		const config: OutputItemOrListConfig<DevicePreference, DevicePreference & WithOrganization> = {
 			itemName: 'device preference',
 			primaryKeyName: 'preferenceId',
 			sortKeyName: 'preferenceId',

--- a/packages/cli/src/commands/deviceprofiles.ts
+++ b/packages/cli/src/commands/deviceprofiles.ts
@@ -8,7 +8,6 @@ import {
 	allOrganizationsFlags,
 	outputItemOrList,
 	forAllOrganizations,
-	TableFieldDefinition,
 	OutputItemOrListConfig,
 } from '@smartthings/cli-lib'
 
@@ -45,10 +44,10 @@ export default class DeviceProfilesCommand extends APIOrganizationCommand<typeof
 	static aliases = ['device-profiles']
 
 	async run(): Promise<void> {
-		const config: OutputItemOrListConfig<DeviceProfile> = {
+		const config: OutputItemOrListConfig<DeviceProfile & WithOrganization> = {
 			primaryKeyName: 'id',
 			sortKeyName: 'name',
-			listTableFieldDefinitions: ['name', 'status', 'id'] as TableFieldDefinition<DeviceProfile & WithOrganization>[],
+			listTableFieldDefinitions: ['name', 'status', 'id'],
 			buildTableOutput: (data: DeviceProfile) => buildTableOutput(this.tableGenerator, data),
 		}
 

--- a/packages/cli/src/commands/installedapps/delete.ts
+++ b/packages/cli/src/commands/installedapps/delete.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 
 import { InstalledApp, InstalledAppListOptions } from '@smartthings/core-sdk'
 
-import { selectFromList, APICommand, withLocations, SelectFromListConfig } from '@smartthings/cli-lib'
+import { selectFromList, APICommand, withLocations, SelectFromListConfig, WithNamedLocation } from '@smartthings/cli-lib'
 
 
 export default class InstalledAppDeleteCommand extends APICommand<typeof InstalledAppDeleteCommand.flags> {
@@ -28,7 +28,7 @@ export default class InstalledAppDeleteCommand extends APICommand<typeof Install
 	}]
 
 	async run(): Promise<void> {
-		const config: SelectFromListConfig<InstalledApp> = {
+		const config: SelectFromListConfig<InstalledApp & WithNamedLocation> = {
 			primaryKeyName: 'installedAppId',
 			sortKeyName: 'displayName',
 			listTableFieldDefinitions: ['displayName', 'installedAppType', 'installedAppStatus', 'installedAppId'],
@@ -41,7 +41,7 @@ export default class InstalledAppDeleteCommand extends APICommand<typeof Install
 			locationId: this.flags.location,
 		}
 
-		const id = await selectFromList<InstalledApp>(this, config, {
+		const id = await selectFromList(this, config, {
 			preselectedId: this.args.id,
 			listItems: async () => {
 				const apps = await this.client.installedApps.list(listOptions)

--- a/packages/cli/src/commands/installedapps/rename.ts
+++ b/packages/cli/src/commands/installedapps/rename.ts
@@ -3,7 +3,7 @@ import inquirer from 'inquirer'
 
 import { InstalledApp, InstalledAppListOptions } from '@smartthings/core-sdk'
 
-import { APICommand, formatAndWriteItem, FormatAndWriteItemConfig, selectFromList, SelectFromListConfig, withLocations } from '@smartthings/cli-lib'
+import { APICommand, formatAndWriteItem, FormatAndWriteItemConfig, selectFromList, SelectFromListConfig, withLocations, WithNamedLocation } from '@smartthings/cli-lib'
 import { listTableFieldDefinitions, tableFieldDefinitions } from '../../lib/commands/installedapps-util'
 
 
@@ -37,7 +37,7 @@ export default class InstalledAppRenameCommand extends APICommand<typeof Install
 	]
 
 	async run(): Promise<void> {
-		const config: SelectFromListConfig<InstalledApp> & FormatAndWriteItemConfig<InstalledApp> = {
+		const config: SelectFromListConfig<InstalledApp & WithNamedLocation> & FormatAndWriteItemConfig<InstalledApp> = {
 			itemName: 'installed app',
 			primaryKeyName: 'installedAppId',
 			sortKeyName: 'displayName',

--- a/packages/cli/src/commands/installedschema.ts
+++ b/packages/cli/src/commands/installedschema.ts
@@ -35,7 +35,7 @@ export default class InstalledSchemaAppsCommand extends APICommand<typeof Instal
 	}]
 
 	async run(): Promise<void> {
-		const config: OutputItemOrListConfig<InstalledSchemaApp, InstalledSchemaApp & WithNamedLocation> = {
+		const config: OutputItemOrListConfig<InstalledSchemaApp & WithNamedLocation> = {
 			primaryKeyName: 'isaId',
 			sortKeyName: 'appName',
 			listTableFieldDefinitions,

--- a/packages/cli/src/commands/installedschema/delete.ts
+++ b/packages/cli/src/commands/installedschema/delete.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 
 import { InstalledSchemaApp } from '@smartthings/core-sdk'
 
-import { APICommand, selectFromList, SelectFromListConfig } from '@smartthings/cli-lib'
+import { APICommand, selectFromList, SelectFromListConfig, WithNamedLocation } from '@smartthings/cli-lib'
 
 import { installedSchemaInstances } from '../../lib/commands/installedschema-util'
 
@@ -29,7 +29,7 @@ export default class InstalledSchemaAppDeleteCommand extends APICommand<typeof I
 	}]
 
 	async run(): Promise<void> {
-		const config: SelectFromListConfig<InstalledSchemaApp> = {
+		const config: SelectFromListConfig<InstalledSchemaApp & WithNamedLocation> = {
 			primaryKeyName: 'isaId',
 			sortKeyName: 'appName',
 			listTableFieldDefinitions: ['appName', 'partnerName', 'partnerSTConnection', 'isaId'],
@@ -38,7 +38,7 @@ export default class InstalledSchemaAppDeleteCommand extends APICommand<typeof I
 			config.listTableFieldDefinitions.splice(3, 0, 'location')
 		}
 
-		const id = await selectFromList<InstalledSchemaApp>(this, config, {
+		const id = await selectFromList(this, config, {
 			preselectedId: this.args.id,
 			listItems: () => installedSchemaInstances(this.client, this.flags.location, this.flags.verbose),
 			promptMessage: 'Select an installed schema app to delete.',

--- a/packages/cli/src/commands/locations.ts
+++ b/packages/cli/src/commands/locations.ts
@@ -1,9 +1,9 @@
 import { Location, LocationItem } from '@smartthings/core-sdk'
 
-import { APICommand, outputItemOrList, OutputItemOrListConfig, selectFromList, SelectFromListConfig, stringTranslateToId } from '@smartthings/cli-lib'
+import { APICommand, outputItemOrList, OutputItemOrListConfig, selectFromList, SelectFromListConfig, stringTranslateToId, TableFieldDefinition } from '@smartthings/cli-lib'
 
 
-export const tableFieldDefinitions = [
+export const tableFieldDefinitions: TableFieldDefinition<Location>[] = [
 	'name', 'locationId', 'countryCode', 'timeZoneId', 'backgroundImage',
 	'latitude', 'longitude', 'regionRadius', 'temperatureScale', 'locale',
 ]

--- a/packages/cli/src/commands/locations/rooms.ts
+++ b/packages/cli/src/commands/locations/rooms.ts
@@ -32,7 +32,7 @@ export default class RoomsCommand extends APICommand<typeof RoomsCommand.flags> 
 	static aliases = ['rooms']
 
 	async run(): Promise<void> {
-		const config: OutputItemOrListConfig<Room, Room & WithNamedLocation> = {
+		const config: OutputItemOrListConfig<Room & WithNamedLocation> = {
 			primaryKeyName: 'roomId',
 			sortKeyName: 'name',
 			listTableFieldDefinitions: tableFieldDefinitions,

--- a/packages/cli/src/commands/organizations.ts
+++ b/packages/cli/src/commands/organizations.ts
@@ -1,8 +1,8 @@
-import { APICommand, outputItemOrList, OutputItemOrListConfig } from '@smartthings/cli-lib'
+import { APICommand, outputItemOrList, OutputItemOrListConfig, TableFieldDefinition } from '@smartthings/cli-lib'
 import { OrganizationResponse } from '@smartthings/core-sdk'
 
 
-export const tableFieldDefinitions = [
+export const tableFieldDefinitions: TableFieldDefinition<OrganizationResponse>[] = [
 	'name', 'label', 'organizationId', 'developerGroupId', 'adminGroupId', 'warehouseGroupId',
 	{
 		prop: 'isDefaultUserOrg',

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -26,7 +26,8 @@ export default class SchemaCommand extends APICommand<typeof SchemaCommand.flags
 		const config: OutputItemOrListConfig<SchemaApp> = {
 			tableFieldDefinitions: [
 				'appName', 'partnerName', 'endpointAppId', 'schemaType', 'hostingType',
-				'stClientId', 'oAuthAuthorizationUrl', 'oAuthTokenUrl', 'oAuthClientId',
+				// stClientId is missing from the docs
+				('stClientId' as keyof SchemaApp), 'oAuthAuthorizationUrl', 'oAuthTokenUrl', 'oAuthClientId',
 				'oAuthClientSecret', 'icon', 'icon2x', 'icon3x',
 				{ prop: 'lambdaArn', skipEmpty: true },
 				{ prop: 'lambdaArnAP', skipEmpty: true },

--- a/packages/cli/src/commands/virtualdevices.ts
+++ b/packages/cli/src/commands/virtualdevices.ts
@@ -11,6 +11,7 @@ import {
 	outputItemOrList,
 	OutputItemOrListConfig,
 	withLocationsAndRooms,
+	WithNamedRoom,
 } from '@smartthings/cli-lib'
 
 import { buildTableOutput } from '../lib/commands/devices-util'
@@ -46,7 +47,7 @@ export default class VirtualDevicesCommand extends APICommand<typeof VirtualDevi
 	}]
 
 	async run(): Promise<void> {
-		const config: OutputItemOrListConfig<Device> = {
+		const config: OutputItemOrListConfig<Device & WithNamedRoom> = {
 			primaryKeyName: 'deviceId',
 			sortKeyName: 'label',
 			listTableFieldDefinitions: ['label', 'deviceId'],

--- a/packages/cli/src/lib/commands/apps-util.ts
+++ b/packages/cli/src/lib/commands/apps-util.ts
@@ -1,4 +1,4 @@
-import { AppListOptions, AppResponse, AppSettingsResponse, PagedApp, SmartThingsClient } from '@smartthings/core-sdk'
+import { AppListOptions, AppOAuthRequest, AppResponse, AppSettingsResponse, PagedApp, SmartThingsClient } from '@smartthings/core-sdk'
 
 import {
 	APICommand,
@@ -22,28 +22,28 @@ export const tableFieldDefinitions: TableFieldDefinition<AppResponse>[] = [
 	'description',
 	'singleInstance',
 	{ prop: 'classifications', include: app => !!app.classifications },
-	{ prop: 'installMetadata.certified', include: app => !!app.installMetadata?.certified },
-	{ prop: 'installMetadata.maxInstalls', include: app => !!app.installMetadata?.maxInstalls },
+	{ path: 'installMetadata.certified', include: app => !!app.installMetadata?.certified },
+	{ path: 'installMetadata.maxInstalls', include: app => !!app.installMetadata?.maxInstalls },
 	'appType',
-	{ prop: 'webhookSmartApp.signatureType', include: isWebhookSmartApp },
-	{ prop: 'webhookSmartApp.targetUrl', include: isWebhookSmartApp },
-	{ prop: 'webhookSmartApp.targetStatus', include: isWebhookSmartApp },
+	{ path: 'webhookSmartApp.signatureType', include: isWebhookSmartApp },
+	{ path: 'webhookSmartApp.targetUrl', include: isWebhookSmartApp },
+	{ path: 'webhookSmartApp.targetStatus', include: isWebhookSmartApp },
 	{
-		prop: 'webhookSmartApp.publicKey',
+		label: 'Public Key',
 		include: app => !!app.webhookSmartApp?.publicKey,
 		value: app => app.webhookSmartApp?.publicKey?.replace(/\r\n/g, '\n') ?? '',
 	},
 	{
-		include: app => !!app.lambdaSmartApp?.functions,
 		label: 'Lambda Function',
+		include: app => !!app.lambdaSmartApp?.functions,
 		value: app => app.lambdaSmartApp?.functions?.join('\n') ?? '',
 	},
-	{ prop: 'apiOnly.subscription.targetUrl', include: hasSubscription },
-	{ prop: 'apiOnly.subscription.targetStatus', include: hasSubscription },
-	{ prop: 'installMetadata.certified', include: app => app.installMetadata?.certified !== undefined },
+	{ path: 'apiOnly.subscription.targetUrl', include: hasSubscription },
+	{ path: 'apiOnly.subscription.targetStatus', include: hasSubscription },
+	{ path: 'installMetadata.certified', include: app => app.installMetadata?.certified !== undefined },
 ]
 
-export const oauthTableFieldDefinitions = ['clientName', 'scope', 'redirectUris']
+export const oauthTableFieldDefinitions: TableFieldDefinition<AppOAuthRequest>[] = ['clientName', 'scope', 'redirectUris']
 
 export const chooseApp =  async (command: APICommand<typeof APICommand.flags>, appFromArg?: string, options?: Partial<ChooseOptions>): Promise<string> => {
 	const opts = chooseOptionsWithDefaults(options)

--- a/packages/cli/src/lib/commands/devicepreferences-util.ts
+++ b/packages/cli/src/lib/commands/devicepreferences-util.ts
@@ -5,14 +5,14 @@ import { APICommand, selectFromList, SelectFromListConfig, TableFieldDefinition 
 
 export const tableFieldDefinitions: TableFieldDefinition<DevicePreference>[] = [
 	'preferenceId', 'title', 'name', 'description', 'required', 'preferenceType',
-	{ prop: 'definition.default', skipEmpty: true },
-	{ prop: 'definition.minimum', skipEmpty: true },
-	{ prop: 'definition.maximum', skipEmpty: true },
-	{ prop: 'definition.minLength', skipEmpty: true },
-	{ prop: 'definition.maxLength', skipEmpty: true },
-	{ prop: 'definition.stringType', skipEmpty: true },
+	{ path: 'definition.default', skipEmpty: true },
+	{ path: 'definition.minimum', skipEmpty: true },
+	{ path: 'definition.maximum', skipEmpty: true },
+	{ path: 'definition.minLength', skipEmpty: true },
+	{ path: 'definition.maxLength', skipEmpty: true },
+	{ path: 'definition.stringType', skipEmpty: true },
 	{
-		prop: 'definition.options',
+		path: 'definition.options',
 		skipEmpty: true,
 		value: (pref: DevicePreference): string | undefined => {
 			if (pref.preferenceType !== 'enumeration') {

--- a/packages/cli/src/lib/commands/deviceprofiles-util.ts
+++ b/packages/cli/src/lib/commands/deviceprofiles-util.ts
@@ -16,6 +16,7 @@ import {
 	stringTranslateToId,
 	summarizedText,
 	TableGenerator,
+	WithLocales,
 } from '@smartthings/cli-lib'
 
 
@@ -87,7 +88,7 @@ export const buildTableOutput = (tableGenerator: TableGenerator, data: DevicePro
 	if (options?.includePreferences) {
 		const preferencesInfo = data.preferences?.length
 			? 'Device Preferences\n' + tableGenerator.buildTableFromList(data.preferences,
-				['preferenceId', 'title', 'preferenceType', 'definition.default'])
+				['preferenceId', 'title', 'preferenceType', { path: 'definition.default' }])
 			: 'No preferences'
 		return `Basic Information\n${table.toString()}\n\n` +
 			`${preferencesInfo}\n\n` +
@@ -99,7 +100,7 @@ export const buildTableOutput = (tableGenerator: TableGenerator, data: DevicePro
 export const chooseDeviceProfile = async (command: APIOrganizationCommand<typeof APIOrganizationCommand.flags>,
 		deviceProfileFromArg?: string, options?: Partial<ChooseOptions>): Promise<string> => {
 	const opts = chooseOptionsWithDefaults(options)
-	const config: SelectFromListConfig<DeviceProfile> = {
+	const config: SelectFromListConfig<DeviceProfile & WithLocales> = {
 		itemName: 'device profile',
 		primaryKeyName: 'id',
 		sortKeyName: 'name',
@@ -109,10 +110,10 @@ export const chooseDeviceProfile = async (command: APIOrganizationCommand<typeof
 		config.listTableFieldDefinitions.splice(3, 0, 'locales')
 	}
 
-	const listItems = async (): Promise<DeviceProfile[]> => {
+	const listItems = async (): Promise<(DeviceProfile & WithLocales)[]> => {
 		const deviceProfiles = await command.client.deviceProfiles.list()
 		if (opts.verbose) {
-			const ops = deviceProfiles.map(async (it) => {
+			const ops = deviceProfiles.map(async it => {
 				try {
 					return await command.client.deviceProfiles.listLocales(it.id)
 				} catch (error) {

--- a/packages/cli/src/lib/commands/devices-util.ts
+++ b/packages/cli/src/lib/commands/devices-util.ts
@@ -99,55 +99,55 @@ export const buildTableOutput = (tableGenerator: TableGenerator, device: Device 
 
 	let deviceIntegrationInfo = 'None'
 	let infoFrom
-	if ('app' in device) {
+	if (device.app) {
 		infoFrom = 'app'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.app ?? {},
-			['installedAppId', 'externalId', { prop: 'profile.id', label: 'Profile Id' }])
-	} else if ('ble' in device) {
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.app,
+			['installedAppId', 'externalId', { path: 'profile.id', label: 'Profile Id' }])
+	} else if (device.ble) {
 		infoFrom = 'ble'
 		deviceIntegrationInfo = 'No Device Integration Info for BLE devices'
-	} else if ('bleD2D' in device) {
+	} else if (device.bleD2D) {
 		infoFrom = 'bleD2D'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.bleD2D ?? {},
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.bleD2D,
 			['advertisingId', 'identifier', 'configurationVersion', 'configurationUrl'])
-	} else if ('dth' in device) {
+	} else if (device.dth) {
 		infoFrom = 'dth'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.dth ?? {},
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.dth,
 			['deviceTypeId', 'deviceTypeName', 'completedSetup', 'deviceNetworkType',
 				'executingLocally', 'hubId', 'installedGroovyAppId', 'networkSecurityLevel'])
-	} else if ('lan' in device) {
+	} else if (device.lan) {
 		infoFrom = 'lan'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.lan ?? {},
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.lan,
 			['networkId', 'driverId', 'executingLocally', 'hubId', 'provisioningState'])
-	} else if ('zigbee' in device) {
+	} else if (device.zigbee) {
 		infoFrom = 'zigbee'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.zigbee ?? {},
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.zigbee,
 			['eui', 'networkId', 'driverId', 'executingLocally', 'hubId', 'provisioningState'])
-	} else if ('zwave' in device) {
+	} else if (device.zwave) {
 		infoFrom = 'zwave'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.zwave ?? {},
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.zwave,
 			['networkId', 'driverId', 'executingLocally', 'hubId', 'networkSecurityLevel', 'provisioningState'])
-	} else if ('ir' in device) {
+	} else if (device.ir) {
 		infoFrom = 'ir'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.ir ?? {},
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.ir,
 			['parentDeviceId', 'profileId', 'ocfDeviceType', 'irCode'])
-	} else if ('irOcf' in device) {
+	} else if (device.irOcf) {
 		infoFrom = 'irOcf'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.irOcf ?? {},
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.irOcf,
 			['parentDeviceId', 'profileId', 'ocfDeviceType', 'irCode'])
-	} else if ('ocf' in device) {
+	} else if (device.ocf) {
 		infoFrom = 'ocf'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.ocf ?? {},
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.ocf,
 			['deviceId', 'ocfDeviceType', 'name', 'specVersion', 'verticalDomainSpecVersion',
 				'manufacturerName', 'modelNumber', 'platformVersion', 'platformOS', 'hwVersion',
 				'firmwareVersion', 'vendorId', 'vendorResourceClientServerVersion', 'locale'])
-	} else if ('viper' in device) {
+	} else if (device.viper) {
 		infoFrom = 'viper'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.viper ?? {},
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.viper,
 			['uniqueIdentifier', 'manufacturerName', 'modelName', 'swVersion', 'hwVersion'])
-	} else if ('virtual' in device) {
+	} else if (device.virtual) {
 		infoFrom = 'virtual'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.virtual ?? {},
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.virtual,
 			['name', { prop: 'hubId', skipEmpty: true }, { prop: 'driverId', skipEmpty: true }])
 	}
 

--- a/packages/cli/src/lib/commands/installedapps-util.ts
+++ b/packages/cli/src/lib/commands/installedapps-util.ts
@@ -2,7 +2,8 @@ import { TableFieldDefinition } from '@smartthings/cli-lib'
 import { InstalledApp } from '@smartthings/core-sdk'
 
 
-export const listTableFieldDefinitions = ['displayName', 'installedAppType', 'installedAppStatus', 'installedAppId']
+export const listTableFieldDefinitions: TableFieldDefinition<InstalledApp>[] =
+	['displayName', 'installedAppType', 'installedAppStatus', 'installedAppId']
 
 export const tableFieldDefinitions: TableFieldDefinition<InstalledApp>[] = [
 	'displayName', 'installedAppId', 'installedAppType', 'installedAppStatus',

--- a/packages/cli/src/lib/commands/installedschema-util.ts
+++ b/packages/cli/src/lib/commands/installedschema-util.ts
@@ -3,8 +3,9 @@ import { InstalledSchemaApp, SmartThingsClient } from '@smartthings/core-sdk'
 import { TableFieldDefinition, withLocations, WithNamedLocation } from '@smartthings/cli-lib'
 
 
-export const listTableFieldDefinitions = ['appName', 'partnerName', 'partnerSTConnection', 'isaId']
-export const tableFieldDefinitions: TableFieldDefinition<InstalledSchemaApp>[] = [
+export const listTableFieldDefinitions: TableFieldDefinition<InstalledSchemaApp & WithNamedLocation>[] =
+	['appName', 'partnerName', 'partnerSTConnection', 'isaId']
+export const tableFieldDefinitions: TableFieldDefinition<InstalledSchemaApp & WithNamedLocation>[] = [
 	'appName', 'isaId', 'partnerName', 'partnerSTConnection', 'locationId',
 	'icon', 'icon2x', 'icon3x',
 ]

--- a/packages/cli/src/lib/commands/locations/rooms-util.ts
+++ b/packages/cli/src/lib/commands/locations/rooms-util.ts
@@ -3,11 +3,11 @@ import { Errors } from '@oclif/core'
 import { LocationItem, Room, SmartThingsClient } from '@smartthings/core-sdk'
 
 import * as roomsUtil from './rooms-util'
-import { APICommand, selectFromList, SelectFromListConfig, WithNamedLocation } from '@smartthings/cli-lib'
+import { APICommand, selectFromList, SelectFromListConfig, TableFieldDefinition, WithNamedLocation } from '@smartthings/cli-lib'
 
 
-export const tableFieldDefinitions = ['name', 'roomId', 'locationId' ]
-export const tableFieldDefinitionsWithLocationName = ['name', 'roomId', 'location', 'locationId' ]
+export const tableFieldDefinitions: TableFieldDefinition<Room>[] = ['name', 'roomId', 'locationId' ]
+export const tableFieldDefinitionsWithLocationName: TableFieldDefinition<Room & WithNamedLocation>[] = ['name', 'roomId', 'location', 'locationId' ]
 
 export async function getRoomsByLocation(client: SmartThingsClient, locationId?: string): Promise<(Room & WithNamedLocation)[]> {
 	let locations: LocationItem[] = []
@@ -32,7 +32,7 @@ export async function getRoomsByLocation(client: SmartThingsClient, locationId?:
 
 export async function chooseRoom(command: APICommand<typeof APICommand.flags>, locationId?: string, preselectedId?: string, autoChoose?: boolean): Promise<[string, string]> {
 	const rooms = await roomsUtil.getRoomsByLocation(command.client, locationId)
-	const config: SelectFromListConfig<Room> = {
+	const config: SelectFromListConfig<Room & WithNamedLocation> = {
 		itemName: 'room',
 		primaryKeyName: 'roomId',
 		sortKeyName: 'name',

--- a/packages/cli/src/lib/commands/rules-util.ts
+++ b/packages/cli/src/lib/commands/rules-util.ts
@@ -69,8 +69,8 @@ export const buildExecuteResponseTableOutput = (tableGenerator: TableGenerator, 
 	const actionsInfoTableDefinitions: TableFieldDefinition<ActionExecutionResult>[] = [
 		'actionId',
 		{ label: 'Result', value: calculateResult },
-		'location.locationId',
-		'command.deviceId',
+		{ path: 'location.locationId' },
+		{ path: 'command.deviceId' },
 	]
 	const actionsInfo = executeResponse.actions
 		? tableGenerator.buildTableFromList(executeResponse.actions, actionsInfoTableDefinitions)

--- a/packages/cli/src/lib/commands/scenes-util.ts
+++ b/packages/cli/src/lib/commands/scenes-util.ts
@@ -1,9 +1,9 @@
 import { SceneSummary } from '@smartthings/core-sdk'
 
-import { APICommand, selectFromList, SelectFromListConfig } from '@smartthings/cli-lib'
+import { APICommand, selectFromList, SelectFromListConfig, TableFieldDefinition } from '@smartthings/cli-lib'
 
 
-export const tableFieldDefinitions = [
+export const tableFieldDefinitions: TableFieldDefinition<SceneSummary>[] = [
 	'sceneName', 'sceneId', 'locationId', 'lastExecutedDate',
 ]
 

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -43,7 +43,7 @@
 		"@log4js-node/log4js-api": "^1.0.2",
 		"@oclif/core": "^1.16.3",
 		"@smartthings/cli-lib": "^1.0.0-beta.16",
-		"@smartthings/core-sdk": "^5.1.1",
+		"@smartthings/core-sdk": "^5.1.2",
 		"axios": "^0.21.4",
 		"inquirer": "^8.2.4",
 		"js-yaml": "^4.1.0",

--- a/packages/edge/src/commands/edge/channels.ts
+++ b/packages/edge/src/commands/edge/channels.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 
 import { Channel, SubscriberType } from '@smartthings/core-sdk'
 
-import { allOrganizationsFlags, outputItemOrList, OutputItemOrListConfig } from '@smartthings/cli-lib'
+import { allOrganizationsFlags, outputItemOrList, OutputItemOrListConfig, WithOrganization } from '@smartthings/cli-lib'
 
 import { EdgeCommand } from '../../lib/edge-command'
 import { listChannels, listTableFieldDefinitions, tableFieldDefinitions } from '../../lib/commands/channels-util'
@@ -51,7 +51,7 @@ $ smartthings edge:channels 2
 $ smartthings edge:channels --subscriber-type HUB --subscriber-id <hub-id>`]
 
 	async run(): Promise<void> {
-		const config: OutputItemOrListConfig<Channel> = {
+		const config: OutputItemOrListConfig<Channel & WithOrganization> = {
 			primaryKeyName: 'channelId',
 			sortKeyName: 'name',
 			listTableFieldDefinitions,

--- a/packages/edge/src/commands/edge/channels/create.ts
+++ b/packages/edge/src/commands/edge/channels/create.ts
@@ -2,13 +2,13 @@ import inquirer from 'inquirer'
 
 import { Channel, ChannelCreate } from '@smartthings/core-sdk'
 
-import { inputAndOutputItem, userInputProcessor } from '@smartthings/cli-lib'
+import { inputAndOutputItem, TableFieldDefinition, userInputProcessor } from '@smartthings/cli-lib'
 
 import { EdgeCommand } from '../../../lib/edge-command'
 
 
-const tableFieldDefinitions = ['channelId', 'name', 'description', 'type', 'termsOfServiceUrl',
-	'createdDate', 'lastModifiedDate']
+const tableFieldDefinitions: TableFieldDefinition<Channel>[] = ['channelId', 'name', 'description',
+	'type', 'termsOfServiceUrl', 'createdDate', 'lastModifiedDate']
 
 export default class ChannelsCreateCommand extends EdgeCommand<typeof ChannelsCreateCommand.flags> {
 	static description = 'create a channel'

--- a/packages/edge/src/commands/edge/channels/invites.ts
+++ b/packages/edge/src/commands/edge/channels/invites.ts
@@ -17,15 +17,15 @@ import { Invitation } from '../../../lib/endpoints/invites'
 
 export const listTableFieldDefinitions: TableFieldDefinition<Invitation>[] = [
 	'id',
-	'metadata.name',
-	{ label: 'Channel Id', prop: 'resource.components[0].id' },
+	{ path: 'metadata.name' },
+	{ label: 'Channel Id', path: 'resource.components[0].id' },
 	{
 		label: 'Expiration',
 		value: ({ expiration }) => expiration ? new Date(expiration * 1000).toISOString() : '',
 	},
 	'acceptUrl',
 ]
-export const tableFieldDefinitions = [
+export const tableFieldDefinitions: TableFieldDefinition<Invitation>[] = [
 	...listTableFieldDefinitions,
 	'profileId',
 ]
@@ -43,7 +43,7 @@ export async function chooseInvite(command: EdgeCommand<typeof EdgeCommand.flags
 		itemName: 'invitation',
 		primaryKeyName: 'id',
 		sortKeyName: 'id', // only supports simple properties so we can't sort by metadata.name even though we can use that in the table
-		listTableFieldDefinitions: ['id', 'metadata.name'],
+		listTableFieldDefinitions: ['id', { path: 'metadata.name' }],
 	}
 	const listItems = buildListFunction(command, channelId)
 	const preselectedId = opts.allowIndex

--- a/packages/edge/src/commands/edge/channels/invites/create.ts
+++ b/packages/edge/src/commands/edge/channels/invites/create.ts
@@ -1,14 +1,17 @@
 import { Flags } from '@oclif/core'
 import inquirer from 'inquirer'
 
-import { inputAndOutputItem, userInputProcessor } from '@smartthings/cli-lib'
+import { inputAndOutputItem, TableFieldDefinition, userInputProcessor } from '@smartthings/cli-lib'
 
 import { chooseChannel } from '../../../../lib/commands/channels-util'
 import { EdgeCommand } from '../../../../lib/edge-command'
 import { CreateInvitation, Invitation } from '../../../../lib/endpoints/invites'
 
 
-const tableFieldDefinitions = ['id', 'metadata.name', 'profileId', 'expiration', 'acceptUrl']
+const tableFieldDefinitions: TableFieldDefinition<Invitation>[] = [
+	'id',
+	{ path: 'metadata.name' },
+	'profileId', 'expiration', 'acceptUrl']
 
 const defaultInvitationProfileId = '61a79569-e8fd-4a4d-9b9c-a4a55ccdd15e'
 

--- a/packages/edge/src/commands/edge/drivers.ts
+++ b/packages/edge/src/commands/edge/drivers.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 
 import { EdgeDriver } from '@smartthings/core-sdk'
 
-import { allOrganizationsFlags, outputItemOrList, OutputItemOrListConfig } from '@smartthings/cli-lib'
+import { allOrganizationsFlags, outputItemOrList, OutputItemOrListConfig, WithOrganization } from '@smartthings/cli-lib'
 
 import { EdgeCommand } from '../../lib/edge-command'
 import { buildTableOutput, listDrivers, listTableFieldDefinitions } from '../../lib/commands/drivers-util'
@@ -45,7 +45,7 @@ $ smartthings edge:drivers 699c7308-8c72-4363-9571-880d0f5cc725
 $ smartthings edge:drivers 699c7308-8c72-4363-9571-880d0f5cc725 --version 2021-10-25T00:48:23.295969`]
 
 	async run(): Promise<void> {
-		const config: OutputItemOrListConfig<EdgeDriver> = {
+		const config: OutputItemOrListConfig<EdgeDriver & WithOrganization> = {
 			primaryKeyName: 'driverId',
 			sortKeyName: 'name',
 			buildTableOutput: (driver: EdgeDriver) => buildTableOutput(this.tableGenerator, driver),

--- a/packages/edge/src/commands/edge/drivers/package.ts
+++ b/packages/edge/src/commands/edge/drivers/package.ts
@@ -3,13 +3,14 @@ import fs from 'fs'
 import { Flags } from '@oclif/core'
 import JSZip from 'jszip'
 
-import { outputItem, readFile } from '@smartthings/cli-lib'
+import { outputItem, OutputItemConfig, readFile } from '@smartthings/cli-lib'
 
 import { buildTestFileMatchers, processConfigFile, processFingerprintsFile, processProfiles,
 	processSrcDir, resolveProjectDirName } from '../../../lib/commands/drivers/package-util'
 import { chooseChannel } from '../../../lib/commands/channels-util'
 import { chooseHub } from '../../../lib/commands/drivers-util'
 import { EdgeCommand } from '../../../lib/edge-command'
+import { EdgeDriver } from '@smartthings/core-sdk'
 
 
 export default class PackageCommand extends EdgeCommand<typeof PackageCommand.flags> {
@@ -79,7 +80,7 @@ $ smartthings edge:drivers:package -u driver.zip`]
 
 	async run(): Promise<void> {
 		const uploadAndPostProcess = async (archiveData: Uint8Array): Promise<void> => {
-			const config = {
+			const config: OutputItemConfig<EdgeDriver> = {
 				tableFieldDefinitions: ['driverId', 'name', 'packageKey', 'version'],
 			}
 			const driver = await outputItem(this, config, () => this.client.drivers.upload(archiveData))

--- a/packages/edge/src/lib/commands/channels-util.ts
+++ b/packages/edge/src/lib/commands/channels-util.ts
@@ -8,11 +8,12 @@ import {
 	selectFromList,
 	SelectFromListConfig,
 	stringTranslateToId,
+	TableFieldDefinition,
 } from '@smartthings/cli-lib'
 
 
-export const listTableFieldDefinitions = ['channelId', 'name', 'description', 'termsOfServiceUrl',
-	'createdDate', 'lastModifiedDate']
+export const listTableFieldDefinitions: TableFieldDefinition<Channel>[] =
+	['channelId', 'name', 'description', 'termsOfServiceUrl', 'createdDate', 'lastModifiedDate']
 
 export const tableFieldDefinitions = listTableFieldDefinitions
 

--- a/packages/edge/src/lib/commands/drivers-util.ts
+++ b/packages/edge/src/lib/commands/drivers-util.ts
@@ -18,11 +18,13 @@ import {
 	SelectFromListConfig,
 	stringTranslateToId,
 	summarizedText,
+	TableFieldDefinition,
 	TableGenerator,
 } from '@smartthings/cli-lib'
 
 
-export const listTableFieldDefinitions = ['driverId', 'name', 'version', 'packageKey']
+export const listTableFieldDefinitions: TableFieldDefinition<EdgeDriverSummary>[] =
+	['driverId', 'name', 'version', 'packageKey']
 
 export const permissionsValue = (driver: EdgeDriver): string => driver.permissions?.map(permission => permission.name).join('\n') || 'none'
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -30,7 +30,7 @@
 	"dependencies": {
 		"@log4js-node/log4js-api": "^1.0.2",
 		"@oclif/core": "^1.16.3",
-		"@smartthings/core-sdk": "^5.1.1",
+		"@smartthings/core-sdk": "^5.1.2",
 		"@types/eventsource": "^1.1.9",
 		"axios": "^0.21.4",
 		"chalk": "^4.1.2",

--- a/packages/lib/src/__tests__/output.test.ts
+++ b/packages/lib/src/__tests__/output.test.ts
@@ -1,6 +1,6 @@
 import * as ioUtil from '../io-util'
 import { calculateOutputFormat, itemTableFormatter, jsonFormatter, listTableFormatter, sort, writeOutput, yamlFormatter } from '../output'
-import { DefaultTableGenerator, TableGenerator } from '../table-generator'
+import { DefaultTableGenerator, TableFieldDefinition, TableGenerator } from '../table-generator'
 
 import { buildMockCommand } from './test-lib/mock-command'
 import { SimpleType } from './test-lib/simple-type'
@@ -92,7 +92,7 @@ describe('itemTableFormatter', () => {
 			buildTableFromList: jest.fn(),
 		}
 
-		const fieldDefinitions = ['str', 'num']
+		const fieldDefinitions: TableFieldDefinition<SimpleType>[] = ['str', 'num']
 		const formatter = itemTableFormatter(mockTableGenerator, fieldDefinitions)
 
 		const expected = 'expected result'
@@ -109,7 +109,7 @@ describe('itemTableFormatter', () => {
 })
 
 describe('listTableFormatter', () => {
-	const fieldDefinitions = ['str', 'num']
+	const fieldDefinitions: TableFieldDefinition<SimpleType>[] = ['str', 'num']
 	const expected = 'expected result'
 
 	const list: SimpleType[] = [{ str: 'string1', num: 4 }, { str: 'string2', num: 5 }, { str: 'string3', num: 6 }]

--- a/packages/lib/src/api-helpers.ts
+++ b/packages/lib/src/api-helpers.ts
@@ -91,3 +91,7 @@ export async function forAllNamespaces<T>(
 	const nestedItems = await Promise.all(namespaces.map(async (namespace) => query(namespace)))
 	return nestedItems.flat()
 }
+
+export interface WithLocales {
+	locales?: string
+}

--- a/packages/testlib/package.json
+++ b/packages/testlib/package.json
@@ -29,7 +29,7 @@
 	},
 	"dependencies": {
 		"@smartthings/cli-lib": "^1.0.0-beta.14",
-		"@smartthings/core-sdk": "^5.1.1"
+		"@smartthings/core-sdk": "^5.1.2"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.5",


### PR DESCRIPTION
This refactors the `TableGenerator` and its supporting `TableFieldDefinition` to make the types more strict and as a result lightly touches much of the code that uses `TableGenerator`.

Mainly this is:

* The `TableFieldDefinition` interface was changed to a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) of simpler types so TypeScript can give us errors more often when used improperly. Documentation is more clear as well so hopefully these will be easier to understand.
* Instead of a simple `string` for the path, we use `keyof` to limit values to actual properties of the object passed in. This exposed a few cases where the types we were labeling things were close to but not exactly correct. (Mostly this was cases where we sometimes add extra info like `location` or `organization` to the base objects.
* In cases where we used a lodash path, I've changed the name of the interface property specifying the path to `path` instead of overloading `prop`. This shows up as changes like `location.locationId` becoming `{ path: 'location.locationId' }`.
* updated a few types along the way since they didn't always quite match what they actually were
* updated core SDK because a couple of types issues were found there doing this

TLDR: I fixed up `table-generator.ts` and fixed all the compile errors and test errors that resulted

<!-- Describe your pull request. -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
