### PR TITLE
fix: always include arguments list for capabilities commands in create

### DIFF
--- a/.changeset/quiet-ligers-count.md
+++ b/.changeset/quiet-ligers-count.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+fix issue with creating capabilities with commands with no arguments

--- a/packages/cli/src/commands/capabilities/create.ts
+++ b/packages/cli/src/commands/capabilities/create.ts
@@ -384,10 +384,6 @@ export default class CapabilitiesCreateCommand extends APIOrganizationCommand<ty
 			}
 		} while (argumentName)
 
-		if (command.arguments?.length === 0) {
-			delete command.arguments
-		}
-
 		this.addCommand(capability, name, command)
 	}
 


### PR DESCRIPTION
<!-- Describe your pull request. -->

Always include the arguments list for commands in the `capabilities:create` command even though the docs don't say it's required. This is to workaround a 500 error we are currently getting from the server in this case.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
