### PR TITLE
docs: fix source code link in edge docs

### DIFF
--- a/.changeset/three-needles-grab.md
+++ b/.changeset/three-needles-grab.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/plugin-cli-edge": patch
+---
+
+fixed edge plugin source links in README

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,7 @@
 				"@commitlint/cli": "^17.1.2",
 				"@commitlint/config-conventional": "^17.1.0",
 				"cz-conventional-changelog": "^3.3.0",
-				"rimraf": "^3.0.2",
-				"ts-node": "^10.9.1",
-				"typescript": "^4.8.3"
+				"rimraf": "^3.0.2"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -18629,7 +18627,9 @@
 				"oclif": "^3.1.2",
 				"pkg": "^5.8.0",
 				"rimraf": "^3.0.2",
-				"ts-jest": "^28.0.6"
+				"ts-jest": "^28.0.6",
+				"ts-node": "^10.9.1",
+				"typescript": "^4.8.3"
 			},
 			"engines": {
 				"node": ">=16.14.2 <17",
@@ -18673,7 +18673,9 @@
 				"oclif": "^3.1.2",
 				"rimraf": "^3.0.2",
 				"strip-ansi": "^6.0.1",
-				"ts-jest": "^28.0.6"
+				"ts-jest": "^28.0.6",
+				"ts-node": "^10.9.1",
+				"typescript": "^4.8.3"
 			},
 			"engines": {
 				"node": ">=16.14.2 <17",
@@ -18723,7 +18725,9 @@
 				"mock-stdin": "^1.0.0",
 				"oclif": "^3.1.2",
 				"rimraf": "^3.0.2",
-				"ts-jest": "^28.0.6"
+				"ts-jest": "^28.0.6",
+				"ts-node": "^10.9.1",
+				"typescript": "^4.8.3"
 			},
 			"engines": {
 				"node": ">=16.14.2 <17",
@@ -18765,7 +18769,9 @@
 				"jest": "^28.1.3",
 				"jest-extended": "^0.11.5",
 				"rimraf": "^3.0.2",
-				"ts-jest": "^28.0.6"
+				"ts-jest": "^28.0.6",
+				"ts-node": "^10.9.1",
+				"typescript": "^4.8.3"
 			},
 			"engines": {
 				"node": ">=16.14.2 <17",
@@ -21839,7 +21845,9 @@
 				"oclif": "^3.1.2",
 				"pkg": "^5.8.0",
 				"rimraf": "^3.0.2",
-				"ts-jest": "^28.0.6"
+				"ts-jest": "^28.0.6",
+				"ts-node": "^10.9.1",
+				"typescript": "^4.8.3"
 			}
 		},
 		"@smartthings/cli-lib": {
@@ -21881,7 +21889,9 @@
 				"qs": "^6.11.0",
 				"rimraf": "^3.0.2",
 				"table": "^6.8.0",
-				"ts-jest": "^28.0.6"
+				"ts-jest": "^28.0.6",
+				"ts-node": "^10.9.1",
+				"typescript": "^4.8.3"
 			},
 			"dependencies": {
 				"qs": {
@@ -21911,7 +21921,9 @@
 				"jest": "^28.1.3",
 				"jest-extended": "^0.11.5",
 				"rimraf": "^3.0.2",
-				"ts-jest": "^28.0.6"
+				"ts-jest": "^28.0.6",
+				"ts-node": "^10.9.1",
+				"typescript": "^4.8.3"
 			}
 		},
 		"@smartthings/core-sdk": {
@@ -21961,7 +21973,9 @@
 				"rimraf": "^3.0.2",
 				"strip-ansi": "^6.0.1",
 				"ts-jest": "^28.0.6",
-				"tslib": "^2.3.1"
+				"ts-node": "^10.9.1",
+				"tslib": "^2.3.1",
+				"typescript": "^4.8.3"
 			}
 		},
 		"@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
 		"@commitlint/cli": "^17.1.2",
 		"@commitlint/config-conventional": "^17.1.0",
 		"cz-conventional-changelog": "^3.3.0",
-		"rimraf": "^3.0.2",
-		"ts-node": "^10.9.1",
-		"typescript": "^4.8.3"
+		"rimraf": "^3.0.2"
 	}
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3615,7 +3615,7 @@ EXAMPLES
   $ smartthings edge:channels --subscriber-type HUB --subscriber-id <hub-id>
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels.ts)_
 
 ## `smartthings edge:channels:assign [DRIVERID] [VERSION]`
 
@@ -3647,7 +3647,7 @@ ALIASES
   $ smartthings edge:drivers:publish
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/assign.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/assign.ts)_
 
 ## `smartthings edge:channels:assignments [IDORINDEX]`
 
@@ -3707,7 +3707,7 @@ DESCRIPTION
   create a channel
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/create.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/create.ts)_
 
 ## `smartthings edge:channels:delete [ID]`
 
@@ -3733,7 +3733,7 @@ DESCRIPTION
   delete a channel
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/delete.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/delete.ts)_
 
 ## `smartthings edge:channels:drivers [IDORINDEX]`
 
@@ -3766,7 +3766,7 @@ ALIASES
   $ smartthings edge:channels:assignments
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/drivers.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/drivers.ts)_
 
 ## `smartthings edge:channels:enroll [HUBID]`
 
@@ -3794,7 +3794,7 @@ DESCRIPTION
   enroll a hub in a channel
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/enroll.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/enroll.ts)_
 
 ## `smartthings edge:channels:enrollments [IDORINDEX]`
 
@@ -3824,7 +3824,7 @@ DESCRIPTION
   list all channels a given hub is enrolled in
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/enrollments.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/enrollments.ts)_
 
 ## `smartthings edge:channels:invitations [IDORINDEX]`
 
@@ -4028,7 +4028,7 @@ EXAMPLES
   $ smartthings edge:channels:invites <invite id>      # list details about the invite with id <invite id>
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/invites.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/invites.ts)_
 
 ## `smartthings edge:channels:invites:accept ID`
 
@@ -4057,7 +4057,7 @@ ALIASES
   $ smartthings edge:channels:invitations:accept
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/invites/accept.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/invites/accept.ts)_
 
 ## `smartthings edge:channels:invites:create`
 
@@ -4090,7 +4090,7 @@ ALIASES
   $ smartthings edge:channels:invitations:create
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/invites/create.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/invites/create.ts)_
 
 ## `smartthings edge:channels:invites:delete [ID]`
 
@@ -4123,7 +4123,7 @@ ALIASES
   $ smartthings edge:channels:invites:revoke
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/invites/delete.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/invites/delete.ts)_
 
 ## `smartthings edge:channels:invites:revoke [ID]`
 
@@ -4198,7 +4198,7 @@ EXAMPLES
       699c7308-8c72-4363-9571-880d0f5cc725
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/metainfo.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/metainfo.ts)_
 
 ## `smartthings edge:channels:unassign [DRIVERID]`
 
@@ -4229,7 +4229,7 @@ ALIASES
   $ smartthings edge:drivers:unpublish
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/unassign.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/unassign.ts)_
 
 ## `smartthings edge:channels:unenroll [HUBID]`
 
@@ -4257,7 +4257,7 @@ DESCRIPTION
   unenroll a hub from a channel
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/unenroll.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/unenroll.ts)_
 
 ## `smartthings edge:channels:update [ID]`
 
@@ -4289,7 +4289,7 @@ DESCRIPTION
   update a channel
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/update.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/update.ts)_
 
 ## `smartthings edge:drivers [IDORINDEX]`
 
@@ -4340,7 +4340,7 @@ EXAMPLES
   $ smartthings edge:drivers 699c7308-8c72-4363-9571-880d0f5cc725 --version 2021-10-25T00:48:23.295969
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers.ts)_
 
 ## `smartthings edge:drivers:default`
 
@@ -4372,7 +4372,7 @@ EXAMPLES
     $ smartthings edge:drivers:default
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/default.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/default.ts)_
 
 ## `smartthings edge:drivers:delete [ID]`
 
@@ -4398,7 +4398,7 @@ DESCRIPTION
   delete an edge driver
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/delete.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/delete.ts)_
 
 ## `smartthings edge:drivers:install [DRIVERID]`
 
@@ -4434,7 +4434,7 @@ EXAMPLES
   $ smartthings edge:drivers:install -H <hub-id> -C <channel-id> <driver-id> # install a driver from a channel on an enrolled hub
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/install.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/install.ts)_
 
 ## `smartthings edge:drivers:installed [IDORINDEX]`
 
@@ -4466,7 +4466,7 @@ DESCRIPTION
   list all drivers installed on a given hub
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/installed.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/installed.ts)_
 
 ## `smartthings edge:drivers:logcat [DRIVERID]`
 
@@ -4496,7 +4496,7 @@ DESCRIPTION
   stream logs from installed drivers
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/logcat.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/logcat.ts)_
 
 ## `smartthings edge:drivers:package [PROJECTDIRECTORY]`
 
@@ -4552,7 +4552,7 @@ EXAMPLES
     $ smartthings edge:drivers:package -u driver.zip
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/package.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/package.ts)_
 
 ## `smartthings edge:drivers:publish [DRIVERID] [VERSION]`
 
@@ -4623,7 +4623,7 @@ EXAMPLES
     $ smartthings edge:drivers:switch --include-non-matching
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/switch.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/switch.ts)_
 
 ## `smartthings edge:drivers:uninstall [DRIVERID]`
 
@@ -4651,7 +4651,7 @@ DESCRIPTION
   uninstall an edge driver from a hub
 ```
 
-_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/uninstall.ts)_
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/uninstall.ts)_
 
 ## `smartthings edge:drivers:unpublish [DRIVERID]`
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -101,7 +101,9 @@
 		"oclif": "^3.1.2",
 		"pkg": "^5.8.0",
 		"rimraf": "^3.0.2",
-		"ts-jest": "^28.0.6"
+		"ts-jest": "^28.0.6",
+		"ts-node": "^10.9.1",
+		"typescript": "^4.8.3"
 	},
 	"scripts": {
 		"lint": "eslint --ext ts src",

--- a/packages/edge/README.md
+++ b/packages/edge/README.md
@@ -98,7 +98,7 @@ EXAMPLES
   $ smartthings edge:channels --subscriber-type HUB --subscriber-id <hub-id>
 ```
 
-_See code: [src/commands/edge/channels.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels.ts)_
+_See code: [src/commands/edge/channels.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels.ts)_
 
 ## `smartthings edge:channels:assign [DRIVERID] [VERSION]`
 
@@ -130,7 +130,7 @@ ALIASES
   $ smartthings edge:drivers:publish
 ```
 
-_See code: [src/commands/edge/channels/assign.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/assign.ts)_
+_See code: [src/commands/edge/channels/assign.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/assign.ts)_
 
 ## `smartthings edge:channels:assignments [IDORINDEX]`
 
@@ -190,7 +190,7 @@ DESCRIPTION
   create a channel
 ```
 
-_See code: [src/commands/edge/channels/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/create.ts)_
+_See code: [src/commands/edge/channels/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/create.ts)_
 
 ## `smartthings edge:channels:delete [ID]`
 
@@ -216,7 +216,7 @@ DESCRIPTION
   delete a channel
 ```
 
-_See code: [src/commands/edge/channels/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/delete.ts)_
+_See code: [src/commands/edge/channels/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/delete.ts)_
 
 ## `smartthings edge:channels:drivers [IDORINDEX]`
 
@@ -249,7 +249,7 @@ ALIASES
   $ smartthings edge:channels:assignments
 ```
 
-_See code: [src/commands/edge/channels/drivers.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/drivers.ts)_
+_See code: [src/commands/edge/channels/drivers.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/drivers.ts)_
 
 ## `smartthings edge:channels:enroll [HUBID]`
 
@@ -277,7 +277,7 @@ DESCRIPTION
   enroll a hub in a channel
 ```
 
-_See code: [src/commands/edge/channels/enroll.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/enroll.ts)_
+_See code: [src/commands/edge/channels/enroll.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/enroll.ts)_
 
 ## `smartthings edge:channels:enrollments [IDORINDEX]`
 
@@ -307,7 +307,7 @@ DESCRIPTION
   list all channels a given hub is enrolled in
 ```
 
-_See code: [src/commands/edge/channels/enrollments.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/enrollments.ts)_
+_See code: [src/commands/edge/channels/enrollments.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/enrollments.ts)_
 
 ## `smartthings edge:channels:invitations [IDORINDEX]`
 
@@ -511,7 +511,7 @@ EXAMPLES
   $ smartthings edge:channels:invites <invite id>      # list details about the invite with id <invite id>
 ```
 
-_See code: [src/commands/edge/channels/invites.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/invites.ts)_
+_See code: [src/commands/edge/channels/invites.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/invites.ts)_
 
 ## `smartthings edge:channels:invites:accept ID`
 
@@ -540,7 +540,7 @@ ALIASES
   $ smartthings edge:channels:invitations:accept
 ```
 
-_See code: [src/commands/edge/channels/invites/accept.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/invites/accept.ts)_
+_See code: [src/commands/edge/channels/invites/accept.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/invites/accept.ts)_
 
 ## `smartthings edge:channels:invites:create`
 
@@ -573,7 +573,7 @@ ALIASES
   $ smartthings edge:channels:invitations:create
 ```
 
-_See code: [src/commands/edge/channels/invites/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/invites/create.ts)_
+_See code: [src/commands/edge/channels/invites/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/invites/create.ts)_
 
 ## `smartthings edge:channels:invites:delete [ID]`
 
@@ -606,7 +606,7 @@ ALIASES
   $ smartthings edge:channels:invites:revoke
 ```
 
-_See code: [src/commands/edge/channels/invites/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/invites/delete.ts)_
+_See code: [src/commands/edge/channels/invites/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/invites/delete.ts)_
 
 ## `smartthings edge:channels:invites:revoke [ID]`
 
@@ -681,7 +681,7 @@ EXAMPLES
       699c7308-8c72-4363-9571-880d0f5cc725
 ```
 
-_See code: [src/commands/edge/channels/metainfo.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/metainfo.ts)_
+_See code: [src/commands/edge/channels/metainfo.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/metainfo.ts)_
 
 ## `smartthings edge:channels:unassign [DRIVERID]`
 
@@ -712,7 +712,7 @@ ALIASES
   $ smartthings edge:drivers:unpublish
 ```
 
-_See code: [src/commands/edge/channels/unassign.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/unassign.ts)_
+_See code: [src/commands/edge/channels/unassign.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/unassign.ts)_
 
 ## `smartthings edge:channels:unenroll [HUBID]`
 
@@ -740,7 +740,7 @@ DESCRIPTION
   unenroll a hub from a channel
 ```
 
-_See code: [src/commands/edge/channels/unenroll.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/unenroll.ts)_
+_See code: [src/commands/edge/channels/unenroll.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/unenroll.ts)_
 
 ## `smartthings edge:channels:update [ID]`
 
@@ -772,7 +772,7 @@ DESCRIPTION
   update a channel
 ```
 
-_See code: [src/commands/edge/channels/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/channels/update.ts)_
+_See code: [src/commands/edge/channels/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/channels/update.ts)_
 
 ## `smartthings edge:drivers [IDORINDEX]`
 
@@ -823,7 +823,7 @@ EXAMPLES
   $ smartthings edge:drivers 699c7308-8c72-4363-9571-880d0f5cc725 --version 2021-10-25T00:48:23.295969
 ```
 
-_See code: [src/commands/edge/drivers.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers.ts)_
+_See code: [src/commands/edge/drivers.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers.ts)_
 
 ## `smartthings edge:drivers:default`
 
@@ -855,7 +855,7 @@ EXAMPLES
     $ smartthings edge:drivers:default
 ```
 
-_See code: [src/commands/edge/drivers/default.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/default.ts)_
+_See code: [src/commands/edge/drivers/default.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/default.ts)_
 
 ## `smartthings edge:drivers:delete [ID]`
 
@@ -881,7 +881,7 @@ DESCRIPTION
   delete an edge driver
 ```
 
-_See code: [src/commands/edge/drivers/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/delete.ts)_
+_See code: [src/commands/edge/drivers/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/delete.ts)_
 
 ## `smartthings edge:drivers:install [DRIVERID]`
 
@@ -917,7 +917,7 @@ EXAMPLES
   $ smartthings edge:drivers:install -H <hub-id> -C <channel-id> <driver-id> # install a driver from a channel on an enrolled hub
 ```
 
-_See code: [src/commands/edge/drivers/install.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/install.ts)_
+_See code: [src/commands/edge/drivers/install.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/install.ts)_
 
 ## `smartthings edge:drivers:installed [IDORINDEX]`
 
@@ -949,7 +949,7 @@ DESCRIPTION
   list all drivers installed on a given hub
 ```
 
-_See code: [src/commands/edge/drivers/installed.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/installed.ts)_
+_See code: [src/commands/edge/drivers/installed.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/installed.ts)_
 
 ## `smartthings edge:drivers:logcat [DRIVERID]`
 
@@ -979,7 +979,7 @@ DESCRIPTION
   stream logs from installed drivers
 ```
 
-_See code: [src/commands/edge/drivers/logcat.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/logcat.ts)_
+_See code: [src/commands/edge/drivers/logcat.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/logcat.ts)_
 
 ## `smartthings edge:drivers:package [PROJECTDIRECTORY]`
 
@@ -1035,7 +1035,7 @@ EXAMPLES
     $ smartthings edge:drivers:package -u driver.zip
 ```
 
-_See code: [src/commands/edge/drivers/package.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/package.ts)_
+_See code: [src/commands/edge/drivers/package.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/package.ts)_
 
 ## `smartthings edge:drivers:publish [DRIVERID] [VERSION]`
 
@@ -1106,7 +1106,7 @@ EXAMPLES
     $ smartthings edge:drivers:switch --include-non-matching
 ```
 
-_See code: [src/commands/edge/drivers/switch.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/switch.ts)_
+_See code: [src/commands/edge/drivers/switch.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/switch.ts)_
 
 ## `smartthings edge:drivers:uninstall [DRIVERID]`
 
@@ -1134,7 +1134,7 @@ DESCRIPTION
   uninstall an edge driver from a hub
 ```
 
-_See code: [src/commands/edge/drivers/uninstall.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/v2.0.0-beta.1/src/commands/edge/drivers/uninstall.ts)_
+_See code: [src/commands/edge/drivers/uninstall.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@2.0.0-beta.1/packages/edge/src/commands/edge/drivers/uninstall.ts)_
 
 ## `smartthings edge:drivers:unpublish [DRIVERID]`
 

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -34,6 +34,7 @@
 	"oclif": {
 		"commands": "./lib/commands",
 		"bin": "smartthings",
+		"repositoryPrefix": "<%- repo %>/blob/@smartthings/plugin-cli-edge@<%- version %>/packages/edge/<%- commandPath %>",
 		"devPlugins": [
 			"@oclif/plugin-help"
 		]
@@ -71,7 +72,9 @@
 		"oclif": "^3.1.2",
 		"rimraf": "^3.0.2",
 		"strip-ansi": "^6.0.1",
-		"ts-jest": "^28.0.6"
+		"ts-jest": "^28.0.6",
+		"ts-node": "^10.9.1",
+		"typescript": "^4.8.3"
 	},
 	"scripts": {
 		"lint": "eslint --ext .ts src",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -66,7 +66,9 @@
 		"mock-stdin": "^1.0.0",
 		"oclif": "^3.1.2",
 		"rimraf": "^3.0.2",
-		"ts-jest": "^28.0.6"
+		"ts-jest": "^28.0.6",
+		"ts-node": "^10.9.1",
+		"typescript": "^4.8.3"
 	},
 	"scripts": {
 		"lint": "eslint --ext ts src",

--- a/packages/testlib/package.json
+++ b/packages/testlib/package.json
@@ -44,7 +44,9 @@
 		"jest": "^28.1.3",
 		"jest-extended": "^0.11.5",
 		"rimraf": "^3.0.2",
-		"ts-jest": "^28.0.6"
+		"ts-jest": "^28.0.6",
+		"ts-node": "^10.9.1",
+		"typescript": "^4.8.3"
 	},
 	"scripts": {
 		"lint": "eslint --ext ts src",


### PR DESCRIPTION
<!-- Describe your pull request. -->

* put `ts-node` and `typescript` dependencies back in their individual package directories
* added `repositoryPrefix` to edge package

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
