### PR TITLE
refactor: clean up types for apps and schema apps

### DIFF
--- a/packages/cli/src/__tests__/commands/apps.test.ts
+++ b/packages/cli/src/__tests__/commands/apps.test.ts
@@ -1,21 +1,27 @@
-import { outputItemOrList } from '@smartthings/cli-lib'
-import { AppResponse, AppClassification, AppsEndpoint, AppType, PagedApp } from '@smartthings/core-sdk'
+import { ListDataFunction, outputItemOrList } from '@smartthings/cli-lib'
+import { AppResponse, AppClassification, AppsEndpoint, AppType, PagedApp, SmartThingsClient } from '@smartthings/core-sdk'
 import AppsCommand from '../../commands/apps'
+import { shortARNorURL, verboseApps } from '../../lib/commands/apps-util'
 
+
+jest.mock('../../lib/commands/apps-util')
 
 describe('AppsCommand', () => {
-	const appId = 'appId'
-	const app = { appId: appId, webhookSmartApp: { targetUrl: 'targetUrl' } } as AppResponse
-	const appList = [{ appId: appId }] as PagedApp[]
-	const mockOutputListing = jest.mocked(outputItemOrList)
+	const app = { appId: 'app-id', webhookSmartApp: { targetUrl: 'targetUrl' } } as AppResponse
+	const appList = [{ appId: 'paged-app-id' }] as PagedApp[]
+	const verboseAppList = [{ appId: 'verbose-app-id' }] as AppResponse[]
+	const mockOutputListing = jest.mocked(outputItemOrList<AppResponse, PagedApp | AppResponse>)
 	const getSpy = jest.spyOn(AppsEndpoint.prototype, 'get').mockImplementation()
 	const listSpy = jest.spyOn(AppsEndpoint.prototype, 'list').mockImplementation()
+	const verboseAppsMock = jest.mocked(verboseApps)
 
-	beforeAll(() => {
-		mockOutputListing.mockImplementation(async (_command, _config, _id, listFunction) => {
-			await listFunction()
-		})
-	})
+	const listItemsForArgs = async (args: string[]): Promise<ListDataFunction<PagedApp | AppResponse>> => {
+		await expect(AppsCommand.run(args)).resolves.not.toThrow()
+		return mockOutputListing.mock.calls[0][3]
+	}
+
+	listSpy.mockResolvedValue(appList)
+	verboseAppsMock.mockResolvedValue(verboseAppList)
 
 	it('calls outputItemOrList with correct config', async () => {
 		await expect(AppsCommand.run([])).resolves.not.toThrow()
@@ -25,7 +31,7 @@ describe('AppsCommand', () => {
 			expect.objectContaining({
 				primaryKeyName: 'appId',
 				sortKeyName: 'displayName',
-				listTableFieldDefinitions: expect.not.arrayContaining(['ARN/URL']),
+				listTableFieldDefinitions: expect.not.arrayContaining([{ label: 'ARN/URL', value: shortARNorURL }]),
 			}),
 			undefined,
 			expect.any(Function),
@@ -34,120 +40,111 @@ describe('AppsCommand', () => {
 	})
 
 	it('calls correct get endpoint', async () => {
-		mockOutputListing.mockImplementationOnce(async (_command, _config, _id, _listFunction, getFunction) => {
-			await getFunction(appId)
-		})
+		await expect(AppsCommand.run(['app-id'])).resolves.not.toThrow()
 
-		await expect(AppsCommand.run([appId])).resolves.not.toThrow()
-		expect(outputItemOrList).toBeCalledWith(
-			expect.anything(),
-			expect.anything(),
-			appId,
-			expect.anything(),
-			expect.anything(),
-		)
-		expect(getSpy).toBeCalledWith(appId)
+		const getItem = mockOutputListing.mock.calls[0][4]
+		getSpy.mockResolvedValueOnce(app)
+
+		expect(await getItem('app-id')).toBe(app)
+
+		expect(getSpy).toHaveBeenCalledTimes(1)
+		expect(getSpy).toHaveBeenCalledWith('app-id')
 	})
 
-	it('calls correct list endpoint', async () => {
-		listSpy.mockResolvedValueOnce(appList)
-
-		await expect(AppsCommand.run([])).resolves.not.toThrow()
-		expect(listSpy).toBeCalledTimes(1)
-		expect(getSpy).not.toBeCalled()
-	})
-
-	it('takes an app type to filter by via flags', async () => {
+	describe('listItems', () => {
 		const appType = AppType.LAMBDA_SMART_APP
 
-		await expect(AppsCommand.run([`--type=${appType}`])).resolves.not.toThrow()
-		expect(listSpy).toBeCalledWith(
-			expect.objectContaining({
-				appType: `${appType}`,
-			}),
-		)
-	})
+		it('calls correct list endpoint', async () => {
+			const listItems = await listItemsForArgs([])
 
-	it('does not accept multiple app types', async () => {
-		const appType = AppType.WEBHOOK_SMART_APP
+			expect(await listItems()).toBe(appList)
 
-		await expect(AppsCommand.run(['--type=LAMBDA_SMART_APP', `--type=${appType}`])).resolves.not.toThrow()
-		expect(listSpy).toBeCalledWith(
-			expect.objectContaining({
-				appType: `${appType}`,
-			}),
-		)
-	})
+			expect(listSpy).toHaveBeenCalledTimes(1)
+			expect(listSpy).toHaveBeenCalledWith({})
+			expect(verboseAppsMock).toHaveBeenCalledTimes(0)
+		})
 
-	it('ignores invalid app types', async () => {
-		await expect(AppsCommand.run(['--type=INVALID_APP_TYPE'])).resolves.not.toThrow()
-		expect(listSpy).toBeCalledWith(
-			expect.objectContaining({
-				appType: undefined,
-			}),
-		)
-	})
+		it('takes an app type to filter by via flags', async () => {
+			const listItems = await listItemsForArgs([`--type=${appType}`])
 
-	it('takes one or more classifications to filter by via flags', async () => {
+			expect(await listItems()).toBe(appList)
+
+			expect(listSpy).toHaveBeenCalledTimes(1)
+			expect(listSpy).toHaveBeenCalledWith({ appType: `${appType}` })
+			expect(verboseAppsMock).toHaveBeenCalledTimes(0)
+		})
+
+		it('does not accept multiple app types', async () => {
+			const listItems = await listItemsForArgs(['--type=LAMBDA_SMART_APP', `--type=${appType}`])
+
+			expect(await listItems()).toBe(appList)
+
+			expect(listSpy).toHaveBeenCalledTimes(1)
+			expect(listSpy).toHaveBeenCalledWith({ appType: `${appType}` })
+			expect(verboseAppsMock).toHaveBeenCalledTimes(0)
+		})
+
+		it('ignores invalid app types', async () => {
+			const listItems = await listItemsForArgs(['--type=INVALID_APP_TYPE'])
+
+			expect(await listItems()).toBe(appList)
+
+			expect(listSpy).toHaveBeenCalledTimes(1)
+			expect(listSpy).toHaveBeenCalledWith({ appType: undefined })
+			expect(verboseAppsMock).toHaveBeenCalledTimes(0)
+		})
+
 		const automation = AppClassification.AUTOMATION
-
-		await expect(AppsCommand.run([`--classification=${automation}`])).resolves.not.toThrow()
-		expect(listSpy).toBeCalledWith(
-			expect.objectContaining({
-				classification: expect.arrayContaining([automation]),
-			}),
-		)
-
 		const service = AppClassification.SERVICE
-		const classifications = [automation, service]
+		it('accepts a single classification for filtering', async () => {
+			const listItems = await listItemsForArgs([`--classification=${automation}`])
 
-		await expect(AppsCommand.run([`--classification=${automation}`, `--classification=${service}`])).resolves.not.toThrow()
-		expect(listSpy).toBeCalledWith(
-			expect.objectContaining({
-				classification: expect.arrayContaining(classifications),
-			}),
-		)
-	})
+			expect(await listItems()).toBe(appList)
 
-	it('ignores invalid app classifications', async () => {
-		const automation = AppClassification.AUTOMATION
+			expect(listSpy).toHaveBeenCalledTimes(1)
+			expect(listSpy).toHaveBeenCalledWith({ classification: [automation] })
+			expect(verboseAppsMock).toHaveBeenCalledTimes(0)
+		})
 
-		await expect(AppsCommand.run([`--classification=${automation}`, '--classification=INVALID'])).resolves.not.toThrow()
-		expect(listSpy).toBeCalledWith(
-			expect.objectContaining({
-				classification: expect.arrayContaining([automation, undefined]),
-			}),
-		)
+		it('accepts multiple classifications for filtering', async () => {
+			const classifications = [automation, service]
+			const listItems = await listItemsForArgs([`--classification=${automation}`, `--classification=${service}`])
+
+			expect(await listItems()).toBe(appList)
+
+			expect(listSpy).toHaveBeenCalledTimes(1)
+			expect(listSpy).toHaveBeenCalledWith({ classification: expect.arrayContaining(classifications) })
+			expect(verboseAppsMock).toHaveBeenCalledTimes(0)
+		})
+
+		it('ignores invalid app classifications', async () => {
+			const listItems = await listItemsForArgs([`--classification=${automation}`, '--classification=INVALID'])
+
+			expect(await listItems()).toBe(appList)
+
+			expect(listSpy).toHaveBeenCalledTimes(1)
+			expect(listSpy).toHaveBeenCalledWith({ classification: [automation, undefined] })
+			expect(verboseAppsMock).toHaveBeenCalledTimes(0)
+		})
 	})
 
 	it('includes URLs and ARNs in output when verbose flag is used', async () => {
-		mockOutputListing.mockResolvedValueOnce(undefined)
+		const listItems = await listItemsForArgs(['--verbose'])
 
-		await expect(AppsCommand.run(['--verbose'])).resolves.not.toThrow()
 		expect(outputItemOrList).toBeCalledWith(
-			expect.anything(),
+			expect.any(AppsCommand),
 			expect.objectContaining({
-				listTableFieldDefinitions: expect.arrayContaining(['ARN/URL']),
+				listTableFieldDefinitions: expect.arrayContaining([{ label: 'ARN/URL', value: shortARNorURL }]),
 			}),
 			undefined,
-			expect.anything(),
-			expect.anything(),
+			expect.any(Function),
+			expect.any(Function),
 		)
-	})
 
-	it('fetches details for each app when verbose flag is used', async () => {
-		mockOutputListing.mockResolvedValueOnce(undefined)
-		listSpy.mockResolvedValueOnce(appList)
-		getSpy.mockResolvedValueOnce(app)
+		expect(await listItems()).toBe(verboseAppList)
 
-		await expect(AppsCommand.run(['--verbose'])).resolves.not.toThrow()
-
-		const listApps = mockOutputListing.mock.calls[0][3]
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		const verboseApp = (await listApps()).pop() as AppResponse & { 'ARN/URL'?: string }
-
-		expect(getSpy).toBeCalledTimes(1)
-		expect(getSpy).toBeCalledWith(appId)
-		expect(verboseApp['ARN/URL']).toBeDefined()
+		expect(listSpy).toHaveBeenCalledTimes(0)
+		expect(verboseAppsMock).toHaveBeenCalledTimes(1)
+		expect(verboseAppsMock).toHaveBeenCalledWith(expect.any(SmartThingsClient), {})
 	})
 })

--- a/packages/cli/src/__tests__/lib/commands/apps-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/apps-util.test.ts
@@ -1,13 +1,13 @@
 import { Config } from '@oclif/core'
 
-import { AppsEndpoint } from '@smartthings/core-sdk'
+import { AppResponse, AppsEndpoint, AppType, PagedApp, SmartThingsClient } from '@smartthings/core-sdk'
 
 import {
 	APICommand, ChooseOptions, chooseOptionsDefaults, chooseOptionsWithDefaults,
 	selectFromList, stringTranslateToId, Table,
 } from '@smartthings/cli-lib'
 
-import { buildTableOutput, chooseApp } from '../../../lib/commands/apps-util'
+import { buildTableOutput, chooseApp, shortARNorURL, verboseApps } from '../../../lib/commands/apps-util'
 
 
 describe('chooseApp', () => {
@@ -138,5 +138,83 @@ describe('buildTableOutput', () => {
 		expect(pushMock).toHaveBeenCalledWith(['setting', 'setting value'])
 		expect(toStringMock).toHaveBeenCalledTimes(1)
 		expect(toStringMock).toHaveBeenCalledWith()
+	})
+})
+
+describe('verboseApps', () => {
+	const listMock = jest.fn()
+	const getMock = jest.fn()
+	const apps = { list: listMock, get: getMock } as unknown as AppsEndpoint
+	const client = { apps } as SmartThingsClient
+
+	it('passes options to list', async () => {
+		listMock.mockResolvedValueOnce([])
+		const options = { appType: AppType.API_ONLY }
+
+		expect(await verboseApps(client, options))
+
+		expect(listMock).toHaveBeenCalledTimes(1)
+		expect(listMock).toHaveBeenCalledWith(options)
+		expect(getMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('uses get for every item in list', async () => {
+		const pagedApp1 = { appId: 'paged-app-1-id' } as PagedApp
+		const pagedApp2 = { appId: 'paged-app-2-id' } as PagedApp
+		const verboseApp1 = { appId: 'verbose-app-1-id' } as AppResponse
+		const verboseApp2 = { appId: 'verbose-app-2-id' } as AppResponse
+
+		listMock.mockResolvedValueOnce([pagedApp1, pagedApp2])
+		getMock.mockResolvedValueOnce(verboseApp1)
+		getMock.mockResolvedValueOnce(verboseApp2)
+
+		expect(await verboseApps(client, {}))
+
+		expect(listMock).toHaveBeenCalledTimes(1)
+		expect(listMock).toHaveBeenCalledWith({})
+		expect(getMock).toHaveBeenCalledTimes(2)
+		expect(getMock).toHaveBeenCalledWith('paged-app-1-id')
+		expect(getMock).toHaveBeenCalledWith('paged-app-2-id')
+	})
+})
+
+describe('shortARNorURL', () => {
+	it('uses webhookSmartApp targetUrl', () => {
+		const targetUrl = 'webhook target URL'
+		expect(shortARNorURL({ webhookSmartApp: { targetUrl } } as unknown as PagedApp)).toBe(targetUrl)
+	})
+
+	it('uses first lambdaSmartApp function', () => {
+		expect(shortARNorURL({ lambdaSmartApp: { functions: ['function 1'] } } as unknown as PagedApp))
+			.toBe('function 1')
+	})
+
+	it('uses empty string for lambdaSmartApp empty function list', () => {
+		expect(shortARNorURL({ lambdaSmartApp: {} } as unknown as PagedApp)).toBe('')
+		expect(shortARNorURL({ lambdaSmartApp: { functions: [] } } as unknown as PagedApp)).toBe('')
+	})
+
+	it('uses apiOnly subscription targetUrl', () => {
+		const targetUrl = 'apiOnly subscription URL'
+		expect(shortARNorURL({ apiOnly: { subscription: { targetUrl } } } as unknown as PagedApp)).toBe(targetUrl)
+		expect(shortARNorURL({ apiOnly: {} } as unknown as PagedApp)).toBe('')
+		expect(shortARNorURL({ apiOnly: { subscription: {} } } as unknown as PagedApp)).toBe('')
+	})
+
+	it('falls back on an empty string', () => {
+		expect(shortARNorURL({} as unknown as PagedApp)).toBe('')
+	})
+
+	it.each([
+		'short URL',
+		'12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345',
+	])('includes full URL for short URLs', (targetUrl) => {
+		expect(shortARNorURL({ webhookSmartApp: { targetUrl } } as unknown as PagedApp)).toBe(targetUrl)
+	})
+
+	it('trims long URLs', () => {
+		const targetUrl = '123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456'
+		const trimmed = '12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345...'
+		expect(shortARNorURL({ webhookSmartApp: { targetUrl } } as unknown as PagedApp)).toBe(trimmed)
 	})
 })

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -40,20 +40,14 @@ export default class SchemaCommand extends APICommand<typeof SchemaCommand.flags
 			listTableFieldDefinitions: ['appName', 'endpointAppId', 'hostingType'],
 		}
 		if (this.flags.verbose) {
-			config.listTableFieldDefinitions.push('ARN/URL')
+			config.listTableFieldDefinitions.push({
+				label: 'ARN/URL',
+				value: app => app.hostingType === 'lambda' ? app.lambdaArn : app.webhookUrl,
+			})
 		}
 
 		await outputItemOrList(this, config, this.args.id,
-			async () => {
-				const schemaApps = await this.client.schema.list()
-				return schemaApps.map(app => {
-					return {
-						...app,
-						// eslint-disable-next-line @typescript-eslint/naming-convention
-						'ARN/URL': app.hostingType === 'lambda' ? app.lambdaArn : app.webhookUrl,
-					}
-				})
-			},
+			() => this.client.schema.list(),
 			id => this.client.schema.get(id),
 		)
 	}

--- a/packages/cli/src/lib/commands/devices-util.ts
+++ b/packages/cli/src/lib/commands/devices-util.ts
@@ -101,53 +101,53 @@ export const buildTableOutput = (tableGenerator: TableGenerator, device: Device 
 	let infoFrom
 	if ('app' in device) {
 		infoFrom = 'app'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.app,
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.app ?? {},
 			['installedAppId', 'externalId', { prop: 'profile.id', label: 'Profile Id' }])
 	} else if ('ble' in device) {
 		infoFrom = 'ble'
 		deviceIntegrationInfo = 'No Device Integration Info for BLE devices'
 	} else if ('bleD2D' in device) {
 		infoFrom = 'bleD2D'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.bleD2D,
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.bleD2D ?? {},
 			['advertisingId', 'identifier', 'configurationVersion', 'configurationUrl'])
 	} else if ('dth' in device) {
 		infoFrom = 'dth'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.dth,
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.dth ?? {},
 			['deviceTypeId', 'deviceTypeName', 'completedSetup', 'deviceNetworkType',
 				'executingLocally', 'hubId', 'installedGroovyAppId', 'networkSecurityLevel'])
 	} else if ('lan' in device) {
 		infoFrom = 'lan'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.lan,
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.lan ?? {},
 			['networkId', 'driverId', 'executingLocally', 'hubId', 'provisioningState'])
 	} else if ('zigbee' in device) {
 		infoFrom = 'zigbee'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.zigbee,
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.zigbee ?? {},
 			['eui', 'networkId', 'driverId', 'executingLocally', 'hubId', 'provisioningState'])
 	} else if ('zwave' in device) {
 		infoFrom = 'zwave'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.zwave,
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.zwave ?? {},
 			['networkId', 'driverId', 'executingLocally', 'hubId', 'networkSecurityLevel', 'provisioningState'])
 	} else if ('ir' in device) {
 		infoFrom = 'ir'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.ir,
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.ir ?? {},
 			['parentDeviceId', 'profileId', 'ocfDeviceType', 'irCode'])
 	} else if ('irOcf' in device) {
 		infoFrom = 'irOcf'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.irOcf,
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.irOcf ?? {},
 			['parentDeviceId', 'profileId', 'ocfDeviceType', 'irCode'])
 	} else if ('ocf' in device) {
 		infoFrom = 'ocf'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.ocf,
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.ocf ?? {},
 			['deviceId', 'ocfDeviceType', 'name', 'specVersion', 'verticalDomainSpecVersion',
 				'manufacturerName', 'modelNumber', 'platformVersion', 'platformOS', 'hwVersion',
 				'firmwareVersion', 'vendorId', 'vendorResourceClientServerVersion', 'locale'])
 	} else if ('viper' in device) {
 		infoFrom = 'viper'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.viper,
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.viper ?? {},
 			['uniqueIdentifier', 'manufacturerName', 'modelName', 'swVersion', 'hwVersion'])
 	} else if ('virtual' in device) {
 		infoFrom = 'virtual'
-		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.virtual,
+		deviceIntegrationInfo = tableGenerator.buildTableFromItem(device.virtual ?? {},
 			['name', { prop: 'hubId', skipEmpty: true }, { prop: 'driverId', skipEmpty: true }])
 	}
 

--- a/packages/lib/src/basic-io.ts
+++ b/packages/lib/src/basic-io.ts
@@ -56,7 +56,7 @@ export interface Naming {
 	pluralItemName?: string
 }
 
-export async function inputItem<I>(command: SmartThingsCommandInterface,
+export async function inputItem<I extends object>(command: SmartThingsCommandInterface,
 		...alternateInputProcessors: InputProcessor<I>[]): Promise<[I, IOFormat]> {
 	const inputProcessor = buildInputProcessor<I>(command, ...alternateInputProcessors)
 	if (inputProcessor.hasInput()) {
@@ -68,7 +68,7 @@ export async function inputItem<I>(command: SmartThingsCommandInterface,
 }
 inputItem.flags = buildInputProcessor.flags
 
-export type OutputItemConfig<O> = FormatAndWriteItemConfig<O>
+export type OutputItemConfig<O extends object> = FormatAndWriteItemConfig<O>
 export async function outputItem<O extends object>(command: SmartThingsCommandInterface, config: OutputItemConfig<O>,
 		getData: GetDataFunction<O>): Promise<O> {
 	const data = await getData()
@@ -88,7 +88,7 @@ export async function outputList<L extends object>(command: SmartThingsCommandIn
 outputList.flags = buildOutputFormatter.flags
 
 
-export type InputAndOutputItemConfig<O> = FormatAndWriteItemConfig<O>
+export type InputAndOutputItemConfig<O extends object> = FormatAndWriteItemConfig<O>
 /**
  * This is the main function used in most create and update commands. It parses input and passes it
  * on to the executeAction function parameter.

--- a/packages/lib/src/format.ts
+++ b/packages/lib/src/format.ts
@@ -6,23 +6,23 @@ import { SmartThingsCommandInterface } from './smartthings-command'
 import { TableFieldDefinition } from './table-generator'
 
 
-export interface TableCommonOutputProducer<O> {
+export interface TableCommonOutputProducer<O extends object> {
 	tableFieldDefinitions: TableFieldDefinition<O>[]
 }
-export interface CustomCommonOutputProducer<O> {
+export interface CustomCommonOutputProducer<O extends object> {
 	buildTableOutput(data: O): string
 }
-export type CommonOutputProducer<O> = TableCommonOutputProducer<O> | CustomCommonOutputProducer<O>
+export type CommonOutputProducer<O extends object> = TableCommonOutputProducer<O> | CustomCommonOutputProducer<O>
 
-export interface TableCommonListOutputProducer<L> {
+export interface TableCommonListOutputProducer<L extends object> {
 	listTableFieldDefinitions: TableFieldDefinition<L>[]
 }
-export interface CustomCommonListOutputProducer<L> {
+export interface CustomCommonListOutputProducer<L extends object> {
 	buildListTableOutput(data: L[]): string
 }
 export type CommonListOutputProducer<L extends object> = TableCommonListOutputProducer<L> | CustomCommonListOutputProducer<L> | Sorting<L>
 
-export type FormatAndWriteItemConfig<O> = CommonOutputProducer<O>
+export type FormatAndWriteItemConfig<O extends object> = CommonOutputProducer<O>
 /**
  * Format and output the given item.
  *
@@ -34,7 +34,7 @@ export type FormatAndWriteItemConfig<O> = CommonOutputProducer<O>
  * @param defaultIOFormat The default IOFormat to use. This should be used when a command also takes
  *   input so the output can default to the input format.
  */
-export async function formatAndWriteItem<O>(command: SmartThingsCommandInterface,
+export async function formatAndWriteItem<O extends object>(command: SmartThingsCommandInterface,
 		config: FormatAndWriteItemConfig<O>, item: O, defaultIOFormat?: IOFormat): Promise<void> {
 	const commonFormatter = 'buildTableOutput' in config
 		? (data: O) => config.buildTableOutput(data)

--- a/packages/lib/src/output-builder.ts
+++ b/packages/lib/src/output-builder.ts
@@ -6,7 +6,7 @@ import { calculateOutputFormat, jsonFormatter, OutputFormatter, yamlFormatter } 
 import { SmartThingsCommandInterface } from './smartthings-command'
 
 
-export function buildOutputFormatter<T>(command: SmartThingsCommandInterface,
+export function buildOutputFormatter<T extends object>(command: SmartThingsCommandInterface,
 		inputFormat?: IOFormat, commonOutputFormatter?: OutputFormatter<T>): OutputFormatter<T> {
 	const outputFormat = calculateOutputFormat(command, inputFormat)
 

--- a/packages/lib/src/output.ts
+++ b/packages/lib/src/output.ts
@@ -35,22 +35,22 @@ export function calculateOutputFormat(command: SmartThingsCommandInterface, defa
 	return stdoutIsTTY() ? IOFormat.COMMON : IOFormat.JSON
 }
 
-export type OutputFormatter<T> = (data: T) => string
+export type OutputFormatter<T extends object> = (data: T) => string
 
-export function jsonFormatter<T>(indent: number): OutputFormatter<T> {
+export function jsonFormatter<T extends object>(indent: number): OutputFormatter<T> {
 	return (data: T) => JSON.stringify(data, null, indent)
 }
 
-export function yamlFormatter<T>(indent: number): OutputFormatter<T> {
+export function yamlFormatter<T extends object>(indent: number): OutputFormatter<T> {
 	return (data: T) => yaml.dump(data, { indent })
 }
 
-export function itemTableFormatter<T>(tableGenerator: TableGenerator,
+export function itemTableFormatter<T extends object>(tableGenerator: TableGenerator,
 		fieldDefinitions: TableFieldDefinition<T>[]): OutputFormatter<T> {
 	return (item: T) => tableGenerator.buildTableFromItem(item, fieldDefinitions)
 }
 
-export function listTableFormatter<T>(tableGenerator: TableGenerator,
+export function listTableFormatter<T extends object>(tableGenerator: TableGenerator,
 		fieldDefinitions: TableFieldDefinition<T>[], includeIndex = false): OutputFormatter<T[]> {
 	let count = 0
 	const tfd = includeIndex ? [{

--- a/packages/lib/src/table-generator.ts
+++ b/packages/lib/src/table-generator.ts
@@ -21,7 +21,7 @@ export const summarizedText = '(Information is summarized, for full details use 
  * Leaving out both label and value is the equivalent of using a simple string
  * for the definition.
  */
-export type TableFieldDefinition<T> = string | {
+export type TableFieldDefinition<T extends object> = string | {
 	/**
 	 * The name of the property from which to get data. This reference a nested
 	 * property if desired.
@@ -78,14 +78,14 @@ export interface TableGenerator {
 	 * will have two columns. The first displays the label for each property
 	 * and the second the associated value.
 	 */
-	buildTableFromItem<T>(item: T, tableFieldDefinitions: TableFieldDefinition<T>[]): string
+	buildTableFromItem<T extends object>(item: T, tableFieldDefinitions: TableFieldDefinition<T>[]): string
 
 	/**
 	 * Build a table for a list of items. The first row will be the header row,
 	 * displaying labels for all the tableFieldDefinitions and there will be
 	 * one row for each item in the items list displaying the associated values.
 	 */
-	buildTableFromList<T>(items: T[], tableFieldDefinitions: TableFieldDefinition<T>[]): string
+	buildTableFromList<T extends object>(items: T[], tableFieldDefinitions: TableFieldDefinition<T>[]): string
 }
 
 export interface TableOptions {
@@ -199,7 +199,7 @@ export class DefaultTableGenerator implements TableGenerator {
 			.replace(/^Is /, '')
 	}
 
-	private getLabelFor<T>(definition: TableFieldDefinition<T>): string {
+	private getLabelFor<T extends object>(definition: TableFieldDefinition<T>): string {
 		if (typeof definition === 'string') {
 			return this.convertToLabel(definition)
 		}
@@ -215,7 +215,7 @@ export class DefaultTableGenerator implements TableGenerator {
 		return this.convertToLabel(definition.prop)
 	}
 
-	private getDisplayValueFor<T>(item: T, definition: TableFieldDefinition<T>): string | undefined {
+	private getDisplayValueFor<T extends object>(item: T, definition: TableFieldDefinition<T>): string | undefined {
 		if (!(typeof definition === 'string') && definition.value) {
 			return definition.value(item)
 		}
@@ -250,7 +250,7 @@ export class DefaultTableGenerator implements TableGenerator {
 		return new TableAdapter(configuredOptions)
 	}
 
-	buildTableFromItem<T>(item: T, definitions: TableFieldDefinition<T>[]): string {
+	buildTableFromItem<T extends object>(item: T, definitions: TableFieldDefinition<T>[]): string {
 		const table = this.newOutputTable()
 		for (const definition of definitions) {
 			if (typeof definition === 'string'
@@ -267,7 +267,7 @@ export class DefaultTableGenerator implements TableGenerator {
 		return table.toString()
 	}
 
-	buildTableFromList<T>(items: T[], definitions: TableFieldDefinition<T>[]): string {
+	buildTableFromList<T extends object>(items: T[], definitions: TableFieldDefinition<T>[]): string {
 		const headingLabels = definitions.map(def => this.getLabelFor(def))
 		const table = this.newOutputTable({ isList: true, head: headingLabels })
 		for (const item of items) {


### PR DESCRIPTION
<!-- Describe your pull request. -->

* cleaned up how the `apps` and `schema` commands handle including the ARN/URL in the output to better support upcoming changes to `TableGenerator`
* moved some code from `apps.ts` into util module for easier testing
* included `extends object` a few more places we are expecting an object
* updated/added unit tests for all touched code

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
