### PR TITLE
feat: add --verbose option to edge:drivers:installed command

### DIFF
--- a/.changeset/six-carrots-repair.md
+++ b/.changeset/six-carrots-repair.md
@@ -1,0 +1,6 @@
+---
+"@smartthings/cli": patch
+"@smartthings/plugin-cli-edge": patch
+---
+
+add --verbose option to edge:drivers:installed command to include channel name

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -306,6 +306,31 @@ COMMON FLAGS
 
 DESCRIPTION
   get a specific app or a list of apps
+
+EXAMPLES
+  list all apps
+
+    $ smartthings apps
+
+  list the first app in the list retrieved by running "smartthings apps"
+
+    $ smartthings apps 1
+
+  list an app by id
+
+    $ smartthings apps <app-id>
+
+  include URLs and ARNs in the output
+
+    $ smartthings apps --verbose
+
+  list only SERVICE classification devices
+
+    $ smartthings apps --classification SERVICE
+
+  list only API only apps
+
+    $ smartthings apps --type API_ONLY
 ```
 
 _See code: [src/commands/apps.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.0-beta.20/packages/cli/src/commands/apps.ts)_
@@ -4445,7 +4470,7 @@ list all drivers installed on a given hub
 ```
 USAGE
   $ smartthings edge:drivers:installed [IDORINDEX] [-h] [-p <value>] [-t <value>] [--language <value>] [-O <value>] [-j]
-    [-y] [-o <value>] [-H <value>] [--device <value>]
+    [-y] [-o <value>] [-H <value>] [--device <value>] [-v]
 
 ARGUMENTS
   IDORINDEX  the driver id or number in list
@@ -4453,6 +4478,7 @@ ARGUMENTS
 FLAGS
   -H, --hub=<UUID>            hub id
   -O, --organization=<value>  the organization ID to use for this command
+  -v, --verbose               include channel name in output
   --device=<UUID>             return drivers matching the specified device
 
 COMMON FLAGS
@@ -4466,6 +4492,23 @@ COMMON FLAGS
 
 DESCRIPTION
   list all drivers installed on a given hub
+
+EXAMPLES
+  list all installed drivers
+
+    $ smartthings edge:drivers:installed
+
+  list all installed drivers and include the channel name in the output
+
+    $ smartthings edge:drivers:installed --verbose
+
+  list the first driver in the list retrieved by running "smartthings edge:drivers:installed"
+
+    $ smartthings edge:drivers:installed 1
+
+  list an installed driver by id
+
+    $ smartthings edge:drivers:installed <driver-id>
 ```
 
 _See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.0-beta.2/packages/edge/src/commands/edge/drivers/installed.ts)_

--- a/packages/edge/README.md
+++ b/packages/edge/README.md
@@ -926,7 +926,7 @@ list all drivers installed on a given hub
 ```
 USAGE
   $ smartthings edge:drivers:installed [IDORINDEX] [-h] [-p <value>] [-t <value>] [--language <value>] [-O <value>] [-j]
-    [-y] [-o <value>] [-H <value>] [--device <value>]
+    [-y] [-o <value>] [-H <value>] [--device <value>] [-v]
 
 ARGUMENTS
   IDORINDEX  the driver id or number in list
@@ -934,6 +934,7 @@ ARGUMENTS
 FLAGS
   -H, --hub=<UUID>            hub id
   -O, --organization=<value>  the organization ID to use for this command
+  -v, --verbose               include channel name in output
   --device=<UUID>             return drivers matching the specified device
 
 COMMON FLAGS
@@ -947,6 +948,23 @@ COMMON FLAGS
 
 DESCRIPTION
   list all drivers installed on a given hub
+
+EXAMPLES
+  list all installed drivers
+
+    $ smartthings edge:drivers:installed
+
+  list all installed drivers and include the channel name in the output
+
+    $ smartthings edge:drivers:installed --verbose
+
+  list the first driver in the list retrieved by running "smartthings edge:drivers:installed"
+
+    $ smartthings edge:drivers:installed 1
+
+  list an installed driver by id
+
+    $ smartthings edge:drivers:installed <driver-id>
 ```
 
 _See code: [src/commands/edge/drivers/installed.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.0-beta.2/packages/edge/src/commands/edge/drivers/installed.ts)_

--- a/packages/edge/src/__tests__/commands/edge/drivers/installed.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/drivers/installed.test.ts
@@ -1,8 +1,9 @@
-import { HubdevicesEndpoint, InstalledDriver } from '@smartthings/core-sdk'
+import { HubdevicesEndpoint, InstalledDriver, SmartThingsClient } from '@smartthings/core-sdk'
 
 import { outputItemOrList } from '@smartthings/cli-lib'
 
 import DriversInstalledCommand from '../../../../commands/edge/drivers/installed'
+import { withChannelNames, WithNamedChannel } from '../../../../lib/commands/channels-util'
 import { chooseHub } from '../../../../lib/commands/drivers-util'
 
 
@@ -14,13 +15,17 @@ jest.mock('@smartthings/cli-lib', () => {
 		outputItemOrList: jest.fn(),
 	}
 })
+jest.mock('../../../../../src/lib/commands/channels-util')
 jest.mock('../../../../../src/lib/commands/drivers-util')
 
 describe('DriversInstalledCommand', () => {
-	const hub = { name: 'Hub' } as InstalledDriver
+	const driver1 = { name: 'Driver 1' } as InstalledDriver
+	const driver2 = { name: 'Driver 2' } as InstalledDriver
+	const driver1WithChannelName = { ...driver1, channelName: 'Channel 1' } as InstalledDriver & WithNamedChannel
+	const driver2WithChannelName = { ...driver2, channelName: 'Channel 2' } as InstalledDriver & WithNamedChannel
 	const chooseHubMock = jest.mocked(chooseHub).mockResolvedValue('chosen-hub-id')
-	const apiHubsListInstalledSpy = jest.spyOn(HubdevicesEndpoint.prototype, 'listInstalled').mockResolvedValue([hub])
-	const apiHubsGetInstalledSpy = jest.spyOn(HubdevicesEndpoint.prototype, 'getInstalled').mockResolvedValue(hub)
+	const apiListInstalledSpy = jest.spyOn(HubdevicesEndpoint.prototype, 'listInstalled').mockResolvedValue([driver1])
+	const apiGetInstalledSpy = jest.spyOn(HubdevicesEndpoint.prototype, 'getInstalled').mockResolvedValue(driver1)
 	const outputItemOrListMock = jest.mocked(outputItemOrList)
 
 	afterEach(() => {
@@ -54,37 +59,93 @@ describe('DriversInstalledCommand', () => {
 		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
 	})
 
-	test('list function', async () => {
-		await expect(DriversInstalledCommand.run(['--device', 'cmd-line-device-id'])).resolves.not.toThrow()
+	it('includes channel name with verbose flag', async () => {
+		await expect(DriversInstalledCommand.run(['--verbose'])).resolves.not.toThrow()
 
 		expect(chooseHubMock).toHaveBeenCalledTimes(1)
-		expect(chooseHubMock).toHaveBeenCalledWith(expect.any(DriversInstalledCommand),
-			'Select a hub.', undefined, { allowIndex: true, useConfigDefault: true })
 
 		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
-
-		const listFunction = outputItemOrListMock.mock.calls[0][3]
-
-		expect(await listFunction()).toStrictEqual([hub])
-
-		expect(apiHubsListInstalledSpy).toHaveBeenCalledTimes(1)
-		expect(apiHubsListInstalledSpy).toHaveBeenCalledWith('chosen-hub-id', 'cmd-line-device-id')
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(DriversInstalledCommand),
+			expect.objectContaining({
+				primaryKeyName: 'driverId',
+				tableFieldDefinitions: expect.arrayContaining(['channelName']),
+				listTableFieldDefinitions: expect.arrayContaining(['channelName']),
+			}),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+		)
 	})
 
-	test('get function', async () => {
-		await expect(DriversInstalledCommand.run(['cmd-line-driver-id'])).resolves.not.toThrow()
+	describe('list function', () => {
+		const withChannelNamesMock = jest.mocked(withChannelNames)
 
-		expect(chooseHubMock).toHaveBeenCalledTimes(1)
-		expect(chooseHubMock).toHaveBeenCalledWith(expect.any(DriversInstalledCommand),
-			'Select a hub.', undefined, { allowIndex: true, useConfigDefault: true })
+		it('calls listInstalled', async () => {
+			await expect(DriversInstalledCommand.run(['--device', 'cmd-line-device-id'])).resolves.not.toThrow()
 
-		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+			expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
 
-		const getFunction = outputItemOrListMock.mock.calls[0][4]
+			const listFunction = outputItemOrListMock.mock.calls[0][3]
 
-		expect(await getFunction('chosen-device-id')).toBe(hub)
+			expect(await listFunction()).toStrictEqual([driver1])
 
-		expect(apiHubsGetInstalledSpy).toHaveBeenCalledTimes(1)
-		expect(apiHubsGetInstalledSpy).toHaveBeenCalledWith('chosen-hub-id', 'chosen-device-id')
+			expect(withChannelNamesMock).toHaveBeenCalledTimes(0)
+			expect(apiListInstalledSpy).toHaveBeenCalledTimes(1)
+			expect(apiListInstalledSpy).toHaveBeenCalledWith('chosen-hub-id', 'cmd-line-device-id')
+		})
+
+		it('uses withChannelNames in verbose mode', async () => {
+			await expect(DriversInstalledCommand.run(['--verbose'])).resolves.not.toThrow()
+
+			expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+
+			const listFunction = outputItemOrListMock.mock.calls[0][3]
+
+			apiListInstalledSpy.mockResolvedValueOnce([driver1, driver2])
+			withChannelNamesMock.mockResolvedValueOnce([driver1WithChannelName, driver2WithChannelName])
+
+			expect(await listFunction()).toStrictEqual([driver1WithChannelName, driver2WithChannelName])
+
+			expect(apiListInstalledSpy).toHaveBeenCalledTimes(1)
+			expect(apiListInstalledSpy).toHaveBeenCalledWith('chosen-hub-id', undefined)
+			expect(withChannelNamesMock).toHaveBeenCalledTimes(1)
+			expect(withChannelNamesMock).toHaveBeenCalledWith(expect.any(SmartThingsClient), [driver1, driver2])
+		})
+	})
+
+	describe('get function', () => {
+		const withChannelNamesMock = jest.mocked(withChannelNames) as unknown as
+			jest.Mock<Promise<InstalledDriver & WithNamedChannel>, [SmartThingsClient, InstalledDriver]>
+
+		it('calls getInstalled', async () => {
+			await expect(DriversInstalledCommand.run(['cmd-line-driver-id'])).resolves.not.toThrow()
+
+			expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+
+			const getFunction = outputItemOrListMock.mock.calls[0][4]
+
+			expect(await getFunction('chosen-device-id')).toBe(driver1)
+
+			expect(withChannelNamesMock).toHaveBeenCalledTimes(0)
+			expect(apiGetInstalledSpy).toHaveBeenCalledTimes(1)
+			expect(apiGetInstalledSpy).toHaveBeenCalledWith('chosen-hub-id', 'chosen-device-id')
+		})
+
+		it('uses withChannelNames in verbose mode', async () => {
+			await expect(DriversInstalledCommand.run(['cmd-line-driver-id', '--verbose'])).resolves.not.toThrow()
+
+			expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+
+			const getFunction = outputItemOrListMock.mock.calls[0][4]
+			withChannelNamesMock.mockResolvedValueOnce(driver1WithChannelName)
+
+			expect(await getFunction('chosen-device-id')).toBe(driver1WithChannelName)
+
+			expect(apiGetInstalledSpy).toHaveBeenCalledTimes(1)
+			expect(apiGetInstalledSpy).toHaveBeenCalledWith('chosen-hub-id', 'chosen-device-id')
+			expect(withChannelNamesMock).toHaveBeenCalledTimes(1)
+			expect(withChannelNamesMock).toHaveBeenCalledWith(expect.any(SmartThingsClient), driver1)
+		})
 	})
 })

--- a/packages/edge/src/commands/edge/drivers/installed.ts
+++ b/packages/edge/src/commands/edge/drivers/installed.ts
@@ -6,6 +6,7 @@ import { outputItemOrList, OutputItemOrListConfig } from '@smartthings/cli-lib'
 
 import { chooseHub } from '../../../lib/commands/drivers-util'
 import { EdgeCommand } from '../../../lib/edge-command'
+import { WithNamedChannel, withChannelNames } from '../../../lib/commands/channels-util'
 
 
 export default class DriversInstalledCommand extends EdgeCommand<typeof DriversInstalledCommand.flags> {
@@ -23,6 +24,10 @@ export default class DriversInstalledCommand extends EdgeCommand<typeof DriversI
 			description: 'return drivers matching the specified device',
 			helpValue: '<UUID>',
 		}),
+		verbose: Flags.boolean({
+			description: 'include channel name in output',
+			char: 'v',
+		}),
 	}
 
 	static args = [{
@@ -30,21 +35,47 @@ export default class DriversInstalledCommand extends EdgeCommand<typeof DriversI
 		description: 'the driver id or number in list',
 	}]
 
+	static examples = [
+		{
+			description: 'list all installed drivers',
+			command: 'smartthings edge:drivers:installed',
+		},
+		{
+			description: 'list all installed drivers and include the channel name in the output',
+			command: 'smartthings edge:drivers:installed --verbose',
+		},
+		{
+			description: 'list the first driver in the list retrieved by running "smartthings edge:drivers:installed"',
+			command: 'smartthings edge:drivers:installed 1',
+		},
+		{
+			description: 'list an installed driver by id',
+			command: 'smartthings edge:drivers:installed <driver-id>',
+		},
+	]
+
 	async run(): Promise<void> {
-		const config: OutputItemOrListConfig<InstalledDriver> = {
+		const config: OutputItemOrListConfig<InstalledDriver & WithNamedChannel> = {
 			primaryKeyName: 'driverId',
 			sortKeyName: 'name',
-			tableFieldDefinitions: ['driverId', 'name', 'description', 'version', 'channelId',
+			tableFieldDefinitions: ['name', 'driverId', 'description', 'version', 'channelId',
 				'developer', 'vendorSupportInformation'],
-			listTableFieldDefinitions: ['driverId', 'name', 'description', 'version', 'channelId',
-				'developer', 'vendorSupportInformation'],
+			listTableFieldDefinitions: ['name', 'driverId', 'version', 'channelId'],
 		}
+		if (this.flags.verbose) {
+			config.tableFieldDefinitions.splice(4, 0, 'channelName')
+			config.listTableFieldDefinitions.splice(3, 0, 'channelName')
+		}
+		const listInstalledWrapper: (drivers: Promise<InstalledDriver[]>) => Promise<(InstalledDriver & WithNamedChannel)[]> =
+			this.flags.verbose ? async drivers => withChannelNames(this.client, await drivers) : drivers => drivers
+		const getInstalledWrapper: (driver: Promise<InstalledDriver>) => Promise<InstalledDriver & WithNamedChannel> =
+			this.flags.verbose ? async driver => withChannelNames(this.client, await driver) : driver => driver
 
 		const hubId = await chooseHub(this, 'Select a hub.', this.flags.hub,
 			{ allowIndex: true, useConfigDefault: true })
 
 		await outputItemOrList(this, config, this.args.idOrIndex,
-			() => this.client.hubdevices.listInstalled(hubId, this.flags.device),
-			id => this.client.hubdevices.getInstalled(hubId, id))
+			() => listInstalledWrapper(this.client.hubdevices.listInstalled(hubId, this.flags.device)),
+			id => getInstalledWrapper(this.client.hubdevices.getInstalled(hubId, id)))
 	}
 }


### PR DESCRIPTION
<!-- Describe your pull request. -->

add --verbose option to edge:drivers:installed command

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
