### PR TITLE
feat: make channels list fit on a reasonably-size screen

### DIFF
--- a/.changeset/selfish-avocados-agree.md
+++ b/.changeset/selfish-avocados-agree.md
@@ -1,0 +1,6 @@
+---
+"@smartthings/cli": patch
+"@smartthings/plugin-cli-edge": patch
+---
+
+output fewer columns when listing channels to make the list fit on the screen better

--- a/packages/edge/src/lib/commands/channels-util.ts
+++ b/packages/edge/src/lib/commands/channels-util.ts
@@ -13,9 +13,10 @@ import {
 
 
 export const listTableFieldDefinitions: TableFieldDefinition<Channel>[] =
-	['channelId', 'name', 'description', 'termsOfServiceUrl', 'createdDate', 'lastModifiedDate']
+	['channelId', 'name', 'createdDate', 'lastModifiedDate']
 
-export const tableFieldDefinitions = listTableFieldDefinitions
+export const tableFieldDefinitions: TableFieldDefinition<Channel>[] =
+	['channelId', 'name', 'description', 'termsOfServiceUrl', 'createdDate', 'lastModifiedDate']
 
 export interface ChooseChannelOptions extends ChooseOptions {
 	includeReadOnly: boolean


### PR DESCRIPTION
<!-- Describe your pull request. -->

Removed `description` and `termsOfServiceUrl` from list output for `edge:channels` command.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
