### PR TITLE
docs: add basic "edge" command for better help message

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -172,6 +172,7 @@ that map to the API spec.
 * [`smartthings devices:rename [ID] [LABEL]`](#smartthings-devicesrename-id-label)
 * [`smartthings devices:status [ID]`](#smartthings-devicesstatus-id)
 * [`smartthings devices:update [ID]`](#smartthings-devicesupdate-id)
+* [`smartthings edge`](#smartthings-edge)
 * [`smartthings edge:channels [IDORINDEX]`](#smartthings-edgechannels-idorindex)
 * [`smartthings edge:channels:assign [DRIVERID] [VERSION]`](#smartthings-edgechannelsassign-driverid-version)
 * [`smartthings edge:channels:create`](#smartthings-edgechannelscreate)
@@ -2631,6 +2632,23 @@ DESCRIPTION
 ```
 
 _See code: [src/commands/devices/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.0/packages/cli/src/commands/devices/update.ts)_
+
+## `smartthings edge`
+
+edge topic
+
+```
+USAGE
+  $ smartthings edge [-h]
+
+COMMON FLAGS
+  -h, --help  Show CLI help.
+
+DESCRIPTION
+  edge topic
+```
+
+_See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.0/packages/edge/src/commands/edge.ts)_
 
 ## `smartthings edge:channels [IDORINDEX]`
 

--- a/packages/edge/README.md
+++ b/packages/edge/README.md
@@ -20,6 +20,7 @@ for information on running the CLI.
 # Commands
 
 <!-- commands -->
+* [`smartthings edge`](#smartthings-edge)
 * [`smartthings edge:channels [IDORINDEX]`](#smartthings-edgechannels-idorindex)
 * [`smartthings edge:channels:assign [DRIVERID] [VERSION]`](#smartthings-edgechannelsassign-driverid-version)
 * [`smartthings edge:channels:create`](#smartthings-edgechannelscreate)
@@ -44,6 +45,23 @@ for information on running the CLI.
 * [`smartthings edge:drivers:package [PROJECTDIRECTORY]`](#smartthings-edgedriverspackage-projectdirectory)
 * [`smartthings edge:drivers:switch [DEVICEID]`](#smartthings-edgedriversswitch-deviceid)
 * [`smartthings edge:drivers:uninstall [DRIVERID]`](#smartthings-edgedriversuninstall-driverid)
+
+## `smartthings edge`
+
+edge topic
+
+```
+USAGE
+  $ smartthings edge [-h]
+
+COMMON FLAGS
+  -h, --help  Show CLI help.
+
+DESCRIPTION
+  edge topic
+```
+
+_See code: [src/commands/edge.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.0/packages/edge/src/commands/edge.ts)_
 
 ## `smartthings edge:channels [IDORINDEX]`
 

--- a/packages/edge/src/__tests__/commands/edge.test.ts
+++ b/packages/edge/src/__tests__/commands/edge.test.ts
@@ -1,0 +1,13 @@
+import EdgeCommand from '../../commands/edge'
+
+
+describe('EdgeCommand', () => {
+	it('logs info on getting help when invoked without arguments', async () => {
+		const logSpy = jest.spyOn(EdgeCommand.prototype, 'log')
+
+		await expect(EdgeCommand.run([])).resolves.not.toThrow()
+
+		expect(logSpy).toHaveBeenCalledTimes(1)
+		expect(logSpy).toHaveBeenCalledWith('Run "smartthings edge --help" for info on the edge topic.')
+	})
+})

--- a/packages/edge/src/commands/edge.ts
+++ b/packages/edge/src/commands/edge.ts
@@ -1,0 +1,18 @@
+import { Command } from '@oclif/core'
+
+import { SmartThingsCommand } from '@smartthings/cli-lib'
+
+
+/**
+ * There is no top-level command for the `edge` topic, so we provide this stub to give
+ * oclif a description of the topic.
+ */
+export default class EdgeCommand extends Command {
+	static description = 'edge topic'
+
+	static flags = { help: SmartThingsCommand.flags.help }
+
+	async run(): Promise<void> {
+		this.log('Run "smartthings edge --help" for info on the edge topic.')
+	}
+}


### PR DESCRIPTION
<!-- Describe your pull request. -->

I added a basic "edge" command so the help message you get with `smartthings edge` or `smartthings edge --help` would be for the topic rather than the `edge:channels` command.

Ideally `smartthings edge` would display the same usage info `smartthings edge --help` does but I haven't been able to figure out how to do this with oclif yet so for now it simply prints a message suggesting the user run `smartthings edge --help`.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
