### PR TITLE
fix: remove profile dependency from reset test

### DIFF
--- a/packages/cli/src/__tests__/commands/config/reset.test.ts
+++ b/packages/cli/src/__tests__/commands/config/reset.test.ts
@@ -2,7 +2,7 @@ import inquirer from 'inquirer'
 
 import ConfigResetCommand from '../../../commands/config/reset'
 
-import { resetManagedConfig } from '@smartthings/cli-lib'
+import { resetManagedConfig, SmartThingsCommand } from '@smartthings/cli-lib'
 
 
 jest.mock('inquirer')
@@ -14,6 +14,8 @@ describe('ConfigResetCommand', () => {
 
 	const resetManagedConfigMock = jest.mocked(resetManagedConfig)
 
+	const profileNameSpy = jest.spyOn(SmartThingsCommand.prototype, 'profileName', 'get')
+
 	it('does nothing if user says no to prompt', async () => {
 		promptMock.mockResolvedValueOnce({ confirmed: false })
 
@@ -24,11 +26,14 @@ describe('ConfigResetCommand', () => {
 
 	it('resets config if user says yes to prompt', async () => {
 		promptMock.mockResolvedValueOnce({ confirmed: true })
+		profileNameSpy.mockReturnValue('default')
 
 		await expect(ConfigResetCommand.run([])).resolves.not.toThrow()
 
 		expect(resetManagedConfigMock).toHaveBeenCalledTimes(1)
 		expect(resetManagedConfigMock).toHaveBeenCalledWith(expect.anything(), 'default')
+
+		profileNameSpy.mockRestore()
 	})
 
 	it('resets config for alternate profile', async () => {


### PR DESCRIPTION
<!-- Describe your pull request. -->
fix bug causing test of reset command to fail if SMARTTHINGS_PROFILE was set

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
