### PR TITLE
fix: check for input before saying stdin has input

### DIFF
--- a/.changeset/sixty-geckos-hug.md
+++ b/.changeset/sixty-geckos-hug.md
@@ -1,0 +1,6 @@
+---
+"@smartthings/cli": patch
+"@smartthings/cli-lib": patch
+---
+
+fixed error handling stdin when not run from the console

--- a/packages/cli/src/__tests__/commands/devices/commands.test.ts
+++ b/packages/cli/src/__tests__/commands/devices/commands.test.ts
@@ -44,7 +44,7 @@ describe('DeviceCommandsCommand', () => {
 	const getCapabilitiesSpy = jest.spyOn(CapabilitiesEndpoint.prototype, 'get').mockImplementation()
 	const promptSpy = jest.spyOn(inquirer, 'prompt').mockImplementation()
 	jest.spyOn(DeviceCommandsCommand.prototype, 'log').mockImplementation()
-	jest.spyOn(StdinInputProcessor.prototype, 'hasInput').mockReturnValue(false)
+	jest.spyOn(StdinInputProcessor.prototype, 'hasInput').mockResolvedValue(false)
 
 	const chooseDeviceMock = jest.mocked(chooseDevice).mockResolvedValue('deviceId')
 

--- a/packages/lib/src/__tests__/input-builder.test.ts
+++ b/packages/lib/src/__tests__/input-builder.test.ts
@@ -40,7 +40,8 @@ describe('buildInputProcessor', () => {
 		}
 
 		const fileInputProcessor = makeProcessor()
-		const fileSpy = jest.spyOn(input, 'FileInputProcessor').mockReturnValue(fileInputProcessor)
+		const fileSpy = jest.spyOn(input, 'FileInputProcessor')
+			.mockReturnValue(fileInputProcessor as input.FileInputProcessor<SimpleType>)
 		const stdinInputProcessor = makeProcessor()
 		const stdinSpy = jest.spyOn(input, 'StdinInputProcessor')
 			.mockReturnValue(stdinInputProcessor as input.StdinInputProcessor<SimpleType>)

--- a/packages/lib/src/basic-io.ts
+++ b/packages/lib/src/basic-io.ts
@@ -59,7 +59,9 @@ export interface Naming {
 export async function inputItem<I extends object>(command: SmartThingsCommandInterface,
 		...alternateInputProcessors: InputProcessor<I>[]): Promise<[I, IOFormat]> {
 	const inputProcessor = buildInputProcessor<I>(command, ...alternateInputProcessors)
-	if (inputProcessor.hasInput()) {
+	const hasInputResult = inputProcessor.hasInput()
+	const hasInput = typeof hasInputResult === 'boolean' ? hasInputResult : await hasInputResult
+	if (hasInput) {
 		const item = await inputProcessor.read()
 		return [item, inputProcessor.ioFormat]
 	} else {


### PR DESCRIPTION
<!-- Describe your pull request. -->

* checked for input before saying stdin has input
* cleaned up affected unit tests a bit

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
