### PR TITLE
feat: validate saved default values for hubs and channels before using them

### DIFF
--- a/.changeset/tough-snakes-allow.md
+++ b/.changeset/tough-snakes-allow.md
@@ -1,0 +1,8 @@
+---
+"@smartthings/plugin-cli-edge": patch
+"@smartthings/cli-lib": patch
+---
+
+* Validate saved default values for hubs and channels before using them).
+* Inform the user when a default value is used.
+* Don't use default value for `edge:drivers:install` command.

--- a/packages/edge/src/__tests__/commands/edge/channels/delete.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/channels/delete.test.ts
@@ -29,7 +29,8 @@ describe('ChannelsDeleteCommand', () => {
 		)
 
 		const predicate = resetManagedConfigKeyMock.mock.calls[0][2]
-		expect(predicate('another-channel-id')).toBeFalsy()
-		expect(predicate('chosen-channel-id')).toBeTruthy()
+		expect(predicate).toBeDefined()
+		expect(predicate?.('another-channel-id')).toBeFalsy()
+		expect(predicate?.('chosen-channel-id')).toBeTruthy()
 	})
 })

--- a/packages/edge/src/commands/edge/drivers/install.ts
+++ b/packages/edge/src/commands/edge/drivers/install.ts
@@ -47,7 +47,6 @@ export default class DriversInstallCommand extends EdgeCommand<typeof DriversIns
 		return selectFromList(this, config, {
 			listItems,
 			promptMessage: 'Select a channel to install the driver from.',
-			configKeyForDefaultValue: 'defaultChannel',
 		})
 	}
 

--- a/packages/edge/src/lib/commands/channels-util.ts
+++ b/packages/edge/src/lib/commands/channels-util.ts
@@ -45,9 +45,15 @@ export async function chooseChannel(command: APICommand<typeof APICommand.flags>
 			: channelFromArg)
 		: undefined
 
-	const configKeyForDefaultValue = opts.useConfigDefault ? 'defaultChannel' : undefined
+	const defaultValue = opts.useConfigDefault
+		? {
+			configKey: 'defaultChannel',
+			getItem: (id: string): Promise<Channel> => command.client.channels.get(id),
+			userMessage: (channel: Channel): string => `using previously specified default channel named "${channel.name}" (${channel.channelId})`,
+		}
+		: undefined
 	return selectFromList(command, config,
-		{ preselectedId, listItems, promptMessage, configKeyForDefaultValue })
+		{ preselectedId, listItems, promptMessage, defaultValue })
 }
 
 export interface ListChannelOptions {

--- a/packages/edge/src/lib/commands/drivers-util.ts
+++ b/packages/edge/src/lib/commands/drivers-util.ts
@@ -150,9 +150,14 @@ export const chooseHub = async (command: APICommand<typeof APICommand.flags>, pr
 			: commandLineHubId)
 		: undefined
 
-	const configKeyForDefaultValue = opts.useConfigDefault ? 'defaultHub' : undefined
-	return selectFromList(command, config,
-		{ preselectedId, listItems, promptMessage, configKeyForDefaultValue })
+	const defaultValue = opts.useConfigDefault
+		? {
+			configKey: 'defaultHub',
+			getItem: (id: string): Promise<Device> => command.client.devices.get(id),
+			userMessage: (hub: Device): string => `using previously specified default hub labeled "${hub.label}" (${hub.deviceId})`,
+		}
+		: undefined
+	return selectFromList(command, config, { preselectedId, listItems, promptMessage, defaultValue })
 }
 
 export interface DriverChannelDetailsWithName extends DriverChannelDetails {

--- a/packages/lib/src/__mocks__/cli-config.ts
+++ b/packages/lib/src/__mocks__/cli-config.ts
@@ -1,6 +1,8 @@
 import { CLIConfig, CLIConfigDescription } from '../cli-config'
 
 
+export const mergeProfiles = jest.fn()
+
 export const loadConfig = jest.fn().mockImplementation(async (description: CLIConfigDescription): Promise<CLIConfig> =>
 	({
 		...description,
@@ -12,3 +14,5 @@ export const loadConfig = jest.fn().mockImplementation(async (description: CLICo
 
 
 export const setConfigKey = jest.fn()
+export const resetManagedConfigKey = jest.fn()
+export const resetManagedConfig = jest.fn()

--- a/packages/lib/src/__tests__/cli-config.test.ts
+++ b/packages/lib/src/__tests__/cli-config.test.ts
@@ -339,6 +339,14 @@ describe('cli-config', () => {
 			expect(predicateMock).toHaveBeenCalledTimes(2)
 		})
 
+		it('removes managed keys when no predicate is specified', async () => {
+			const cliConfig = makeConfig(profiles, profilesWithKeyToRemove)
+
+			await expect(resetManagedConfigKey(cliConfig, 'keyToRemove')).resolves.not.toThrow()
+
+			expect(cliConfig).toStrictEqual(makeConfig(profiles, profilesWithKeysRemoved))
+		})
+
 		it('removes managed keys that match predicate', async () => {
 			const cliConfig = makeConfig(profiles, profilesWithKeyToRemove)
 

--- a/packages/lib/src/__tests__/test-lib/mock-command.ts
+++ b/packages/lib/src/__tests__/test-lib/mock-command.ts
@@ -5,6 +5,8 @@ import { DefaultTableGenerator } from '../../table-generator'
 
 
 export const exitMock = jest.fn() as jest.Mock<never, [code?: number]>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const logToStderrMock: jest.Mock<void, [string, any[]]> = jest.fn()
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function buildMockCommand(flags: { [name: string]: any } = {}, profile: Profile = {}): SmartThingsCommandInterface {
@@ -22,5 +24,6 @@ export function buildMockCommand(flags: { [name: string]: any } = {}, profile: P
 		stringArrayConfigValue: jest.fn(),
 		booleanConfigValue: jest.fn(),
 		exit: exitMock,
+		logToStderr: logToStderrMock,
 	}
 }

--- a/packages/lib/src/cli-config.ts
+++ b/packages/lib/src/cli-config.ts
@@ -114,9 +114,9 @@ export const setConfigKey = async (config: CLIConfig, key: string, value: unknow
  *
  * This can be used to wipe out default values when something is deleted.
  */
-export const resetManagedConfigKey = async (config: CLIConfig, key: string, predicate: (value: unknown) => boolean): Promise<void> => {
+export const resetManagedConfigKey = async (config: CLIConfig, key: string, predicate?: (value: unknown) => boolean): Promise<void> => {
 	config.managedProfiles = Object.fromEntries(Object.entries(config.managedProfiles).map(([profileName, profile]) => {
-		if (key in profile && predicate(profile[key])) {
+		if (key in profile && (!predicate || predicate(profile[key]))) {
 			delete profile[key]
 		}
 		return [profileName, profile]

--- a/packages/lib/src/smartthings-command.ts
+++ b/packages/lib/src/smartthings-command.ts
@@ -14,7 +14,7 @@ export interface Loggable {
  * An interface version of SmartThingsCommand to make its contract easier to mix with other
  * interfaces and to limit what we need to mock for tests.
  */
-export interface SmartThingsCommandInterface extends Loggable {
+export type SmartThingsCommandInterface = Loggable & Pick<Command, 'exit' | 'logToStderr'> & {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	readonly flags: Interfaces.OutputFlags<any>
 
@@ -58,8 +58,6 @@ export interface SmartThingsCommandInterface extends Loggable {
 	 * exists but is not a boolean.
 	 */
 	booleanConfigValue(keyName: string, defaultValue?: boolean): boolean
-
-	exit(code?: number): void
 }
 
 /**


### PR DESCRIPTION
* Validated saved default values for hubs and channels before using them).
* If the saved default is valid, inform the user of the default being used
* If the saved default is valid, clear the key from the CLI-managed config file
* The `edge:drivers:install` command no longer uses a saved default channel (using the saved one here doesn't make sense because the list of channels valid for this command is limited to those the chosen hub is enrolled in).

Implements #445 

<!-- Describe your pull request. -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
