### PR TITLE
feat: allow more history recall when using JSON or YAML output

### DIFF
--- a/.changeset/fifty-kiwis-smoke.md
+++ b/.changeset/fifty-kiwis-smoke.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+allow more history recall when using JSON or YAML output

--- a/packages/cli/src/__tests__/commands/devices/history.test.ts
+++ b/packages/cli/src/__tests__/commands/devices/history.test.ts
@@ -6,9 +6,9 @@ import {
 	jsonFormatter,
 	writeOutput,
 } from '@smartthings/cli-lib'
-import { Device, DeviceActivity, DevicesEndpoint, HistoryEndpoint, PaginatedList } from '@smartthings/core-sdk'
+import { Device, DeviceActivity, DevicesEndpoint, HistoryEndpoint, PaginatedList, SmartThingsClient } from '@smartthings/core-sdk'
 import DeviceHistoryCommand from '../../../commands/devices/history'
-import { writeDeviceEventsTable } from '../../../lib/commands/history-util'
+import { calculateRequestLimit, getHistory, writeDeviceEventsTable } from '../../../lib/commands/history-util'
 
 
 jest.mock('../../../lib/commands/history-util')
@@ -19,16 +19,18 @@ describe('DeviceHistoryCommand', () => {
 	const deviceSelectionMock = jest.mocked(chooseDevice).mockResolvedValue('deviceId')
 	const calculateOutputFormatMock = jest.mocked(calculateOutputFormat).mockReturnValue(IOFormat.COMMON)
 	const writeDeviceEventsTableMock = jest.mocked(writeDeviceEventsTable)
+	const calculateHistoryRequestLimitMock = jest.mocked(calculateRequestLimit)
+	const getHistoryMock = jest.mocked(getHistory)
 
 	it('prompts user to select device', async () => {
-		getDeviceSpy.mockResolvedValue({ locationId: 'locationId' } as Device)
+		getDeviceSpy.mockResolvedValueOnce({ locationId: 'locationId' } as Device)
 		historySpy.mockResolvedValueOnce({
 			items: [],
 			hasNext: (): boolean => false,
 		} as unknown as PaginatedList<DeviceActivity>)
 		await expect(DeviceHistoryCommand.run(['deviceId'])).resolves.not.toThrow()
 
-		expect(deviceSelectionMock).toBeCalledWith(
+		expect(deviceSelectionMock).toHaveBeenCalledWith(
 			expect.any(DeviceHistoryCommand),
 			'deviceId',
 			{ allowIndex: true },
@@ -36,7 +38,7 @@ describe('DeviceHistoryCommand', () => {
 	})
 
 	it('queries history and writes event table interactively', async () => {
-		getDeviceSpy.mockResolvedValue({ locationId: 'locationId' } as Device)
+		getDeviceSpy.mockResolvedValueOnce({ locationId: 'locationId' } as Device)
 		historySpy.mockResolvedValueOnce({
 			items: [],
 			hasNext: (): boolean => false,
@@ -44,39 +46,47 @@ describe('DeviceHistoryCommand', () => {
 
 		await expect(DeviceHistoryCommand.run(['deviceId'])).resolves.not.toThrow()
 
-		expect(getDeviceSpy).toBeCalledTimes(1)
-		expect(getDeviceSpy).toBeCalledWith('deviceId')
-		expect(historySpy).toBeCalledTimes(1)
-		expect(historySpy).toBeCalledWith({
+		expect(getDeviceSpy).toHaveBeenCalledTimes(1)
+		expect(getDeviceSpy).toHaveBeenCalledWith('deviceId')
+		expect(historySpy).toHaveBeenCalledTimes(1)
+		expect(historySpy).toHaveBeenCalledWith({
 			deviceId: 'deviceId',
 			locationId: 'locationId',
 		})
-		expect(writeDeviceEventsTableMock).toBeCalledTimes(1)
+		expect(writeDeviceEventsTableMock).toHaveBeenCalledTimes(1)
 	})
 
 	it('queries history and write event table directly', async () => {
 		const buildOutputFormatterMock = jest.mocked(buildOutputFormatter)
 		const writeOutputMock = jest.mocked(writeOutput)
 
-		getDeviceSpy.mockResolvedValue({ locationId: 'locationId' } as Device)
+		calculateHistoryRequestLimitMock.mockReturnValueOnce(20)
+		getDeviceSpy.mockResolvedValueOnce({ locationId: 'locationId' } as Device)
 		historySpy.mockResolvedValueOnce({
 			items: [],
 			hasNext: (): boolean => false,
 		} as unknown as PaginatedList<DeviceActivity>)
-		calculateOutputFormatMock.mockReturnValue(IOFormat.JSON)
-		buildOutputFormatterMock.mockReturnValue(jsonFormatter(4))
+		calculateOutputFormatMock.mockReturnValueOnce(IOFormat.JSON)
+		buildOutputFormatterMock.mockReturnValueOnce(jsonFormatter(4))
 
 		await expect(DeviceHistoryCommand.run(['deviceId'])).resolves.not.toThrow()
 
-		expect(getDeviceSpy).toBeCalledTimes(1)
-		expect(getDeviceSpy).toBeCalledWith('deviceId')
-		expect(historySpy).toBeCalledTimes(1)
-		expect(historySpy).toBeCalledWith({
-			deviceId: 'deviceId',
-			locationId: 'locationId',
-		})
-		expect(writeDeviceEventsTableMock).toBeCalledTimes(0)
-		expect(buildOutputFormatterMock).toBeCalledTimes(1)
-		expect(writeOutputMock).toBeCalledTimes(1)
+		expect(getDeviceSpy).toHaveBeenCalledTimes(1)
+		expect(getDeviceSpy).toHaveBeenCalledWith('deviceId')
+		expect(getHistoryMock).toHaveBeenCalledTimes(1)
+		expect(getHistoryMock).toHaveBeenCalledWith(
+			expect.any(SmartThingsClient),
+			20,
+			20,
+			expect.objectContaining({
+				deviceId: 'deviceId',
+				locationId: 'locationId',
+			}),
+		)
+		expect(buildOutputFormatterMock).toHaveBeenCalledTimes(1)
+		expect(writeOutputMock).toHaveBeenCalledTimes(1)
+
+		expect(historySpy).toHaveBeenCalledTimes(0)
+		expect(writeDeviceEventsTableMock).toHaveBeenCalledTimes(0)
 	})
 })

--- a/packages/cli/src/__tests__/commands/locations/history.test.ts
+++ b/packages/cli/src/__tests__/commands/locations/history.test.ts
@@ -5,9 +5,9 @@ import {
 	jsonFormatter,
 	writeOutput,
 } from '@smartthings/cli-lib'
-import { DeviceActivity, HistoryEndpoint, PaginatedList } from '@smartthings/core-sdk'
+import { DeviceActivity, HistoryEndpoint, PaginatedList, SmartThingsClient } from '@smartthings/core-sdk'
 import LocationHistoryCommand from '../../../commands/locations/history'
-import { writeDeviceEventsTable } from '../../../lib/commands/history-util'
+import { calculateRequestLimit, getHistory, writeDeviceEventsTable } from '../../../lib/commands/history-util'
 import { chooseLocation } from '../../../commands/locations'
 
 
@@ -19,6 +19,8 @@ describe('LocationHistoryCommand', () => {
 	const historySpy = jest.spyOn(HistoryEndpoint.prototype, 'devices').mockImplementation()
 	const calculateOutputFormatMock = jest.mocked(calculateOutputFormat).mockReturnValue(IOFormat.COMMON)
 	const writeDeviceEventsTableMock = jest.mocked(writeDeviceEventsTable)
+	const calculateHistoryRequestLimitMock = jest.mocked(calculateRequestLimit)
+	const getHistoryMock = jest.mocked(getHistory)
 
 	it('queries history and writes event table interactively', async () => {
 		historySpy.mockResolvedValueOnce({
@@ -28,34 +30,44 @@ describe('LocationHistoryCommand', () => {
 
 		await expect(LocationHistoryCommand.run(['locationId'])).resolves.not.toThrow()
 
-		expect(mockChooseLocation).toBeCalledTimes(1)
-		expect(historySpy).toBeCalledTimes(1)
-		expect(historySpy).toBeCalledWith({
+		expect(mockChooseLocation).toHaveBeenCalledTimes(1)
+		expect(calculateOutputFormatMock).toHaveBeenCalledTimes(1)
+		expect(historySpy).toHaveBeenCalledTimes(1)
+		expect(historySpy).toHaveBeenCalledWith({
 			locationId: 'locationId',
+			limit: 20,
 		})
-		expect(writeDeviceEventsTableMock).toBeCalledTimes(1)
+		expect(writeDeviceEventsTableMock).toHaveBeenCalledTimes(1)
 	})
 
 	it('queries history and write event table directly', async () => {
 		const buildOutputFormatterMock = jest.mocked(buildOutputFormatter)
 		const writeOutputMock = jest.mocked(writeOutput)
 
-		historySpy.mockResolvedValueOnce({
-			items: [],
-			hasNext: (): boolean => false,
-		} as unknown as PaginatedList<DeviceActivity>)
-		calculateOutputFormatMock.mockReturnValue(IOFormat.JSON)
-		buildOutputFormatterMock.mockReturnValue(jsonFormatter(4))
+		calculateHistoryRequestLimitMock.mockReturnValueOnce(20)
+		calculateOutputFormatMock.mockReturnValueOnce(IOFormat.JSON)
+		buildOutputFormatterMock.mockReturnValueOnce(jsonFormatter(4))
 
 		await expect(LocationHistoryCommand.run(['locationId'])).resolves.not.toThrow()
 
-		expect(mockChooseLocation).toBeCalledTimes(1)
-		expect(historySpy).toBeCalledTimes(1)
-		expect(historySpy).toBeCalledWith({
-			locationId: 'locationId',
-		})
-		expect(writeDeviceEventsTableMock).toBeCalledTimes(0)
-		expect(buildOutputFormatterMock).toBeCalledTimes(1)
-		expect(writeOutputMock).toBeCalledTimes(1)
+		expect(calculateHistoryRequestLimitMock).toHaveBeenCalledTimes(1)
+		expect(calculateHistoryRequestLimitMock).toHaveBeenCalledWith(20)
+		expect(mockChooseLocation).toHaveBeenCalledTimes(1)
+		expect(calculateOutputFormatMock).toHaveBeenCalledTimes(1)
+		expect(getHistoryMock).toHaveBeenCalledTimes(1)
+		expect(getHistoryMock).toHaveBeenCalledWith(
+			expect.any(SmartThingsClient),
+			20,
+			20,
+			expect.objectContaining({
+				locationId: 'locationId',
+			}),
+		)
+		expect(writeDeviceEventsTableMock).toHaveBeenCalledTimes(0)
+		expect(buildOutputFormatterMock).toHaveBeenCalledTimes(1)
+		expect(writeOutputMock).toHaveBeenCalledTimes(1)
+
+		expect(historySpy).toHaveBeenCalledTimes(0)
+		expect(writeDeviceEventsTableMock).toHaveBeenCalledTimes(0)
 	})
 })


### PR DESCRIPTION
<!-- Describe your pull request. -->

* updated `devices:history and `locations:history` commands to work with API limit of 300 items per request
* added a soft limit of 6 requests worth of history when querying JSON or YAML output
  * If more than 6 requests will be needed, the user is prompted with options of canceling the request, limiting it, or going ahead
* updated some code and unit tests for history-util to achieve 100% code coverage for unit tests of this module

fixes #449 

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
