### PR TITLE
docs: add references to API docs in a couple commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -280,6 +280,11 @@ COMMON FLAGS
 DESCRIPTION
   get a specific app or a list of apps
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listApps,
+  https://developer.smartthings.com/docs/api/public/#operation/getApp
+
 EXAMPLES
   list all apps
 
@@ -374,6 +379,10 @@ COMMON FLAGS
 DESCRIPTION
   create an app
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/createApp
+
 EXAMPLES
   create an app defined in "my-app.yaml"
 
@@ -406,6 +415,10 @@ COMMON FLAGS
 
 DESCRIPTION
   delete the app
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteApp
 
 EXAMPLES
   select app to delete from list
@@ -441,6 +454,10 @@ COMMON FLAGS
 
 DESCRIPTION
   get OAuth information for the app
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getAppOauth
 ```
 
 _See code: [src/commands/apps/oauth.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/apps/oauth.ts)_
@@ -472,6 +489,10 @@ COMMON FLAGS
 
 DESCRIPTION
   regenerate the OAuth clientId and clientSecret of an app
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateAppOauth
 ```
 
 _See code: [src/commands/apps/oauth/generate.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/apps/oauth/generate.ts)_
@@ -526,6 +547,10 @@ COMMON FLAGS
 
 DESCRIPTION
   send request to app target URL to confirm existence and authorize lifecycle events
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/register
 ```
 
 _See code: [src/commands/apps/register.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/apps/register.ts)_
@@ -552,6 +577,10 @@ COMMON FLAGS
 
 DESCRIPTION
   get the settings of the app
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getAppSettings
 ```
 
 _See code: [src/commands/apps/settings.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/apps/settings.ts)_
@@ -583,6 +612,10 @@ COMMON FLAGS
 
 DESCRIPTION
   update the settings of the app
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateAppSettings
 ```
 
 _See code: [src/commands/apps/settings/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/apps/settings/update.ts)_
@@ -617,6 +650,10 @@ COMMON FLAGS
 
 DESCRIPTION
   update the settings of the app
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateApp
 ```
 
 _See code: [src/commands/apps/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/apps/update.ts)_
@@ -652,7 +689,7 @@ _See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomp
 
 ## `smartthings capabilities [ID] [VERSION]`
 
-get a specific capability
+get a specific capability or a list of capabilities
 
 ```
 USAGE
@@ -679,7 +716,7 @@ COMMON FLAGS
   --language=<value>     ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 
 DESCRIPTION
-  get a specific capability
+  get a specific capability or a list of capabilities
 ```
 
 _See code: [src/commands/capabilities.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/capabilities.ts)_

--- a/packages/cli/src/commands/apps.ts
+++ b/packages/cli/src/commands/apps.ts
@@ -5,7 +5,8 @@ import { shortARNorURL, tableFieldDefinitions, verboseApps } from '../lib/comman
 
 
 export default class AppsCommand extends APICommand<typeof AppsCommand.flags> {
-	static description = 'get a specific app or a list of apps'
+	static description = 'get a specific app or a list of apps' +
+		this.apiDocsURL('listApps', 'getApp')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/apps/create.ts
+++ b/packages/cli/src/commands/apps/create.ts
@@ -6,7 +6,8 @@ import { tableFieldDefinitions } from '../../lib/commands/apps-util'
 
 
 export default class AppCreateCommand extends APICommand<typeof AppCreateCommand.flags> {
-	static description = 'create an app'
+	static description = 'create an app' +
+		this.apiDocsURL('createApp')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/apps/delete.ts
+++ b/packages/cli/src/commands/apps/delete.ts
@@ -3,7 +3,8 @@ import { chooseApp } from '../../lib/commands/apps-util'
 
 
 export default class AppDeleteCommand extends APICommand<typeof AppDeleteCommand.flags> {
-	static description = 'delete the app'
+	static description = 'delete the app' +
+		this.apiDocsURL('deleteApp')
 
 	static flags = APICommand.flags
 

--- a/packages/cli/src/commands/apps/oauth.ts
+++ b/packages/cli/src/commands/apps/oauth.ts
@@ -3,7 +3,8 @@ import { chooseApp, oauthTableFieldDefinitions } from '../../lib/commands/apps-u
 
 
 export default class AppOauthCommand extends APICommand<typeof AppOauthCommand.flags> {
-	static description = 'get OAuth information for the app'
+	static description = 'get OAuth information for the app' +
+		this.apiDocsURL('getAppOauth')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/apps/oauth/generate.ts
+++ b/packages/cli/src/commands/apps/oauth/generate.ts
@@ -4,7 +4,8 @@ import { chooseApp } from '../../../lib/commands/apps-util'
 
 
 export default class AppOauthGenerateCommand extends APICommand<typeof AppOauthGenerateCommand.flags> {
-	static description = 'regenerate the OAuth clientId and clientSecret of an app'
+	static description = 'regenerate the OAuth clientId and clientSecret of an app' +
+		this.apiDocsURL('updateAppOauth')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/apps/register.ts
+++ b/packages/cli/src/commands/apps/register.ts
@@ -4,7 +4,8 @@ import { inspect } from 'util'
 
 
 export default class AppRegisterCommand extends APICommand<typeof AppRegisterCommand.flags> {
-	static description = 'send request to app target URL to confirm existence and authorize lifecycle events'
+	static description = 'send request to app target URL to confirm existence and authorize lifecycle events' +
+		this.apiDocsURL('register')
 
 	static flags = APICommand.flags
 

--- a/packages/cli/src/commands/apps/settings.ts
+++ b/packages/cli/src/commands/apps/settings.ts
@@ -4,7 +4,8 @@ import { buildTableOutput, chooseApp } from '../../lib/commands/apps-util'
 
 
 export default class AppSettingsCommand extends APICommand<typeof AppSettingsCommand.flags> {
-	static description = 'get the settings of the app'
+	static description = 'get the settings of the app' +
+		this.apiDocsURL('getAppSettings')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/apps/settings/update.ts
+++ b/packages/cli/src/commands/apps/settings/update.ts
@@ -4,7 +4,8 @@ import { buildTableOutput, chooseApp } from '../../../lib/commands/apps-util'
 
 
 export default class AppSettingsUpdateCommand extends APICommand<typeof AppSettingsUpdateCommand.flags> {
-	static description = 'update the settings of the app'
+	static description = 'update the settings of the app' +
+		this.apiDocsURL('updateAppSettings')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/apps/update.ts
+++ b/packages/cli/src/commands/apps/update.ts
@@ -6,7 +6,8 @@ import { chooseApp, tableFieldDefinitions } from '../../lib/commands/apps-util'
 
 
 export default class AppUpdateCommand extends APICommand<typeof AppUpdateCommand.flags> {
-	static description = 'update the settings of the app'
+	static description = 'update the settings of the app' +
+		this.apiDocsURL('updateApp')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/lib/src/api-command.ts
+++ b/packages/lib/src/api-command.ts
@@ -28,6 +28,9 @@ export abstract class APICommand<T extends typeof APICommand.flags> extends Smar
 		}),
 	}
 
+	static apiDocsURL = (...names: string[]): string => '\nFor API information, see:\n\n' +
+		names.map(name => `https://developer.smartthings.com/docs/api/public/#operation/${name}`).join(', ')
+
 	protected clientIdProvider = defaultClientIdProvider
 	protected token?: string
 	private _authenticator!: Authenticator


### PR DESCRIPTION
<!-- Describe your pull request. -->

This pull request is an example of how we might add these links to the descriptions of the commands that are backed by API calls.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
