### PR TITLE
feat: enable verbose when getting device

### DIFF
--- a/.changeset/cyan-boats-dream.md
+++ b/.changeset/cyan-boats-dream.md
@@ -1,0 +1,9 @@
+---
+"@smartthings/cli": minor
+"@smartthings/cli-lib": minor
+"@smartthings/cli-testlib": minor
+---
+
+enable verbose flag when getting a single device
+
+add helper method to get location and room names for a single item

--- a/packages/cli/src/__tests__/lib/commands/devices-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/devices-util.test.ts
@@ -266,6 +266,21 @@ describe('devices-util', () => {
 			expect(tablePushMock).toHaveBeenCalledWith(['Last Updated', '2022-07-28T14:50:42.899Z'])
 		})
 
+		it('displays location and room names', () => {
+			const verboseDevice = {
+				room: 'room-name',
+				location: 'location-name',
+			} as unknown as Device
+			tableToStringMock.mockReturnValueOnce('main table')
+
+			expect(buildTableOutput(tableGeneratorMock, verboseDevice))
+				.toEqual('Main Info\nmain table')
+
+			expect(tablePushMock).toHaveBeenCalledTimes(10)
+			expect(tablePushMock).toHaveBeenCalledWith(['Room', 'room-name'])
+			expect(tablePushMock).toHaveBeenCalledWith(['Location', 'location-name'])
+		})
+
 		it('displays device status', () => {
 			const device = {
 				components: [

--- a/packages/cli/src/lib/commands/devices-util.ts
+++ b/packages/cli/src/lib/commands/devices-util.ts
@@ -1,6 +1,6 @@
 import { Device, DeviceHealth, DeviceStatus } from '@smartthings/core-sdk'
 
-import { TableGenerator } from '@smartthings/cli-lib'
+import { TableGenerator, WithNamedRoom } from '@smartthings/cli-lib'
 
 
 export type DeviceWithLocation = Device & { location?: string }
@@ -76,7 +76,7 @@ export const buildEmbeddedStatusTableOutput = (tableGenerator: TableGenerator, d
 	return hasStatus ? output : ''
 }
 
-export const buildTableOutput = (tableGenerator: TableGenerator, device: Device & { profileId?: string; healthState?: DeviceHealth }): string => {
+export const buildTableOutput = (tableGenerator: TableGenerator, device: Device & WithNamedRoom & { profileId?: string; healthState?: DeviceHealth }): string => {
 	const table = tableGenerator.newOutputTable()
 	table.push(['Label', device.label])
 	table.push(['Name', device.name])
@@ -84,7 +84,13 @@ export const buildTableOutput = (tableGenerator: TableGenerator, device: Device 
 	table.push(['Type', device.type])
 	table.push(['Manufacturer Code', device.deviceManufacturerCode ?? ''])
 	table.push(['Location Id', device.locationId ?? ''])
+	if (device.location) {
+		table.push(['Location', device.location])
+	}
 	table.push(['Room Id', device.roomId ?? ''])
+	if (device.room) {
+		table.push(['Room', device.room])
+	}
 	table.push(['Profile Id', device.profile?.id ?? (device.profileId ?? '')])
 	for (const comp of device.components ?? []) {
 		const label = comp.id === 'main' ? 'Capabilities' : `Capabilities (${comp.id})`

--- a/packages/lib/src/__tests__/api-helpers.test.ts
+++ b/packages/lib/src/__tests__/api-helpers.test.ts
@@ -8,7 +8,7 @@ import {
 	SmartThingsClient,
 } from '@smartthings/core-sdk'
 
-import { forAllNamespaces, forAllOrganizations, withLocation, withLocations, withLocationsAndRooms } from '../api-helpers'
+import { forAllNamespaces, forAllOrganizations, withLocation, withLocations, withLocationAndRoom, withLocationsAndRooms } from '../api-helpers'
 import * as apiHelpers from '../api-helpers'
 import { SimpleType } from './test-lib/simple-type'
 
@@ -250,6 +250,27 @@ describe('api-helpers', () => {
 				{ ...things[2], location: 'vacation home', room: 'living room' },
 				{ ...things[3], location: 'main location', room: 'garage' },
 			])
+		})
+	})
+
+	describe('withLocationAndRoom', () => {
+		const withLocationsAndRoomsSpy = jest.spyOn(apiHelpers, 'withLocationsAndRooms')
+
+		it('proxies to withLocationsAndRooms and indexes return', async () => {
+			const item: SimpleType & apiHelpers.WithRoom = {
+				num: 1,
+				str: 'string',
+				locationId: 'location-id',
+				roomId: 'room-id',
+			}
+			const itemWithLocationAndRoom = { ...item, location: 'Location Name', room: 'Room Name' }
+
+			withLocationsAndRoomsSpy.mockResolvedValueOnce([itemWithLocationAndRoom])
+
+			expect(await withLocationAndRoom(client, item)).toBe(itemWithLocationAndRoom)
+
+			expect(withLocationsAndRoomsSpy).toHaveBeenCalledTimes(1)
+			expect(withLocationsAndRoomsSpy).toHaveBeenCalledWith(client, [item])
 		})
 	})
 

--- a/packages/lib/src/api-helpers.ts
+++ b/packages/lib/src/api-helpers.ts
@@ -71,6 +71,9 @@ export const withLocationsAndRooms = async <T extends WithRoom>(client: SmartThi
 	})
 }
 
+export const withLocationAndRoom = async <T extends WithRoom>(client: SmartThingsClient, item: T): Promise<T & WithNamedRoom> =>
+	(await withLocationsAndRooms(client, [item]))[0]
+
 export async function forAllOrganizations<T>(
 		client: SmartThingsClient,
 		query: (orgClient: SmartThingsClient, org: OrganizationResponse) => Promise<T[]>): Promise<(T & WithOrganization)[]> {

--- a/packages/testlib/src/index.ts
+++ b/packages/testlib/src/index.ts
@@ -21,6 +21,7 @@ jest.mock('@smartthings/cli-lib', () => {
 		formatAndWriteItem: jest.fn(),
 		withLocation: jest.fn(),
 		withLocations: jest.fn(),
+		withLocationAndRoom: jest.fn(),
 		withLocationsAndRooms: jest.fn(),
 		yamlExists: jest.fn(),
 		chooseDevice: jest.fn(),


### PR DESCRIPTION
- enable verbose flag when getting a single device
- add helper method to get location and room names for a single item

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
