### PR TITLE
docs: add references to API docs where available

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,7 +17,7 @@ https://www.npmjs.com/package/@oclif/dev-cli
 SmartThings CLI
 =======================
 
-The SmartThings CLI is a tool to help with developing applications and drivers for the SmartThings ecosystem.
+The SmartThings CLI is a tool to help with developing SmartApps and drivers for the SmartThings ecosystem.
 
 <!-- toc -->
 * [Overview](#overview)
@@ -717,6 +717,12 @@ COMMON FLAGS
 
 DESCRIPTION
   get a specific capability or a list of capabilities
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listNamespacedCapabilities,
+  https://developer.smartthings.com/docs/api/public/#operation/listCapabilities,
+  https://developer.smartthings.com/docs/api/public/#operation/getCapability
 ```
 
 _See code: [src/commands/capabilities.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/capabilities.ts)_
@@ -747,6 +753,10 @@ COMMON FLAGS
 
 DESCRIPTION
   create a capability for a user
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/createCapability
 ```
 
 _See code: [src/commands/capabilities/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/capabilities/create.ts)_
@@ -774,6 +784,10 @@ COMMON FLAGS
 
 DESCRIPTION
   delete a capability
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteCapability
 ```
 
 _See code: [src/commands/capabilities/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/capabilities/delete.ts)_
@@ -833,6 +847,10 @@ COMMON FLAGS
 
 DESCRIPTION
   get presentation information for a specific capability
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getCapabilityPresentation
 ```
 
 _See code: [src/commands/capabilities/presentation.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/capabilities/presentation.ts)_
@@ -866,6 +884,10 @@ COMMON FLAGS
 
 DESCRIPTION
   create presentation model for a capability
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/createCustomCapabilityPresentation
 ```
 
 _See code: [src/commands/capabilities/presentation/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/capabilities/presentation/create.ts)_
@@ -899,6 +921,10 @@ COMMON FLAGS
 
 DESCRIPTION
   update presentation information of a capability
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateCustomCapabilityPresentation
 ```
 
 _See code: [src/commands/capabilities/presentation/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/capabilities/presentation/update.ts)_
@@ -933,6 +959,11 @@ COMMON FLAGS
 
 DESCRIPTION
   get list of locales supported by the capability
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listCapabilityLocalizations,
+  https://developer.smartthings.com/docs/api/public/#operation/getCapabilityLocalization
 
 EXAMPLES
   $ smartthings capabilities:translations
@@ -1035,6 +1066,10 @@ COMMON FLAGS
 DESCRIPTION
   create a capability translation
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/createCapabilityLocalization
+
 EXAMPLES
   $ smartthings capabilities:translations:create custom1.outputModulation 1 -i en.yaml 
 
@@ -1119,6 +1154,10 @@ COMMON FLAGS
 
 DESCRIPTION
   update a capability translation
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateCapabilityLocalization
 
 EXAMPLES
   $ smartthings capabilities:translations:update custom1.outputModulation 1 -i en.yaml 
@@ -1205,6 +1244,11 @@ COMMON FLAGS
 DESCRIPTION
   create or update a capability translation
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateCapabilityLocalization,
+  https://developer.smartthings.com/docs/api/public/#operation/createCapabilityLocalization
+
 EXAMPLES
   $ smartthings capabilities:translations:upsert custom1.outputModulation 1 -i en.yaml 
 
@@ -1289,6 +1333,10 @@ COMMON FLAGS
 
 DESCRIPTION
   update a capability
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateCapability
 ```
 
 _See code: [src/commands/capabilities/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/capabilities/update.ts)_
@@ -1371,6 +1419,11 @@ COMMON FLAGS
 DESCRIPTION
   list device preferences or get information for a specific device preference
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listPreferences,
+  https://developer.smartthings.com/docs/api/public/#operation/getPreferenceById
+
 EXAMPLES
   $ smartthings devicepreferences                       # list all device preferences, sorted by title
 
@@ -1410,6 +1463,10 @@ COMMON FLAGS
 
 DESCRIPTION
   create a device preference
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/createPreference
 
 EXAMPLES
   # create a new device preference by answering questions
@@ -1574,6 +1631,10 @@ COMMON FLAGS
 DESCRIPTION
   update a device preference
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updatePreferenceById
+
 EXAMPLES
   $ smartthings devicepreferences:update -i dp.json                   # update a device preference with data from dp.json, select which preference from a list
 
@@ -1610,6 +1671,11 @@ COMMON FLAGS
 
 DESCRIPTION
   list all device profiles available in a user account or retrieve a single profile
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listDeviceProfiles,
+  https://developer.smartthings.com/docs/api/public/#operation/getDeviceProfile
 
 EXAMPLES
   $ smartthings deviceprofiles                      # list all device profiles
@@ -1653,11 +1719,12 @@ COMMON FLAGS
 DESCRIPTION
   create a new device profile
 
-  Creates a new device profile. If a vid field is not present in the meta
+  Creates a new device profile. If a vid field is not present in the meta then a default device presentation will be
+  created for this profile and the vid set to reference it.
 
-  then a default device presentation will be created for this profile and the
+  For API information, see:
 
-  vid set to reference it.
+  https://developer.smartthings.com/docs/api/public/#operation/createDeviceProfile
 
 EXAMPLES
   $ smartthings deviceprofiles:create -i myprofile.json    # create a device profile from the JSON file definition
@@ -1691,6 +1758,10 @@ COMMON FLAGS
 
 DESCRIPTION
   delete a device profile
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteDeviceProfile
 
 EXAMPLES
   $ smartthings deviceprofiles:delete 63b8c91e-9686-4c43-9afb-fbd9f77e3bb0  # delete profile with this UUID
@@ -1726,6 +1797,11 @@ COMMON FLAGS
 
 DESCRIPTION
   get the device configuration associated with a device profile
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getDeviceProfile,
+  https://developer.smartthings.com/docs/api/public/#operation/getDeviceConfiguration
 ```
 
 _See code: [src/commands/deviceprofiles/device-config.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/deviceprofiles/device-config.ts)_
@@ -1756,6 +1832,11 @@ COMMON FLAGS
 
 DESCRIPTION
   get the presentation associated with a device profile
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getDeviceProfile,
+  https://developer.smartthings.com/docs/api/public/#operation/getDevicePresentation
 
 EXAMPLES
   $ smartthings deviceprofiles:presentation fd4adb7f-4a23-4134-9b39-05ed889a03cf
@@ -2132,6 +2213,10 @@ COMMON FLAGS
 
 DESCRIPTION
   update a device profile
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateDeviceProfile
 ```
 
 _See code: [src/commands/deviceprofiles/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/deviceprofiles/update.ts)_
@@ -2162,6 +2247,10 @@ COMMON FLAGS
 
 DESCRIPTION
   show device profile and device configuration in a single, consolidated view
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getDeviceProfile, getDeviceConfiguration
 ```
 
 _See code: [src/commands/deviceprofiles/view.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/deviceprofiles/view.ts)_
@@ -2192,11 +2281,15 @@ COMMON FLAGS
 DESCRIPTION
   create a new device profile and device configuration
 
-  Creates a new device profile and device configuration. Unlike deviceprofiles:create,
+  Creates a new device profile and device configuration. Unlike deviceprofiles:create, this command accepts a
+  consolidated object that can include a device configuration in a property named "view".
 
-  this command accepts a consolidated object that can include a device configuration
+  For API information, see:
 
-  in a property named "view".
+  https://developer.smartthings.com/docs/api/public/#operation/createDeviceProfile,
+  https://developer.smartthings.com/docs/api/public/#operation/createDeviceConfiguration,
+  https://developer.smartthings.com/docs/api/public/#operation/updateDeviceProfile,
+  https://developer.smartthings.com/docs/api/public/#operation/generateDeviceConfig
 
 EXAMPLES
   $ smartthings deviceprofiles:view:create -i test.json
@@ -2271,13 +2364,15 @@ COMMON FLAGS
 DESCRIPTION
   update a device profile and configuration
 
-  Updates a device profile and device configuration and sets the vid of the profile
+  Updates a device profile and device configuration and sets the vid of the profile to the vid of the updated
+  configuration. Unlike deviceprofiles:update this command accepts a consolidated object that can include a device
+  configuration in a property named "view".
 
-  to the vid of the updated configuration. Unlike deviceprofiles:update this
+  For API information, see:
 
-  command accepts a consolidated object that can include a device configuration
-
-  in a property named "view".
+  https://developer.smartthings.com/docs/api/public/#operation/createDeviceConfiguration,
+  https://developer.smartthings.com/docs/api/public/#operation/updateDeviceProfile,
+  https://developer.smartthings.com/docs/api/public/#operation/generateDeviceConfig
 
 EXAMPLES
   $ smartthings deviceprofiles:view:update 84042863-0d34-4c5c-b497-808daf230787 -i test.json
@@ -2350,7 +2445,7 @@ FLAGS
   -d, --device=<UUID>...            filter results by device
   -l, --location=<UUID>...          filter results by location
   -s, --status                      include attribute values in the response
-  -v, --verbose                     include location name in output
+  -v, --verbose                     include location and room name in output
   --type=<option>...                filter results by device type
                                     <options: BLE|BLE_D2D|DTH|ENDPOINT_APP|GROUP|HUB|IR|IR_OCF|LAN|MATTER|MOBILE|MQTT|OC
                                     F|PENGYOU|SHP|VIDEO|VIPER|VIRTUAL|WATCH|ZIGBEE|ZWAVE>
@@ -2366,6 +2461,11 @@ COMMON FLAGS
 
 DESCRIPTION
   list all devices available in a user account or retrieve a single device
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getDevices,
+  https://developer.smartthings.com/docs/api/public/#operation/getDevice
 ```
 
 _See code: [src/commands/devices.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/devices.ts)_
@@ -2395,6 +2495,10 @@ COMMON FLAGS
 
 DESCRIPTION
   get the current status of all of a device capability's attributes
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getDeviceStatusByCapability
 ```
 
 _See code: [src/commands/devices/capability-status.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/devices/capability-status.ts)_
@@ -2423,6 +2527,10 @@ COMMON FLAGS
 
 DESCRIPTION
   execute a device command
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/executeDeviceCommands
 
 EXAMPLES
   # simple capability and command
@@ -2460,6 +2568,10 @@ COMMON FLAGS
 
 DESCRIPTION
   get the current status of a device component's attributes
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getDeviceComponentStatus
 ```
 
 _See code: [src/commands/devices/component-status.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/devices/component-status.ts)_
@@ -2483,6 +2595,10 @@ COMMON FLAGS
 
 DESCRIPTION
   delete a device
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteDevice
 ```
 
 _See code: [src/commands/devices/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/devices/delete.ts)_
@@ -2624,6 +2740,10 @@ COMMON FLAGS
 
 DESCRIPTION
   rename a device
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateDevice
 ```
 
 _See code: [src/commands/devices/rename.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/devices/rename.ts)_
@@ -2650,6 +2770,10 @@ COMMON FLAGS
 
 DESCRIPTION
   get the current status of all of a device's component's attributes
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getDeviceStatus
 ```
 
 _See code: [src/commands/devices/status.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/devices/status.ts)_
@@ -2681,6 +2805,10 @@ COMMON FLAGS
 
 DESCRIPTION
   update a device's label and room
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateDevice
 ```
 
 _See code: [src/commands/devices/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/devices/update.ts)_
@@ -2734,6 +2862,11 @@ COMMON FLAGS
 DESCRIPTION
   list all channels owned by you or retrieve a single channel
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listChannels,
+  https://developer.smartthings.com/docs/api/public/#operation/channelById
+
 EXAMPLES
   # list all user-owned channels
   $ smartthings edge:channels
@@ -2773,6 +2906,10 @@ COMMON FLAGS
 
 DESCRIPTION
   assign a driver to a channel
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/createDriverChannel
 ```
 
 _See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/channels/assign.ts)_
@@ -2802,6 +2939,10 @@ COMMON FLAGS
 
 DESCRIPTION
   create a channel
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/createChannel
 ```
 
 _See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/channels/create.ts)_
@@ -2828,13 +2969,17 @@ COMMON FLAGS
 
 DESCRIPTION
   delete a channel
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteChannel
 ```
 
 _See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/channels/delete.ts)_
 
 ## `smartthings edge:channels:drivers [IDORINDEX]`
 
-list all drivers assigned to a given channel
+list drivers assigned to a given channel
 
 ```
 USAGE
@@ -2857,7 +3002,12 @@ COMMON FLAGS
   --language=<value>     ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 
 DESCRIPTION
-  list all drivers assigned to a given channel
+  list drivers assigned to a given channel
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getChannelDrivers,
+  https://developer.smartthings.com/docs/api/public/#operation/getDriverChannel
 ```
 
 _See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/channels/drivers.ts)_
@@ -2916,6 +3066,10 @@ COMMON FLAGS
 
 DESCRIPTION
   list all channels a given hub is enrolled in
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listDriverChannels
 ```
 
 _See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/channels/enrollments.ts)_
@@ -3112,6 +3266,10 @@ COMMON FLAGS
 
 DESCRIPTION
   remove a driver from a channel
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteDriverChannel
 ```
 
 _See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/channels/unassign.ts)_
@@ -3172,6 +3330,10 @@ COMMON FLAGS
 
 DESCRIPTION
   update a channel
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateChannel
 ```
 
 _See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/channels/update.ts)_
@@ -3207,11 +3369,14 @@ DESCRIPTION
 
   Use this command to list all drivers you own, even if they are not yet assigned to a channel.
 
-  See also:
+  See also edge:drivers:installed to list installed drivers and edge:channels:drivers to list drivers that are part of a
+  channel you own or have subscribed to
 
-  edge:drivers:installed to list installed drivers
+  For API information, see:
 
-  edge:channels:drivers to list drivers that are part of a channel you own or have subscribed to
+  https://developer.smartthings.com/docs/api/public/#operation/listDrivers,
+  https://developer.smartthings.com/docs/api/public/#operation/getDriver,
+  https://developer.smartthings.com/docs/api/public/#operation/getDriverRevision
 
 EXAMPLES
   # list all user-owned drivers
@@ -3251,6 +3416,10 @@ COMMON FLAGS
 DESCRIPTION
   list default drivers available to all users
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getDefaultDrivers
+
 EXAMPLES
   # list default drivers
 
@@ -3281,6 +3450,10 @@ COMMON FLAGS
 
 DESCRIPTION
   delete an edge driver
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteDriver
 ```
 
 _See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/drivers/delete.ts)_
@@ -3310,6 +3483,10 @@ COMMON FLAGS
 
 DESCRIPTION
   install an edge driver onto a hub
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/installDrivers
 
 EXAMPLES
   $ smartthings edge:drivers:install                                         # use Q&A format to enter required values
@@ -3350,6 +3527,11 @@ COMMON FLAGS
 
 DESCRIPTION
   list all drivers installed on a given hub
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listHubInstalledDrivers,
+  https://developer.smartthings.com/docs/api/public/#operation/getHubDeviceDriver
 
 EXAMPLES
   list all installed drivers
@@ -3436,6 +3618,10 @@ COMMON FLAGS
 DESCRIPTION
   build and upload an edge package
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/uploadDriverPackage
+
 EXAMPLES
   # build and upload driver found in current directory:
   $ smartthings edge:drivers:package
@@ -3485,6 +3671,10 @@ COMMON FLAGS
 DESCRIPTION
   change the driver used by an installed device
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateHubDevice
+
 EXAMPLES
   # switch driver, prompting user for all necessary input
   $ smartthings edge:drivers:switch
@@ -3522,6 +3712,10 @@ COMMON FLAGS
 
 DESCRIPTION
   uninstall an edge driver from a hub
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/uninstallDriver
 ```
 
 _See code: [@smartthings/plugin-cli-edge](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/drivers/uninstall.ts)_
@@ -3573,6 +3767,11 @@ COMMON FLAGS
 
 DESCRIPTION
   get a specific app or a list of apps
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listInstallations,
+  https://developer.smartthings.com/docs/api/public/#operation/getInstallation
 ```
 
 _See code: [src/commands/installedapps.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/installedapps.ts)_
@@ -3600,6 +3799,10 @@ COMMON FLAGS
 
 DESCRIPTION
   delete the installed app instance
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteInstallation
 ```
 
 _See code: [src/commands/installedapps/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/installedapps/delete.ts)_
@@ -3663,6 +3866,11 @@ COMMON FLAGS
 
 DESCRIPTION
   get a specific schema connector instance or a list of instances
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getIsaByLocationId,
+  https://developer.smartthings.com/docs/api/public/#operation/getDevicesByIsaId
 ```
 
 _See code: [src/commands/installedschema.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/installedschema.ts)_
@@ -3690,6 +3898,10 @@ COMMON FLAGS
 
 DESCRIPTION
   delete the installed schema connector instance
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteIsaByIsaId
 ```
 
 _See code: [src/commands/installedschema/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/installedschema/delete.ts)_
@@ -3716,6 +3928,11 @@ COMMON FLAGS
 
 DESCRIPTION
   list locations or get information for a specific Location
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listLocations,
+  https://developer.smartthings.com/docs/api/public/#operation/getLocation
 ```
 
 _See code: [src/commands/locations.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/locations.ts)_
@@ -3744,6 +3961,10 @@ COMMON FLAGS
 
 DESCRIPTION
   create a Location for a user
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/createLocation
 ```
 
 _See code: [src/commands/locations/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/locations/create.ts)_
@@ -3767,6 +3988,10 @@ COMMON FLAGS
 
 DESCRIPTION
   delete a location
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteLocation
 
 EXAMPLES
   $ smartthings locations:delete                 # choose the location to delete from a list
@@ -3838,6 +4063,11 @@ COMMON FLAGS
 
 DESCRIPTION
   list rooms or get information for a specific room
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listRooms,
+  https://developer.smartthings.com/docs/api/public/#operation/getRoom
 ```
 
 _See code: [src/commands/locations/rooms.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/locations/rooms.ts)_
@@ -3867,6 +4097,10 @@ COMMON FLAGS
 
 DESCRIPTION
   create a room
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/createRoom
 ```
 
 _See code: [src/commands/locations/rooms/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/locations/rooms/create.ts)_
@@ -3893,6 +4127,10 @@ COMMON FLAGS
 
 DESCRIPTION
   delete a room
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteRoom
 ```
 
 _See code: [src/commands/locations/rooms/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/locations/rooms/delete.ts)_
@@ -3925,6 +4163,10 @@ COMMON FLAGS
 
 DESCRIPTION
   update a room
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateRoom
 ```
 
 _See code: [src/commands/locations/rooms/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/locations/rooms/update.ts)_
@@ -3956,6 +4198,10 @@ COMMON FLAGS
 
 DESCRIPTION
   update a location
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateLocation
 ```
 
 _See code: [src/commands/locations/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/locations/update.ts)_
@@ -4293,6 +4539,10 @@ COMMON FLAGS
 DESCRIPTION
   query device presentation by vid
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getDevicePresentation
+
 EXAMPLES
   $ smartthings presentation fd4adb7f-4a23-4134-9b39-05ed889a03cf
 
@@ -4339,6 +4589,10 @@ COMMON FLAGS
 
 DESCRIPTION
   query device config by presentationId
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getDeviceConfiguration
 ```
 
 _See code: [src/commands/presentation/device-config.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/presentation/device-config.ts)_
@@ -4367,6 +4621,10 @@ COMMON FLAGS
 
 DESCRIPTION
   create a device config
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/createDeviceConfiguration
 ```
 
 _See code: [src/commands/presentation/device-config/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/presentation/device-config/create.ts)_
@@ -4399,6 +4657,10 @@ COMMON FLAGS
 
 DESCRIPTION
   generate the default device configuration
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/generateDeviceConfig
 ```
 
 _See code: [src/commands/presentation/device-config/generate.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/presentation/device-config/generate.ts)_
@@ -4429,6 +4691,11 @@ COMMON FLAGS
 
 DESCRIPTION
   get a specific rule
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listRules,
+  https://developer.smartthings.com/docs/api/public/#operation/getRule
 ```
 
 _See code: [src/commands/rules.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/rules.ts)_
@@ -4444,7 +4711,7 @@ USAGE
 
 FLAGS
   -d, --dry-run          produce JSON but don't actually submit
-  -l, --location=<UUID>  a specific location to query
+  -l, --location=<UUID>  the location for the rule
 
 COMMON FLAGS
   -h, --help             Show CLI help.
@@ -4458,6 +4725,10 @@ COMMON FLAGS
 
 DESCRIPTION
   create a rule
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/createRule
 ```
 
 _See code: [src/commands/rules/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/rules/create.ts)_
@@ -4484,6 +4755,10 @@ COMMON FLAGS
 
 DESCRIPTION
   delete a rule
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteRule
 ```
 
 _See code: [src/commands/rules/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/rules/delete.ts)_
@@ -4514,6 +4789,10 @@ COMMON FLAGS
 
 DESCRIPTION
   execute a rule
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/executeRule
 
 EXAMPLES
   # prompt for a rule to execute and then execute it
@@ -4557,6 +4836,10 @@ COMMON FLAGS
 
 DESCRIPTION
   update a rule
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateRule
 ```
 
 _See code: [src/commands/rules/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/rules/update.ts)_
@@ -4587,6 +4870,10 @@ COMMON FLAGS
 
 DESCRIPTION
   list scenes or get information for a specific scene
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listScenes
 ```
 
 _See code: [src/commands/scenes.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/scenes.ts)_
@@ -4613,6 +4900,10 @@ COMMON FLAGS
 
 DESCRIPTION
   execute a scene
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/executeScene
 
 EXAMPLES
   # prompt for a scene to execute and then execute it
@@ -4653,6 +4944,11 @@ COMMON FLAGS
 
 DESCRIPTION
   list all ST Schema Apps currently available in a user account
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getAppsByUserToken,
+  https://developer.smartthings.com/docs/api/public/#operation/getAppsByEndpointAppId
 ```
 
 _See code: [src/commands/schema.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/schema.ts)_
@@ -4728,6 +5024,10 @@ COMMON FLAGS
 
 DESCRIPTION
   create an ST Schema connector
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/postApps
 ```
 
 _See code: [src/commands/schema/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/schema/create.ts)_
@@ -4751,13 +5051,17 @@ COMMON FLAGS
 
 DESCRIPTION
   delete the ST Schema connector
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteAppsByEndpointAppId
 ```
 
 _See code: [src/commands/schema/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/schema/delete.ts)_
 
 ## `smartthings schema:regenerate [ID]`
 
-Regenerate the clientId and clientSecret of the ST Schema connector. The previous values will be invalidated, which may affect existing installations.
+regenerate the clientId and clientSecret of the ST Schema connector
 
 ```
 USAGE
@@ -4776,8 +5080,13 @@ COMMON FLAGS
   --language=<value>     ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 
 DESCRIPTION
-  Regenerate the clientId and clientSecret of the ST Schema connector. The previous values will be invalidated, which
-  may affect existing installations.
+  regenerate the clientId and clientSecret of the ST Schema connector
+
+  NOTE: The previous values will be invalidated, which may affect existing installations.
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/generateStOauthCredentials
 ```
 
 _See code: [src/commands/schema/regenerate.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/schema/regenerate.ts)_
@@ -4810,6 +5119,10 @@ COMMON FLAGS
 
 DESCRIPTION
   update an ST Schema connector
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/putAppsByEndpointAppId
 ```
 
 _See code: [src/commands/schema/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.0.1/packages/cli/src/commands/schema/update.ts)_

--- a/packages/cli/src/commands/capabilities.ts
+++ b/packages/cli/src/commands/capabilities.ts
@@ -23,7 +23,8 @@ import {
 
 
 export default class CapabilitiesCommand extends APIOrganizationCommand<typeof CapabilitiesCommand.flags> {
-	static description = 'get a specific capability'
+	static description = 'get a specific capability or a list of capabilities' +
+		this.apiDocsURL('listNamespacedCapabilities', 'listCapabilities', 'getCapability')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/capabilities/create.ts
+++ b/packages/cli/src/commands/capabilities/create.ts
@@ -35,7 +35,8 @@ function unitOfMeasureValidator(input: string): boolean | string {
 }
 
 export default class CapabilitiesCreateCommand extends APIOrganizationCommand<typeof CapabilitiesCreateCommand.flags> {
-	static description = 'create a capability for a user'
+	static description = 'create a capability for a user' +
+		this.apiDocsURL('createCapability')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/capabilities/delete.ts
+++ b/packages/cli/src/commands/capabilities/delete.ts
@@ -4,7 +4,8 @@ import { capabilityIdInputArgs, chooseCapability } from '../../lib/commands/capa
 
 
 export default class CapabilitiesDeleteCommand extends APIOrganizationCommand<typeof CapabilitiesDeleteCommand.flags> {
-	static description = 'delete a capability'
+	static description = 'delete a capability' +
+		this.apiDocsURL('deleteCapability')
 
 	static flags = APIOrganizationCommand.flags
 

--- a/packages/cli/src/commands/capabilities/presentation.ts
+++ b/packages/cli/src/commands/capabilities/presentation.ts
@@ -67,7 +67,8 @@ export function buildTableOutput(tableGenerator: TableGenerator, presentation: C
 }
 
 export default class PresentationsCommand extends APIOrganizationCommand<typeof PresentationsCommand.flags> {
-	static description = 'get presentation information for a specific capability'
+	static description = 'get presentation information for a specific capability' +
+		this.apiDocsURL('getCapabilityPresentation')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/capabilities/presentation/create.ts
+++ b/packages/cli/src/commands/capabilities/presentation/create.ts
@@ -7,7 +7,8 @@ import { capabilityIdInputArgs, chooseCapability } from '../../../lib/commands/c
 
 
 export default class CapabilitiesPresentationCreate extends APIOrganizationCommand<typeof CapabilitiesPresentationCreate.flags> {
-	static description = 'create presentation model for a capability'
+	static description = 'create presentation model for a capability' +
+		this.apiDocsURL('createCustomCapabilityPresentation')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/capabilities/presentation/update.ts
+++ b/packages/cli/src/commands/capabilities/presentation/update.ts
@@ -7,7 +7,8 @@ import { capabilityIdInputArgs, chooseCapability } from '../../../lib/commands/c
 
 
 export default class CapabilitiesPresentationUpdate extends APIOrganizationCommand<typeof CapabilitiesPresentationUpdate.flags> {
-	static description = 'update presentation information of a capability'
+	static description = 'update presentation information of a capability' +
+		this.apiDocsURL('updateCustomCapabilityPresentation')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/capabilities/translations.ts
+++ b/packages/cli/src/commands/capabilities/translations.ts
@@ -45,8 +45,8 @@ export function buildTableOutput(tableGenerator: TableGenerator, data: Capabilit
 export type CapabilitySummaryWithLocales = CapabilitySummaryWithNamespace & WithLocales
 
 export default class CapabilityTranslationsCommand extends APIOrganizationCommand<typeof CapabilityTranslationsCommand.flags> {
-
-	static description = 'get list of locales supported by the capability'
+	static description = 'get list of locales supported by the capability' +
+		this.apiDocsURL('listCapabilityLocalizations', 'getCapabilityLocalization')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/capabilities/translations/create.ts
+++ b/packages/cli/src/commands/capabilities/translations/create.ts
@@ -7,7 +7,8 @@ import { capabilityIdInputArgs, chooseCapability } from '../../../lib/commands/c
 
 
 export default class CapabilityTranslationsCreateCommand extends APIOrganizationCommand<typeof CapabilityTranslationsCreateCommand.flags> {
-	static description = 'create a capability translation'
+	static description = 'create a capability translation' +
+		this.apiDocsURL('createCapabilityLocalization')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/capabilities/translations/update.ts
+++ b/packages/cli/src/commands/capabilities/translations/update.ts
@@ -7,7 +7,8 @@ import { capabilityIdInputArgs, chooseCapability } from '../../../lib/commands/c
 
 
 export default class CapabilityTranslationsUpdateCommand extends APIOrganizationCommand<typeof CapabilityTranslationsUpdateCommand.flags> {
-	static description = 'update a capability translation'
+	static description = 'update a capability translation' +
+		this.apiDocsURL('updateCapabilityLocalization')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/capabilities/translations/upsert.ts
+++ b/packages/cli/src/commands/capabilities/translations/upsert.ts
@@ -7,7 +7,8 @@ import { capabilityIdInputArgs, chooseCapability } from '../../../lib/commands/c
 
 
 export default class CapabilityTranslationsUpsertCommand extends APIOrganizationCommand<typeof CapabilityTranslationsUpsertCommand.flags> {
-	static description = 'create or update a capability translation'
+	static description = 'create or update a capability translation' +
+		this.apiDocsURL('updateCapabilityLocalization', 'createCapabilityLocalization')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/capabilities/update.ts
+++ b/packages/cli/src/commands/capabilities/update.ts
@@ -6,7 +6,8 @@ import { buildTableOutput, capabilityIdInputArgs, chooseCapability } from '../..
 
 
 export default class CapabilitiesUpdate extends APIOrganizationCommand<typeof CapabilitiesUpdate.flags> {
-	static description = 'update a capability'
+	static description = 'update a capability' +
+		this.apiDocsURL('updateCapability')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/devicepreferences.ts
+++ b/packages/cli/src/commands/devicepreferences.ts
@@ -37,7 +37,8 @@ export async function preferencesForAllOrganizations(command: APIOrganizationCom
 }
 
 export default class DevicePreferencesCommand extends APIOrganizationCommand<typeof DevicePreferencesCommand.flags> {
-	static description = 'list device preferences or get information for a specific device preference'
+	static description = 'list device preferences or get information for a specific device preference' +
+		this.apiDocsURL('listPreferences', 'getPreferenceById')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/devicepreferences/create.ts
+++ b/packages/cli/src/commands/devicepreferences/create.ts
@@ -6,7 +6,8 @@ import { tableFieldDefinitions } from '../../lib/commands/devicepreferences-util
 
 
 export default class DevicePreferencesCreateCommand extends APIOrganizationCommand<typeof DevicePreferencesCreateCommand.flags> {
-	static description = 'create a device preference'
+	static description = 'create a device preference' +
+		this.apiDocsURL('createPreference')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/devicepreferences/update.ts
+++ b/packages/cli/src/commands/devicepreferences/update.ts
@@ -4,7 +4,8 @@ import { chooseDevicePreference, tableFieldDefinitions } from '../../lib/command
 
 
 export default class DevicePreferencesUpdateCommand extends APIOrganizationCommand<typeof DevicePreferencesUpdateCommand.flags> {
-	static description = 'update a device preference'
+	static description = 'update a device preference' +
+		this.apiDocsURL('updatePreferenceById')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/deviceprofiles.ts
+++ b/packages/cli/src/commands/deviceprofiles.ts
@@ -15,7 +15,8 @@ import { buildTableOutput } from '../lib/commands/deviceprofiles-util'
 
 
 export default class DeviceProfilesCommand extends APIOrganizationCommand<typeof DeviceProfilesCommand.flags> {
-	static description = 'list all device profiles available in a user account or retrieve a single profile'
+	static description = 'list all device profiles available in a user account or retrieve a single profile' +
+		this.apiDocsURL('listDeviceProfiles', 'getDeviceProfile')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/deviceprofiles/create.ts
+++ b/packages/cli/src/commands/deviceprofiles/create.ts
@@ -8,9 +8,10 @@ import { createWithDefaultConfig, getInputFromUser } from '../../lib/commands/de
 
 export default class DeviceProfileCreateCommand extends APIOrganizationCommand<typeof DeviceProfileCreateCommand.flags> {
 	static description = 'create a new device profile\n' +
-		'Creates a new device profile. If a vid field is not present in the meta\n' +
-		'then a default device presentation will be created for this profile and the\n' +
-		'vid set to reference it.'
+		'Creates a new device profile. If a vid field is not present in the meta ' +
+		'then a default device presentation will be created for this profile and the ' +
+		'vid set to reference it.' +
+		this.apiDocsURL('createDeviceProfile')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/deviceprofiles/delete.ts
+++ b/packages/cli/src/commands/deviceprofiles/delete.ts
@@ -4,7 +4,8 @@ import { chooseDeviceProfile } from '../../lib/commands/deviceprofiles-util'
 
 
 export default class DeviceProfileDeleteCommand extends APIOrganizationCommand<typeof DeviceProfileDeleteCommand.flags> {
-	static description = 'delete a device profile'
+	static description = 'delete a device profile' +
+		this.apiDocsURL('deleteDeviceProfile')
 
 	static flags = APIOrganizationCommand.flags
 

--- a/packages/cli/src/commands/deviceprofiles/device-config.ts
+++ b/packages/cli/src/commands/deviceprofiles/device-config.ts
@@ -7,7 +7,8 @@ import { chooseDeviceProfile } from '../../lib/commands/deviceprofiles-util'
 
 
 export default class DeviceProfileDeviceConfigCommand extends APIOrganizationCommand<typeof DeviceProfileDeviceConfigCommand.flags> {
-	static description = 'get the device configuration associated with a device profile'
+	static description = 'get the device configuration associated with a device profile' +
+		this.apiDocsURL('getDeviceProfile', 'getDeviceConfiguration')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/deviceprofiles/presentation.ts
+++ b/packages/cli/src/commands/deviceprofiles/presentation.ts
@@ -7,7 +7,8 @@ import { chooseDeviceProfile } from '../../lib/commands/deviceprofiles-util'
 
 
 export default class DeviceProfilePresentationCommand extends APIOrganizationCommand<typeof DeviceProfilePresentationCommand.flags> {
-	static description = 'get the presentation associated with a device profile'
+	static description = 'get the presentation associated with a device profile' +
+		this.apiDocsURL('getDeviceProfile', 'getDevicePresentation')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/deviceprofiles/update.ts
+++ b/packages/cli/src/commands/deviceprofiles/update.ts
@@ -13,7 +13,8 @@ import {
 
 
 export default class DeviceProfileUpdateCommand extends APIOrganizationCommand<typeof DeviceProfileUpdateCommand.flags> {
-	static description = 'update a device profile'
+	static description = 'update a device profile' +
+		this.apiDocsURL('updateDeviceProfile')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/deviceprofiles/view.ts
+++ b/packages/cli/src/commands/deviceprofiles/view.ts
@@ -7,7 +7,8 @@ import { prunePresentation } from '../../lib/commands/deviceprofiles/view-util'
 
 
 export default class DeviceProfilesViewCommand extends APIOrganizationCommand<typeof DeviceProfilesViewCommand.flags> {
-	static description = 'show device profile and device configuration in a single, consolidated view'
+	static description = 'show device profile and device configuration in a single, consolidated view' +
+		this.apiDocsURL('getDeviceProfile, getDeviceConfiguration')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/deviceprofiles/view/create.ts
+++ b/packages/cli/src/commands/deviceprofiles/view/create.ts
@@ -10,9 +10,10 @@ import {
 
 export default class DeviceDefCreateCommand extends APIOrganizationCommand<typeof DeviceDefCreateCommand.flags> {
 	static description = 'create a new device profile and device configuration\n' +
-		'Creates a new device profile and device configuration. Unlike deviceprofiles:create,\n' +
-		'this command accepts a consolidated object that can include a device configuration\n' +
-		'in a property named "view".'
+		'Creates a new device profile and device configuration. Unlike deviceprofiles:create, ' +
+		'this command accepts a consolidated object that can include a device configuration ' +
+		'in a property named "view".' +
+		this.apiDocsURL('createDeviceProfile', 'createDeviceConfiguration', 'updateDeviceProfile', 'generateDeviceConfig')
 
 	static flags = {
 		...APIOrganizationCommand.flags,

--- a/packages/cli/src/commands/deviceprofiles/view/update.ts
+++ b/packages/cli/src/commands/deviceprofiles/view/update.ts
@@ -11,10 +11,11 @@ import { chooseDeviceProfile, cleanupForUpdate } from '../../../lib/commands/dev
 
 export default class DeviceProfilesViewUpdateCommand extends APIOrganizationCommand<typeof DeviceProfilesViewUpdateCommand.flags> {
 	static description = 'update a device profile and configuration\n' +
-		'Updates a device profile and device configuration and sets the vid of the profile\n' +
-		'to the vid of the updated configuration. Unlike deviceprofiles:update this\n' +
-		'command accepts a consolidated object that can include a device configuration\n' +
-		'in a property named "view".'
+		'Updates a device profile and device configuration and sets the vid of the profile ' +
+		'to the vid of the updated configuration. Unlike deviceprofiles:update this ' +
+		'command accepts a consolidated object that can include a device configuration ' +
+		'in a property named "view".' +
+		this.apiDocsURL('createDeviceConfiguration', 'updateDeviceProfile', 'generateDeviceConfig')
 
 	static examples = [
 		'$ smartthings deviceprofiles:view:update 84042863-0d34-4c5c-b497-808daf230787 -i test.json',

--- a/packages/cli/src/commands/devices.ts
+++ b/packages/cli/src/commands/devices.ts
@@ -16,7 +16,8 @@ import { buildTableOutput } from '../lib/commands/devices-util'
 
 
 export default class DevicesCommand extends APICommand<typeof DevicesCommand.flags> {
-	static description = 'list all devices available in a user account or retrieve a single device'
+	static description = 'list all devices available in a user account or retrieve a single device' +
+		this.apiDocsURL('getDevices', 'getDevice')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/devices/capability-status.ts
+++ b/packages/cli/src/commands/devices/capability-status.ts
@@ -20,7 +20,8 @@ function buildTableOutput(tableGenerator: TableGenerator, capability: Capability
 }
 
 export default class DeviceCapabilityStatusCommand extends APICommand<typeof DeviceCapabilityStatusCommand.flags> {
-	static description = "get the current status of all of a device capability's attributes"
+	static description = "get the current status of all of a device capability's attributes" +
+		this.apiDocsURL('getDeviceStatusByCapability')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/devices/commands.ts
+++ b/packages/cli/src/commands/devices/commands.ts
@@ -64,7 +64,8 @@ function parseDeviceCommand(str: string, componentId?: string, capabilityId?: st
 }
 
 export default class DeviceCommandsCommand extends APICommand<typeof DeviceCommandsCommand.flags> {
-	static description = 'execute a device command'
+	static description = 'execute a device command' +
+		this.apiDocsURL('executeDeviceCommands')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/devices/component-status.ts
+++ b/packages/cli/src/commands/devices/component-status.ts
@@ -22,7 +22,8 @@ function buildTableOutput(tableGenerator: TableGenerator, component: ComponentSt
 }
 
 export default class DeviceComponentStatusCommand extends APICommand<typeof DeviceComponentStatusCommand.flags> {
-	static description = "get the current status of a device component's attributes"
+	static description = "get the current status of a device component's attributes" +
+		this.apiDocsURL('getDeviceComponentStatus')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/devices/delete.ts
+++ b/packages/cli/src/commands/devices/delete.ts
@@ -2,7 +2,8 @@ import { APICommand, chooseDevice } from '@smartthings/cli-lib'
 
 
 export default class DeviceDeleteCommand extends APICommand<typeof DeviceDeleteCommand.flags> {
-	static description = 'delete a device'
+	static description = 'delete a device' +
+		this.apiDocsURL('deleteDevice')
 
 	static flags = APICommand.flags
 

--- a/packages/cli/src/commands/devices/rename.ts
+++ b/packages/cli/src/commands/devices/rename.ts
@@ -6,7 +6,8 @@ import { buildTableOutput } from '../../lib/commands/devices-util'
 
 
 export default class DeviceRenameCommand extends APICommand<typeof DeviceRenameCommand.flags> {
-	static description = 'rename a device'
+	static description = 'rename a device' +
+		this.apiDocsURL('updateDevice')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/devices/status.ts
+++ b/packages/cli/src/commands/devices/status.ts
@@ -4,7 +4,8 @@ import { buildStatusTableOutput } from '../../lib/commands/devices-util'
 
 
 export default class DeviceStatusCommand extends APICommand<typeof DeviceStatusCommand.flags> {
-	static description = "get the current status of all of a device's component's attributes"
+	static description = "get the current status of all of a device's component's attributes" +
+		this.apiDocsURL('getDeviceStatus')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/devices/update.ts
+++ b/packages/cli/src/commands/devices/update.ts
@@ -6,7 +6,8 @@ import { buildTableOutput } from '../../lib/commands/devices-util'
 
 
 export default class DeviceUpdateCommand extends APICommand<typeof DeviceUpdateCommand.flags> {
-	static description = "update a device's label and room"
+	static description = "update a device's label and room" +
+		this.apiDocsURL('updateDevice')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/installedapps.ts
+++ b/packages/cli/src/commands/installedapps.ts
@@ -7,7 +7,8 @@ import { listTableFieldDefinitions, tableFieldDefinitions } from '../lib/command
 
 
 export default class InstalledAppsCommand extends APICommand<typeof InstalledAppsCommand.flags> {
-	static description = 'get a specific app or a list of apps'
+	static description = 'get a specific app or a list of apps' +
+		this.apiDocsURL('listInstallations', 'getInstallation')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/installedapps/delete.ts
+++ b/packages/cli/src/commands/installedapps/delete.ts
@@ -6,7 +6,8 @@ import { selectFromList, APICommand, withLocations, SelectFromListConfig, WithNa
 
 
 export default class InstalledAppDeleteCommand extends APICommand<typeof InstalledAppDeleteCommand.flags> {
-	static description = 'delete the installed app instance'
+	static description = 'delete the installed app instance' +
+		this.apiDocsURL('deleteInstallation')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/installedschema.ts
+++ b/packages/cli/src/commands/installedschema.ts
@@ -12,7 +12,8 @@ import {
 
 
 export default class InstalledSchemaAppsCommand extends APICommand<typeof InstalledSchemaAppsCommand.flags> {
-	static description = 'get a specific schema connector instance or a list of instances'
+	static description = 'get a specific schema connector instance or a list of instances' +
+		this.apiDocsURL('getIsaByLocationId', 'getDevicesByIsaId')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/installedschema/delete.ts
+++ b/packages/cli/src/commands/installedschema/delete.ts
@@ -8,7 +8,8 @@ import { installedSchemaInstances } from '../../lib/commands/installedschema-uti
 
 
 export default class InstalledSchemaAppDeleteCommand extends APICommand<typeof InstalledSchemaAppDeleteCommand.flags> {
-	static description = 'delete the installed schema connector instance'
+	static description = 'delete the installed schema connector instance' +
+		this.apiDocsURL('deleteIsaByIsaId')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/locations.ts
+++ b/packages/cli/src/commands/locations.ts
@@ -33,7 +33,8 @@ export async function chooseLocation(
 }
 
 export default class LocationsCommand extends APICommand<typeof LocationsCommand.flags> {
-	static description = 'list locations or get information for a specific Location'
+	static description = 'list locations or get information for a specific Location' +
+		this.apiDocsURL('listLocations', 'getLocation')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/locations/create.ts
+++ b/packages/cli/src/commands/locations/create.ts
@@ -6,7 +6,8 @@ import { tableFieldDefinitions } from '../locations'
 
 
 export default class LocationsCreateCommand extends APICommand<typeof LocationsCreateCommand.flags> {
-	static description = 'create a Location for a user'
+	static description = 'create a Location for a user' +
+		this.apiDocsURL('createLocation')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/locations/delete.ts
+++ b/packages/cli/src/commands/locations/delete.ts
@@ -4,7 +4,8 @@ import { chooseLocation } from '../locations'
 
 
 export default class LocationsDeleteCommand extends APICommand<typeof LocationsDeleteCommand.flags> {
-	static description = 'delete a location'
+	static description = 'delete a location' +
+		this.apiDocsURL('deleteLocation')
 
 	static flags = APICommand.flags
 

--- a/packages/cli/src/commands/locations/rooms.ts
+++ b/packages/cli/src/commands/locations/rooms.ts
@@ -8,7 +8,8 @@ import { getRoomsByLocation, tableFieldDefinitions, tableFieldDefinitionsWithLoc
 
 
 export default class RoomsCommand extends APICommand<typeof RoomsCommand.flags> {
-	static description = 'list rooms or get information for a specific room'
+	static description = 'list rooms or get information for a specific room' +
+		this.apiDocsURL('listRooms', 'getRoom')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/locations/rooms/create.ts
+++ b/packages/cli/src/commands/locations/rooms/create.ts
@@ -6,7 +6,8 @@ import { tableFieldDefinitions } from '../../../lib/commands/locations/rooms-uti
 
 
 export default class RoomsCreateCommand extends APICommand<typeof RoomsCreateCommand.flags> {
-	static description = 'create a room'
+	static description = 'create a room' +
+		this.apiDocsURL('createRoom')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/locations/rooms/delete.ts
+++ b/packages/cli/src/commands/locations/rooms/delete.ts
@@ -4,7 +4,8 @@ import { chooseRoom } from '../../../lib/commands/locations/rooms-util'
 
 
 export default class RoomsDeleteCommand extends APICommand<typeof RoomsDeleteCommand.flags> {
-	static description = 'delete a room'
+	static description = 'delete a room' +
+		this.apiDocsURL('deleteRoom')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/locations/rooms/update.ts
+++ b/packages/cli/src/commands/locations/rooms/update.ts
@@ -5,7 +5,8 @@ import { chooseRoom, tableFieldDefinitions } from '../../../lib/commands/locatio
 
 
 export default class RoomsUpdateCommand extends APICommand<typeof RoomsUpdateCommand.flags> {
-	static description = 'update a room'
+	static description = 'update a room' +
+		this.apiDocsURL('updateRoom')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/locations/update.ts
+++ b/packages/cli/src/commands/locations/update.ts
@@ -6,7 +6,8 @@ import { chooseLocation, tableFieldDefinitions } from '../locations'
 
 
 export default class LocationsUpdateCommand extends APICommand<typeof LocationsUpdateCommand.flags> {
-	static description = 'update a location'
+	static description = 'update a location' +
+		this.apiDocsURL('updateLocation')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/presentation.ts
+++ b/packages/cli/src/commands/presentation.ts
@@ -83,7 +83,8 @@ export function buildTableOutput(tableGenerator: TableGenerator, presentation: P
 }
 
 export default class PresentationCommand extends APICommand<typeof PresentationCommand.flags> {
-	static description = 'query device presentation by vid'
+	static description = 'query device presentation by vid' +
+		this.apiDocsURL('getDevicePresentation')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/presentation/device-config.ts
+++ b/packages/cli/src/commands/presentation/device-config.ts
@@ -75,7 +75,8 @@ export function buildTableOutput(tableGenerator: TableGenerator, deviceConfig: P
 }
 
 export default class DeviceConfigPresentationCommand extends APICommand<typeof DeviceConfigPresentationCommand.flags> {
-	static description = 'query device config by presentationId'
+	static description = 'query device config by presentationId' +
+		this.apiDocsURL('getDeviceConfiguration')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/presentation/device-config/create.ts
+++ b/packages/cli/src/commands/presentation/device-config/create.ts
@@ -6,7 +6,8 @@ import { buildTableOutput } from '../device-config'
 
 
 export default class DeviceConfigCreateCommand extends APICommand<typeof DeviceConfigCreateCommand.flags> {
-	static description = 'create a device config'
+	static description = 'create a device config' +
+		this.apiDocsURL('createDeviceConfiguration')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/presentation/device-config/generate.ts
+++ b/packages/cli/src/commands/presentation/device-config/generate.ts
@@ -8,7 +8,8 @@ import { buildTableOutput } from '../device-config'
 
 
 export default class GeneratePresentationCommand extends APICommand<typeof GeneratePresentationCommand.flags> {
-	static description = 'generate the default device configuration'
+	static description = 'generate the default device configuration' +
+		this.apiDocsURL('generateDeviceConfig')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/rules.ts
+++ b/packages/cli/src/commands/rules.ts
@@ -8,7 +8,8 @@ import { getRulesByLocation, getRuleWithLocation, tableFieldDefinitions } from '
 
 
 export default class RulesCommand extends APICommand<typeof RulesCommand.flags> {
-	static description = 'get a specific rule'
+	static description = 'get a specific rule' +
+		this.apiDocsURL('listRules', 'getRule')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/rules/create.ts
+++ b/packages/cli/src/commands/rules/create.ts
@@ -9,14 +9,15 @@ import { tableFieldDefinitions } from '../../lib/commands/rules-util'
 
 
 export default class RulesCreateCommand extends APICommand<typeof RulesCreateCommand.flags> {
-	static description = 'create a rule'
+	static description = 'create a rule' +
+		this.apiDocsURL('createRule')
 
 	static flags = {
 		...APICommand.flags,
 		...inputAndOutputItem.flags,
 		location: Flags.string({
 			char: 'l',
-			description: 'a specific location to query',
+			description: 'the location for the rule',
 			helpValue: '<UUID>',
 		}),
 	}

--- a/packages/cli/src/commands/rules/delete.ts
+++ b/packages/cli/src/commands/rules/delete.ts
@@ -6,7 +6,8 @@ import { chooseRule, getRuleWithLocation } from '../../lib/commands/rules-util'
 
 
 export default class RulesDeleteCommand extends APICommand<typeof RulesDeleteCommand.flags> {
-	static description = 'delete a rule'
+	static description = 'delete a rule' +
+		this.apiDocsURL('deleteRule')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/rules/execute.ts
+++ b/packages/cli/src/commands/rules/execute.ts
@@ -8,7 +8,8 @@ import { buildExecuteResponseTableOutput, chooseRule, getRuleWithLocation } from
 
 
 export default class RulesExecuteCommand extends APICommand<typeof RulesExecuteCommand.flags> {
-	static description = 'execute a rule'
+	static description = 'execute a rule' +
+		this.apiDocsURL('executeRule')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/rules/update.ts
+++ b/packages/cli/src/commands/rules/update.ts
@@ -8,7 +8,8 @@ import { chooseRule, getRuleWithLocation, tableFieldDefinitions } from '../../li
 
 
 export default class RulesUpdateCommand extends APICommand<typeof RulesUpdateCommand.flags> {
-	static description = 'update a rule'
+	static description = 'update a rule' +
+		this.apiDocsURL('updateRule')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/scenes.ts
+++ b/packages/cli/src/commands/scenes.ts
@@ -8,7 +8,8 @@ import { tableFieldDefinitions } from '../lib/commands/scenes-util'
 
 
 export default class ScenesCommand extends APICommand<typeof ScenesCommand.flags> {
-	static description = 'list scenes or get information for a specific scene'
+	static description = 'list scenes or get information for a specific scene' +
+		this.apiDocsURL('listScenes')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/scenes/execute.ts
+++ b/packages/cli/src/commands/scenes/execute.ts
@@ -4,7 +4,8 @@ import { chooseScene } from '../../lib/commands/scenes-util'
 
 
 export default class ScenesExecuteCommand extends APICommand<typeof ScenesExecuteCommand.flags> {
-	static description = 'execute a scene'
+	static description = 'execute a scene' +
+		this.apiDocsURL('executeScene')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -6,7 +6,8 @@ import { APICommand, outputItemOrList, OutputItemOrListConfig } from '@smartthin
 
 
 export default class SchemaCommand extends APICommand<typeof SchemaCommand.flags> {
-	static description = 'list all ST Schema Apps currently available in a user account'
+	static description = 'list all ST Schema Apps currently available in a user account' +
+		this.apiDocsURL('getAppsByUserToken', 'getAppsByEndpointAppId')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/schema/create.ts
+++ b/packages/cli/src/commands/schema/create.ts
@@ -9,7 +9,8 @@ import { SCHEMA_AWS_PRINCIPAL } from '../../lib/commands/schema-util'
 
 
 export default class SchemaAppCreateCommand extends APICommand<typeof SchemaAppCreateCommand.flags> {
-	static description = 'create an ST Schema connector'
+	static description = 'create an ST Schema connector' +
+		this.apiDocsURL('postApps')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/schema/delete.ts
+++ b/packages/cli/src/commands/schema/delete.ts
@@ -4,7 +4,8 @@ import { APICommand, selectFromList, SelectFromListConfig } from '@smartthings/c
 
 
 export default class SchemaAppDeleteCommand extends APICommand<typeof SchemaAppDeleteCommand.flags> {
-	static description = 'delete the ST Schema connector'
+	static description = 'delete the ST Schema connector' +
+		this.apiDocsURL('deleteAppsByEndpointAppId')
 
 	static flags = APICommand.flags
 

--- a/packages/cli/src/commands/schema/regenerate.ts
+++ b/packages/cli/src/commands/schema/regenerate.ts
@@ -3,7 +3,9 @@ import { SchemaApp } from '@smartthings/core-sdk'
 
 
 export default class SchemaAppRegenerateCommand extends APICommand<typeof SchemaAppRegenerateCommand.flags> {
-	static description = 'Regenerate the clientId and clientSecret of the ST Schema connector. The previous values will be invalidated, which may affect existing installations.'
+	static description = 'regenerate the clientId and clientSecret of the ST Schema connector\n' +
+		'NOTE: The previous values will be invalidated, which may affect existing installations.' +
+		this.apiDocsURL('generateStOauthCredentials')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/cli/src/commands/schema/update.ts
+++ b/packages/cli/src/commands/schema/update.ts
@@ -8,7 +8,8 @@ import { addSchemaPermission } from '../../lib/aws-utils'
 
 
 export default class SchemaUpdateCommand extends APICommand<typeof SchemaUpdateCommand.flags> {
-	static description = 'update an ST Schema connector'
+	static description = 'update an ST Schema connector' +
+		this.apiDocsURL('putAppsByEndpointAppId')
 
 	static flags = {
 		...APICommand.flags,

--- a/packages/edge/README.md
+++ b/packages/edge/README.md
@@ -95,6 +95,11 @@ COMMON FLAGS
 DESCRIPTION
   list all channels owned by you or retrieve a single channel
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listChannels,
+  https://developer.smartthings.com/docs/api/public/#operation/channelById
+
 EXAMPLES
   # list all user-owned channels
   $ smartthings edge:channels
@@ -134,6 +139,10 @@ COMMON FLAGS
 
 DESCRIPTION
   assign a driver to a channel
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/createDriverChannel
 ```
 
 _See code: [src/commands/edge/channels/assign.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/channels/assign.ts)_
@@ -163,6 +172,10 @@ COMMON FLAGS
 
 DESCRIPTION
   create a channel
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/createChannel
 ```
 
 _See code: [src/commands/edge/channels/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/channels/create.ts)_
@@ -189,13 +202,17 @@ COMMON FLAGS
 
 DESCRIPTION
   delete a channel
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteChannel
 ```
 
 _See code: [src/commands/edge/channels/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/channels/delete.ts)_
 
 ## `smartthings edge:channels:drivers [IDORINDEX]`
 
-list all drivers assigned to a given channel
+list drivers assigned to a given channel
 
 ```
 USAGE
@@ -218,7 +235,12 @@ COMMON FLAGS
   --language=<value>     ISO language code or "NONE" to not specify a language. Defaults to the OS locale
 
 DESCRIPTION
-  list all drivers assigned to a given channel
+  list drivers assigned to a given channel
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getChannelDrivers,
+  https://developer.smartthings.com/docs/api/public/#operation/getDriverChannel
 ```
 
 _See code: [src/commands/edge/channels/drivers.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/channels/drivers.ts)_
@@ -277,6 +299,10 @@ COMMON FLAGS
 
 DESCRIPTION
   list all channels a given hub is enrolled in
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listDriverChannels
 ```
 
 _See code: [src/commands/edge/channels/enrollments.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/channels/enrollments.ts)_
@@ -473,6 +499,10 @@ COMMON FLAGS
 
 DESCRIPTION
   remove a driver from a channel
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteDriverChannel
 ```
 
 _See code: [src/commands/edge/channels/unassign.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/channels/unassign.ts)_
@@ -533,6 +563,10 @@ COMMON FLAGS
 
 DESCRIPTION
   update a channel
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateChannel
 ```
 
 _See code: [src/commands/edge/channels/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/channels/update.ts)_
@@ -568,11 +602,14 @@ DESCRIPTION
 
   Use this command to list all drivers you own, even if they are not yet assigned to a channel.
 
-  See also:
+  See also edge:drivers:installed to list installed drivers and edge:channels:drivers to list drivers that are part of a
+  channel you own or have subscribed to
 
-  edge:drivers:installed to list installed drivers
+  For API information, see:
 
-  edge:channels:drivers to list drivers that are part of a channel you own or have subscribed to
+  https://developer.smartthings.com/docs/api/public/#operation/listDrivers,
+  https://developer.smartthings.com/docs/api/public/#operation/getDriver,
+  https://developer.smartthings.com/docs/api/public/#operation/getDriverRevision
 
 EXAMPLES
   # list all user-owned drivers
@@ -612,6 +649,10 @@ COMMON FLAGS
 DESCRIPTION
   list default drivers available to all users
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/getDefaultDrivers
+
 EXAMPLES
   # list default drivers
 
@@ -642,6 +683,10 @@ COMMON FLAGS
 
 DESCRIPTION
   delete an edge driver
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/deleteDriver
 ```
 
 _See code: [src/commands/edge/drivers/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/drivers/delete.ts)_
@@ -671,6 +716,10 @@ COMMON FLAGS
 
 DESCRIPTION
   install an edge driver onto a hub
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/installDrivers
 
 EXAMPLES
   $ smartthings edge:drivers:install                                         # use Q&A format to enter required values
@@ -711,6 +760,11 @@ COMMON FLAGS
 
 DESCRIPTION
   list all drivers installed on a given hub
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/listHubInstalledDrivers,
+  https://developer.smartthings.com/docs/api/public/#operation/getHubDeviceDriver
 
 EXAMPLES
   list all installed drivers
@@ -797,6 +851,10 @@ COMMON FLAGS
 DESCRIPTION
   build and upload an edge package
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/uploadDriverPackage
+
 EXAMPLES
   # build and upload driver found in current directory:
   $ smartthings edge:drivers:package
@@ -846,6 +904,10 @@ COMMON FLAGS
 DESCRIPTION
   change the driver used by an installed device
 
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/updateHubDevice
+
 EXAMPLES
   # switch driver, prompting user for all necessary input
   $ smartthings edge:drivers:switch
@@ -883,6 +945,10 @@ COMMON FLAGS
 
 DESCRIPTION
   uninstall an edge driver from a hub
+
+  For API information, see:
+
+  https://developer.smartthings.com/docs/api/public/#operation/uninstallDriver
 ```
 
 _See code: [src/commands/edge/drivers/uninstall.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/plugin-cli-edge@2.0.1/packages/edge/src/commands/edge/drivers/uninstall.ts)_

--- a/packages/edge/src/commands/edge/channels.ts
+++ b/packages/edge/src/commands/edge/channels.ts
@@ -9,7 +9,8 @@ import { listChannels, listTableFieldDefinitions, tableFieldDefinitions } from '
 
 
 export default class ChannelsCommand extends EdgeCommand<typeof ChannelsCommand.flags> {
-	static description = 'list all channels owned by you or retrieve a single channel'
+	static description = 'list all channels owned by you or retrieve a single channel' +
+		this.apiDocsURL('listChannels', 'channelById')
 
 	/* eslint-disable @typescript-eslint/naming-convention */
 	static flags = {

--- a/packages/edge/src/commands/edge/channels/assign.ts
+++ b/packages/edge/src/commands/edge/channels/assign.ts
@@ -6,7 +6,8 @@ import { EdgeCommand } from '../../../lib/edge-command'
 
 
 export class ChannelsAssignCommand extends EdgeCommand<typeof ChannelsAssignCommand.flags> {
-	static description = 'assign a driver to a channel'
+	static description = 'assign a driver to a channel' +
+		this.apiDocsURL('createDriverChannel')
 
 	static flags = {
 		...EdgeCommand.flags,

--- a/packages/edge/src/commands/edge/channels/create.ts
+++ b/packages/edge/src/commands/edge/channels/create.ts
@@ -11,7 +11,8 @@ const tableFieldDefinitions: TableFieldDefinition<Channel>[] = ['channelId', 'na
 	'type', 'termsOfServiceUrl', 'createdDate', 'lastModifiedDate']
 
 export default class ChannelsCreateCommand extends EdgeCommand<typeof ChannelsCreateCommand.flags> {
-	static description = 'create a channel'
+	static description = 'create a channel' +
+		this.apiDocsURL('createChannel')
 
 	static flags = {
 		...EdgeCommand.flags,

--- a/packages/edge/src/commands/edge/channels/delete.ts
+++ b/packages/edge/src/commands/edge/channels/delete.ts
@@ -5,7 +5,8 @@ import { EdgeCommand } from '../../../lib/edge-command'
 
 
 export default class ChannelsDeleteCommand extends EdgeCommand<typeof ChannelsDeleteCommand.flags> {
-	static description = 'delete a channel'
+	static description = 'delete a channel' +
+		this.apiDocsURL('deleteChannel')
 
 	static flags = EdgeCommand.flags
 

--- a/packages/edge/src/commands/edge/channels/drivers.ts
+++ b/packages/edge/src/commands/edge/channels/drivers.ts
@@ -6,7 +6,8 @@ import { EdgeCommand } from '../../../lib/edge-command'
 
 
 export default class ChannelsDriversCommand extends EdgeCommand<typeof ChannelsDriversCommand.flags> {
-	static description = 'list all drivers assigned to a given channel'
+	static description = 'list drivers assigned to a given channel' +
+		this.apiDocsURL('getChannelDrivers', 'getDriverChannel')
 
 	static flags = {
 		...EdgeCommand.flags,

--- a/packages/edge/src/commands/edge/channels/enrollments.ts
+++ b/packages/edge/src/commands/edge/channels/enrollments.ts
@@ -7,7 +7,8 @@ import { EdgeCommand } from '../../../lib/edge-command'
 
 
 export default class ChannelsEnrollmentsCommand extends EdgeCommand<typeof ChannelsEnrollmentsCommand.flags> {
-	static description = 'list all channels a given hub is enrolled in'
+	static description = 'list all channels a given hub is enrolled in' +
+		this.apiDocsURL('listDriverChannels')
 
 	static flags = {
 		...EdgeCommand.flags,

--- a/packages/edge/src/commands/edge/channels/unassign.ts
+++ b/packages/edge/src/commands/edge/channels/unassign.ts
@@ -41,7 +41,8 @@ export async function chooseAssignedDriver(command: APICommand<typeof APICommand
 }
 
 export class ChannelsUnassignCommand extends EdgeCommand<typeof ChannelsUnassignCommand.flags> {
-	static description = 'remove a driver from a channel'
+	static description = 'remove a driver from a channel' +
+		this.apiDocsURL('deleteDriverChannel')
 
 	static flags = {
 		...EdgeCommand.flags,

--- a/packages/edge/src/commands/edge/channels/update.ts
+++ b/packages/edge/src/commands/edge/channels/update.ts
@@ -7,7 +7,8 @@ import { EdgeCommand } from '../../../lib/edge-command'
 
 
 export default class ChannelsUpdateCommand extends EdgeCommand<typeof ChannelsUpdateCommand.flags> {
-	static description = 'update a channel'
+	static description = 'update a channel' +
+		this.apiDocsURL('updateChannel')
 
 	static flags = {
 		...EdgeCommand.flags,

--- a/packages/edge/src/commands/edge/drivers.ts
+++ b/packages/edge/src/commands/edge/drivers.ts
@@ -9,13 +9,11 @@ import { buildTableOutput, listDrivers, listTableFieldDefinitions } from '../../
 
 
 export default class DriversCommand extends EdgeCommand<typeof DriversCommand.flags> {
-	static description = `list all drivers owned by you or retrieve a single driver
-Use this command to list all drivers you own, even if they are not yet assigned to a channel.
-
-See also:
-  edge:drivers:installed to list installed drivers
-  edge:channels:drivers to list drivers that are part of a channel you own or have subscribed to
-`
+	static description = 'list all drivers owned by you or retrieve a single driver\n' +
+		'Use this command to list all drivers you own, even if they are not yet assigned to a channel.\n' +
+		'See also edge:drivers:installed to list installed drivers and edge:channels:drivers to list drivers ' +
+		'that are part of a channel you own or have subscribed to' +
+			this.apiDocsURL('listDrivers', 'getDriver', 'getDriverRevision')
 
 	static flags = {
 		...EdgeCommand.flags,

--- a/packages/edge/src/commands/edge/drivers/default.ts
+++ b/packages/edge/src/commands/edge/drivers/default.ts
@@ -7,7 +7,8 @@ import { listTableFieldDefinitions } from '../../../lib/commands/drivers-util'
 
 
 export default class DriversDefaultCommand extends EdgeCommand<typeof DriversDefaultCommand.flags> {
-	static description = 'list default drivers available to all users'
+	static description = 'list default drivers available to all users' +
+		this.apiDocsURL('getDefaultDrivers')
 
 	static flags = {
 		...EdgeCommand.flags,

--- a/packages/edge/src/commands/edge/drivers/delete.ts
+++ b/packages/edge/src/commands/edge/drivers/delete.ts
@@ -3,7 +3,8 @@ import { chooseDriver } from '../../../lib/commands/drivers-util'
 
 
 export default class DriversDeleteCommand extends EdgeCommand<typeof DriversDeleteCommand.flags> {
-	static description = 'delete an edge driver'
+	static description = 'delete an edge driver' +
+		this.apiDocsURL('deleteDriver')
 
 	static flags = EdgeCommand.flags
 

--- a/packages/edge/src/commands/edge/drivers/install.ts
+++ b/packages/edge/src/commands/edge/drivers/install.ts
@@ -9,7 +9,8 @@ import { EdgeCommand } from '../../../lib/edge-command'
 
 
 export default class DriversInstallCommand extends EdgeCommand<typeof DriversInstallCommand.flags> {
-	static description = 'install an edge driver onto a hub'
+	static description = 'install an edge driver onto a hub' +
+		this.apiDocsURL('installDrivers')
 
 	static examples = [
 		'smartthings edge:drivers:install                                         # use Q&A format to enter required values',

--- a/packages/edge/src/commands/edge/drivers/installed.ts
+++ b/packages/edge/src/commands/edge/drivers/installed.ts
@@ -10,7 +10,8 @@ import { WithNamedChannel, withChannelNames } from '../../../lib/commands/channe
 
 
 export default class DriversInstalledCommand extends EdgeCommand<typeof DriversInstalledCommand.flags> {
-	static description = 'list all drivers installed on a given hub'
+	static description = 'list all drivers installed on a given hub' +
+		this.apiDocsURL('listHubInstalledDrivers', 'getHubDeviceDriver')
 
 	static flags = {
 		...EdgeCommand.flags,

--- a/packages/edge/src/commands/edge/drivers/package.ts
+++ b/packages/edge/src/commands/edge/drivers/package.ts
@@ -14,7 +14,8 @@ import { EdgeDriver } from '@smartthings/core-sdk'
 
 
 export default class PackageCommand extends EdgeCommand<typeof PackageCommand.flags> {
-	static description = 'build and upload an edge package'
+	static description = 'build and upload an edge package' +
+		this.apiDocsURL('uploadDriverPackage')
 
 	static args = [{
 		name: 'projectDirectory',

--- a/packages/edge/src/commands/edge/drivers/switch.ts
+++ b/packages/edge/src/commands/edge/drivers/switch.ts
@@ -10,7 +10,8 @@ import { chooseDriver, chooseHub, listAllAvailableDrivers, listMatchingDrivers }
 
 
 export default class DriversSwitchCommand extends EdgeCommand<typeof DriversSwitchCommand.flags> {
-	static description = 'change the driver used by an installed device'
+	static description = 'change the driver used by an installed device' +
+		this.apiDocsURL('updateHubDevice')
 
 	static examples = [`# switch driver, prompting user for all necessary input
 $ smartthings edge:drivers:switch

--- a/packages/edge/src/commands/edge/drivers/uninstall.ts
+++ b/packages/edge/src/commands/edge/drivers/uninstall.ts
@@ -5,7 +5,8 @@ import { chooseHub, chooseInstalledDriver } from '../../../lib/commands/drivers-
 
 
 export default class DriversUninstallCommand extends EdgeCommand<typeof DriversUninstallCommand.flags> {
-	static description = 'uninstall an edge driver from a hub'
+	static description = 'uninstall an edge driver from a hub' +
+		this.apiDocsURL('uninstallDriver')
 
 	static flags = {
 		...EdgeCommand.flags,


### PR DESCRIPTION
<!-- Describe your pull request. -->

Added links to API docs for the rest of the commands where we have them available. I fixed formatting on the description of a couple of updated commands also but I didn't touch anything else (e.g. the examples) to keep this pull request focused.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
