### PR TITLE
docs: update description of flags in package command that use defaults

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3596,10 +3596,11 @@ ARGUMENTS
   PROJECTDIRECTORY  [default: .] directory containing project to upload
 
 FLAGS
-  -I, --install               prompt for hub to install to after assigning it to the channel, implies --assign if
-                              --assign or --channel not included
+  -I, --install               prompt for hub (or use default if previously specified) to install to after assigning it
+                              to the channel, implies --assign if --assign or --channel not included
   -O, --organization=<value>  the organization ID to use for this command
-  -a, --assign                prompt for a channel to assign the driver to after upload
+  -a, --assign                prompt for a channel (or use default if previously specified) to assign the driver to
+                              after upload
   -b, --build-only=<value>    save package to specified zip file but skip upload
   -u, --upload=<value>        upload zip file previously built with --build flag
   --channel=<UUID>            automatically assign driver to specified channel after upload

--- a/packages/edge/README.md
+++ b/packages/edge/README.md
@@ -829,10 +829,11 @@ ARGUMENTS
   PROJECTDIRECTORY  [default: .] directory containing project to upload
 
 FLAGS
-  -I, --install               prompt for hub to install to after assigning it to the channel, implies --assign if
-                              --assign or --channel not included
+  -I, --install               prompt for hub (or use default if previously specified) to install to after assigning it
+                              to the channel, implies --assign if --assign or --channel not included
   -O, --organization=<value>  the organization ID to use for this command
-  -a, --assign                prompt for a channel to assign the driver to after upload
+  -a, --assign                prompt for a channel (or use default if previously specified) to assign the driver to
+                              after upload
   -b, --build-only=<value>    save package to specified zip file but skip upload
   -u, --upload=<value>        upload zip file previously built with --build flag
   --channel=<UUID>            automatically assign driver to specified channel after upload

--- a/packages/edge/src/commands/edge/drivers/package.ts
+++ b/packages/edge/src/commands/edge/drivers/package.ts
@@ -39,7 +39,8 @@ export default class PackageCommand extends EdgeCommand<typeof PackageCommand.fl
 		}),
 		assign: Flags.boolean({
 			char: 'a',
-			description: 'prompt for a channel to assign the driver to after upload',
+			description: 'prompt for a channel (or use default if previously specified) to assign the driver to ' +
+				'after upload',
 			exclusive: ['channel', 'build-only'],
 		}),
 		channel: Flags.string({
@@ -49,11 +50,13 @@ export default class PackageCommand extends EdgeCommand<typeof PackageCommand.fl
 		}),
 		install: Flags.boolean({
 			char: 'I',
-			description: 'prompt for hub to install to after assigning it to the channel, implies --assign if --assign or --channel not included',
+			description: 'prompt for hub (or use default if previously specified) to install to after assigning it ' +
+				'to the channel, implies --assign if --assign or --channel not included',
 			exclusive: ['hub', 'build-only'],
 		}),
 		hub: Flags.string({
-			description: 'automatically install driver to specified hub, implies --assign if --assign or --channel not included',
+			description: 'automatically install driver to specified hub, implies --assign if --assign or --channel ' +
+				'not included',
 			exclusive: ['install', 'build-only'],
 			helpValue: '<UUID>',
 		}),


### PR DESCRIPTION
<!-- Describe your pull request. -->

Updated description of `assign` and `install` flags in `edge:drivers:package` command to indicate that defaults will be used if they have been previously specified.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
