### PR TITLE
chore: prefer types over interfaces

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -69,7 +69,7 @@ module.exports = {
 				},
 			},
 		],
-		'@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
+		'@typescript-eslint/consistent-type-definitions': ['error', 'type'],
 		'@typescript-eslint/explicit-function-return-type': ['error', {
 			allowExpressions: true,
 		}],

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -20,7 +20,7 @@ function reservedKey(key: string): boolean {
 	return key === 'logging'
 }
 
-export interface ConfigData {
+export type ConfigData = {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	[name: string]: any
 }

--- a/packages/cli/src/commands/virtualdevices/events.ts
+++ b/packages/cli/src/commands/virtualdevices/events.ts
@@ -35,7 +35,7 @@ function buildTableOutput(tableGenerator: TableGenerator, data: EventInputOutput
 	return table.toString()
 }
 
-interface EventInputOutput {
+type EventInputOutput = {
 	input: DeviceEvent[]
 	output: VirtualDeviceEventsResponse
 }

--- a/packages/cli/src/lib/commands/capabilities-util.ts
+++ b/packages/cli/src/lib/commands/capabilities-util.ts
@@ -110,7 +110,7 @@ export const buildTableOutput = (tableGenerator: TableGenerator, capability: Cap
 	return output
 }
 
-export interface CapabilityId {
+export type CapabilityId = {
 	id: string
 	version: number
 }

--- a/packages/cli/src/lib/commands/deviceprofiles-util.ts
+++ b/packages/cli/src/lib/commands/deviceprofiles-util.ts
@@ -21,7 +21,7 @@ import {
 
 export type ViewPresentationDeviceConfigEntry =
 	Omit<PresentationDeviceConfigEntry, 'component'> & Partial<Pick<PresentationDeviceConfigEntry, 'component'>>
-export interface DeviceView {
+export type DeviceView = {
 	dashboard?: {
 		states: ViewPresentationDeviceConfigEntry[]
 		actions: ViewPresentationDeviceConfigEntry[]
@@ -33,18 +33,18 @@ export interface DeviceView {
 	}
 }
 
-export interface DeviceDefinition extends DeviceProfile {
+export type DeviceDefinition = DeviceProfile & {
 	view?: DeviceView
 }
 
-export interface DeviceDefinitionRequest extends DeviceProfileRequest {
+export type DeviceDefinitionRequest = DeviceProfileRequest & {
 	view?: DeviceView
 }
 
 export const entryValues = (entries: ViewPresentationDeviceConfigEntry[]): string =>
 	entries.map(entry => entry.component ? `${entry.component}/${entry.capability}` : `${entry.capability}`).join('\n')
 
-export interface TableOutputOptions {
+export type TableOutputOptions = {
 	includePreferences?: boolean
 	includeViewInfo?: boolean
 }

--- a/packages/cli/src/lib/commands/deviceprofiles/create-util.ts
+++ b/packages/cli/src/lib/commands/deviceprofiles/create-util.ts
@@ -87,7 +87,7 @@ export const generateDefaultConfig = async (client: SmartThingsClient, devicePro
 	return deviceConfig
 }
 
-export interface DeviceProfileAndConfig {
+export type DeviceProfileAndConfig = {
 	deviceProfile: DeviceProfile
 	deviceConfig: PresentationDeviceConfig
 }

--- a/packages/cli/src/lib/commands/history-util.ts
+++ b/packages/cli/src/lib/commands/history-util.ts
@@ -11,7 +11,7 @@ export const maxItemsPerRequest = 300
 
 export const maxRequestsBeforeWarning = 6
 
-export interface DeviceActivityOptions {
+export type DeviceActivityOptions = {
 	includeName?: boolean
 	utcTimeFormat?: boolean
 }

--- a/packages/cli/src/lib/commands/virtualdevices-util.ts
+++ b/packages/cli/src/lib/commands/virtualdevices-util.ts
@@ -19,7 +19,7 @@ import {
 import { chooseDeviceProfile } from '../../lib/commands/deviceprofiles-util'
 
 
-export interface DevicePrototype {
+export type DevicePrototype = {
 	name: string
 	id: string
 }
@@ -50,20 +50,20 @@ export const allPrototypes = [
 	{ name: 'Thermostat', id: 'VIRTUAL_THERMOSTAT' },
 ]
 
-export interface CapabilityAttributeItem {
+export type CapabilityAttributeItem = {
 	attributeName: string
 	attribute: CapabilityAttribute
 }
 
-export interface CapabilityUnitItem {
+export type CapabilityUnitItem = {
 	unit: string
 }
 
-export interface CapabilityValueItem {
+export type CapabilityValueItem = {
 	value: string
 }
 
-export interface DeviceProfileDefinition {
+export type DeviceProfileDefinition = {
 	deviceProfileId?: string
 	deviceProfile?: DeviceProfileCreateRequest
 }

--- a/packages/edge/src/commands/edge/channels/unassign.ts
+++ b/packages/edge/src/commands/edge/channels/unassign.ts
@@ -8,7 +8,7 @@ import { chooseChannel } from '../../../lib/commands/channels-util'
 import { EdgeCommand } from '../../../lib/edge-command'
 
 
-export interface NamedDriverChannelDetails extends DriverChannelDetails {
+export type NamedDriverChannelDetails = DriverChannelDetails & {
 	name: string
 }
 

--- a/packages/edge/src/commands/edge/drivers/logcat.ts
+++ b/packages/edge/src/commands/edge/drivers/logcat.ts
@@ -73,7 +73,7 @@ async function promptForDrivers(fieldInfo: Sorting<DriverInfo>, list: DriverInfo
 	return inputId
 }
 
-interface KnownHub {
+type KnownHub = {
 	hostname: string
 	fingerprint: string
 }

--- a/packages/edge/src/lib/commands/channels-util.ts
+++ b/packages/edge/src/lib/commands/channels-util.ts
@@ -18,7 +18,7 @@ export const listTableFieldDefinitions: TableFieldDefinition<Channel>[] =
 export const tableFieldDefinitions: TableFieldDefinition<Channel>[] =
 	['channelId', 'name', 'description', 'termsOfServiceUrl', 'createdDate', 'lastModifiedDate']
 
-export interface ChooseChannelOptions extends ChooseOptions {
+export type ChooseChannelOptions = ChooseOptions & {
 	includeReadOnly: boolean
 }
 
@@ -56,7 +56,7 @@ export async function chooseChannel(command: APICommand<typeof APICommand.flags>
 		{ preselectedId, listItems, promptMessage, defaultValue })
 }
 
-export interface ListChannelOptions {
+export type ListChannelOptions = {
 	allOrganizations: boolean
 	includeReadOnly: boolean
 	subscriberType?: SubscriberType
@@ -75,11 +75,11 @@ export async function listChannels(client: SmartThingsClient, options?: Partial<
 	return client.channels.list({ includeReadOnly, subscriberType, subscriberId })
 }
 
-export interface WithChannel {
+export type WithChannel = {
 	channelId: string
 }
 
-export interface WithNamedChannel extends WithChannel {
+export type WithNamedChannel = WithChannel & {
 	channelName?: string
 }
 

--- a/packages/edge/src/lib/commands/drivers-util.ts
+++ b/packages/edge/src/lib/commands/drivers-util.ts
@@ -81,7 +81,7 @@ export const listMatchingDrivers = async (client: SmartThingsClient, deviceId: s
  */
 export type DriverChoice = Pick<EdgeDriverSummary, 'driverId' | 'name'>
 
-export interface ChooseDriverOptions extends ChooseOptions {
+export type ChooseDriverOptions = ChooseOptions & {
 	/**
 	 * By default drivers owned by the user are included, using `command.client.drivers.list()`
 	 * but if you need a different list of drivers, you can include your own function here.
@@ -160,7 +160,7 @@ export const chooseHub = async (command: APICommand<typeof APICommand.flags>, pr
 	return selectFromList(command, config, { preselectedId, listItems, promptMessage, defaultValue })
 }
 
-export interface DriverChannelDetailsWithName extends DriverChannelDetails {
+export type DriverChannelDetailsWithName = DriverChannelDetails & {
 	name: string
 }
 

--- a/packages/edge/src/lib/endpoints/invites.ts
+++ b/packages/edge/src/lib/endpoints/invites.ts
@@ -1,14 +1,14 @@
 import { Endpoint, EndpointClient, EndpointClientConfig } from '@smartthings/core-sdk'
 
 
-export interface InvitationMetadata {
+export type InvitationMetadata = {
 	name: string
 	description: string
 	owner: string
 	termsUrl: string
 }
 
-export interface CreateInvitation {
+export type CreateInvitation = {
 	resource: {
 		root: {
 			service: 'core' | 'iam' | 'platform' | 'mdu' | 'developer'
@@ -28,12 +28,12 @@ export interface CreateInvitation {
 	expiration?: number
 }
 
-export interface Invitation extends CreateInvitation {
+export type Invitation = CreateInvitation & {
 	id: string
 	acceptUrl: string
 }
 
-export interface InvitationSummary {
+export type InvitationSummary = {
 	invitationId: string
 	acceptUrl: string
 }

--- a/packages/edge/src/lib/file-util.ts
+++ b/packages/edge/src/lib/file-util.ts
@@ -49,7 +49,7 @@ export const requireDir = async (dirName: string): Promise<string> => {
 	throw new Errors.CLIError(`missing required directory: ${dirName}`)
 }
 
-export interface YAMLFileData {
+export type YAMLFileData = {
 	[key: string]: string | object | number | undefined
 }
 

--- a/packages/edge/src/lib/live-logging.ts
+++ b/packages/edge/src/lib/live-logging.ts
@@ -21,7 +21,7 @@ export enum LogLevel {
 	PRINT = 1000,
 }
 
-export interface LiveLogMessage {
+export type LiveLogMessage = {
 	/*
 	 * The ISO formatted Local timestamp
 	 */
@@ -61,7 +61,7 @@ export enum DriverInfoStatus {
 	Unknown = 'unknown',
 }
 
-export interface DriverInfo {
+export type DriverInfo = {
 	/**
 	 * A UUID for this driver
 	 * */
@@ -189,7 +189,7 @@ function scrubAuthInfo(obj: unknown): string {
  */
 export type HostVerifier = (cert: PeerCertificate) => Promise<void | never>
 
-export interface LiveLogClientConfig {
+export type LiveLogClientConfig = {
 	/**
 	 * @example 192.168.0.1:9495
 	 */

--- a/packages/lib/src/__tests__/login-authenticator.test.ts
+++ b/packages/lib/src/__tests__/login-authenticator.test.ts
@@ -96,7 +96,7 @@ describe('LoginAuthenticator', () => {
 		},
 	}
 	const codeVerifierRegex = /\bcode_verifier=[\w|-]+\b/
-	interface AuthTokenResponse {
+	type AuthTokenResponse = {
 		/* eslint-disable @typescript-eslint/naming-convention */
 		access_token: string
 		refresh_token: string

--- a/packages/lib/src/__tests__/table-generator.test.ts
+++ b/packages/lib/src/__tests__/table-generator.test.ts
@@ -96,7 +96,7 @@ expect.extend({
 	},
 })
 
-interface SimpleData {
+type SimpleData = {
 	id?: string
 	someNumber: number
 	simpleField?: string

--- a/packages/lib/src/__tests__/test-lib/simple-type.ts
+++ b/packages/lib/src/__tests__/test-lib/simple-type.ts
@@ -1,5 +1,5 @@
 
-export interface SimpleType {
+export type SimpleType = {
 	num: number
 	str: string
 }

--- a/packages/lib/src/api-helpers.ts
+++ b/packages/lib/src/api-helpers.ts
@@ -1,23 +1,23 @@
 import { SmartThingsClient, OrganizationResponse, CapabilityNamespace } from '@smartthings/core-sdk'
 
 
-export interface WithLocation {
+export type WithLocation = {
 	locationId?: string
 }
 
-export interface WithNamedLocation extends WithLocation {
+export type WithNamedLocation = WithLocation & {
 	location?: string
 }
 
-export interface WithRoom extends WithLocation {
+export type WithRoom = WithLocation & {
 	roomId?: string
 }
 
-export interface WithNamedRoom extends WithNamedLocation, WithRoom {
+export type WithNamedRoom = WithNamedLocation & WithRoom & {
 	room?: string
 }
 
-export interface WithOrganization {
+export type WithOrganization = {
 	organization?: string
 }
 
@@ -95,6 +95,6 @@ export async function forAllNamespaces<T>(
 	return nestedItems.flat()
 }
 
-export interface WithLocales {
+export type WithLocales = {
 	locales?: string
 }

--- a/packages/lib/src/basic-io.ts
+++ b/packages/lib/src/basic-io.ts
@@ -26,7 +26,7 @@ export type IdRetrievalFunction<ID, L extends object> = (fieldInfo: Sorting<L>, 
  * results in a consistent order. If the user specifies an index into that list when querying
  * a single location, the sort key specified here is used again to ensure the same ordering.
  */
-export interface Sorting<L extends object> {
+export type Sorting<L extends object> = {
 	/**
 	 * The primary key used to uniquely identify this object.
 	 */
@@ -44,7 +44,7 @@ export interface Sorting<L extends object> {
  * If you're writing code that uses this interface, use `itemName` or `pluralItemName` from
  * command-util to translate a `Naming` instance to a name.
  */
-export interface Naming {
+export type Naming = {
 	/**
 	 * The singular name of your item, using lowercase letters and spaces to separate words.
 	 */

--- a/packages/lib/src/cli-config.ts
+++ b/packages/lib/src/cli-config.ts
@@ -7,7 +7,7 @@ export const seeConfigDocs = 'see https://github.com/SmartThingsCommunity/smartt
 export type Profile = Record<string, unknown>
 export type ProfilesByName = Record<string, Profile>
 
-export interface CLIConfigDescription {
+export type CLIConfigDescription = {
 	/**
 	 * The name of the user-editable configuration file.
 	 */
@@ -24,7 +24,7 @@ export interface CLIConfigDescription {
 	profileName: string
 }
 
-export interface CLIConfig extends CLIConfigDescription {
+export type CLIConfig = CLIConfigDescription & {
 	profiles: ProfilesByName
 	managedProfiles: ProfilesByName
 	mergedProfiles: ProfilesByName

--- a/packages/lib/src/command-util.ts
+++ b/packages/lib/src/command-util.ts
@@ -101,7 +101,7 @@ export async function stringGetIdFromUser<L extends object>(fieldInfo: Sorting<L
  * Note that not all functions that use this interface support all options. Check the
  * `chooseThing` (e.g. `chooseDevice`) method itself.
  */
-export interface ChooseOptions {
+export type ChooseOptions = {
 	allowIndex: boolean
 	verbose: boolean
 	useConfigDefault: boolean

--- a/packages/lib/src/device-util.ts
+++ b/packages/lib/src/device-util.ts
@@ -7,7 +7,7 @@ import { SmartThingsCommandInterface } from './smartthings-command'
 
 
 export type DevicePredicate = (value: Device, index: number, array: Device[]) => boolean
-export interface ChooseDeviceOptions extends ChooseOptions {
+export type ChooseDeviceOptions = ChooseOptions & {
 	deviceListOptions?: DeviceListOptions
 	deviceListFilter?: DevicePredicate
 }

--- a/packages/lib/src/format.ts
+++ b/packages/lib/src/format.ts
@@ -6,18 +6,18 @@ import { SmartThingsCommandInterface } from './smartthings-command'
 import { TableFieldDefinition } from './table-generator'
 
 
-export interface TableCommonOutputProducer<O extends object> {
+export type TableCommonOutputProducer<O extends object> = {
 	tableFieldDefinitions: TableFieldDefinition<O>[]
 }
-export interface CustomCommonOutputProducer<O extends object> {
+export type CustomCommonOutputProducer<O extends object> = {
 	buildTableOutput(data: O): string
 }
 export type CommonOutputProducer<O extends object> = TableCommonOutputProducer<O> | CustomCommonOutputProducer<O>
 
-export interface TableCommonListOutputProducer<L extends object> {
+export type TableCommonListOutputProducer<L extends object> = {
 	listTableFieldDefinitions: TableFieldDefinition<L>[]
 }
-export interface CustomCommonListOutputProducer<L extends object> {
+export type CustomCommonListOutputProducer<L extends object> = {
 	buildListTableOutput(data: L[]): string
 }
 export type CommonListOutputProducer<L extends object> = TableCommonListOutputProducer<L> | CustomCommonListOutputProducer<L> | Sorting<L>

--- a/packages/lib/src/input.ts
+++ b/packages/lib/src/input.ts
@@ -30,7 +30,7 @@ export const inputFlag = {
 }
 
 
-export interface InputProcessor<T> {
+export type InputProcessor<T> = {
 	/**
 	 * Return the type of input this processor retrieved. This should not be called until after
 	 * data has been read via `read` so throwing an exception before that is acceptable.
@@ -100,7 +100,7 @@ export function inputProcessor<T>(hasInput: () => boolean | Promise<boolean>, re
 	return { ioFormat, hasInput, read }
 }
 
-export interface CommandLineInputCommand<T> {
+export type CommandLineInputCommand<T> = {
 	hasCommandLineInput(): boolean
 	getInputFromCommandLine(): Promise<T>
 }
@@ -112,7 +112,7 @@ export function commandLineInputProcessor<T>(command: CommandLineInputCommand<T>
 	return inputProcessor(() => command.hasCommandLineInput(), () => command.getInputFromCommandLine())
 }
 
-export interface UserInputCommand<T> {
+export type UserInputCommand<T> = {
 	getInputFromUser(): Promise<T>
 }
 /**

--- a/packages/lib/src/login-authenticator.ts
+++ b/packages/lib/src/login-authenticator.ts
@@ -11,7 +11,7 @@ import log4js from '@log4js-node/log4js-api'
 import { CliUx } from '@oclif/core'
 
 
-export interface ClientIdProvider extends SmartThingsURLProvider {
+export type ClientIdProvider = SmartThingsURLProvider & {
 	clientId: string
 	baseOAuthInURL: string
 	oauthAuthTokenRefreshURL: string
@@ -27,7 +27,7 @@ export const defaultClientIdProvider: ClientIdProvider = {
 // All the scopes the clientId we are using is configured to use.
 const scopes = ['controller:stCli']
 
-interface AuthenticationInfo {
+type AuthenticationInfo = {
 	accessToken: string
 	refreshToken: string
 	expires: Date
@@ -45,7 +45,7 @@ function credentialsFile(): string {
 	return (global as unknown as { _credentialsFile: string })._credentialsFile
 }
 
-interface CredentialsFileData {
+type CredentialsFileData = {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	[profileName: string]: any
 }

--- a/packages/lib/src/select.ts
+++ b/packages/lib/src/select.ts
@@ -15,7 +15,7 @@ function promptFromNaming(config: Naming): string | undefined {
 	return config.itemName ? `Select ${indefiniteArticleFor(config.itemName)} ${config.itemName}.` : undefined
 }
 
-export interface PromptUserOptions<L extends object, ID = string> {
+export type PromptUserOptions<L extends object, ID = string> = {
 	/**
 	 * A function that returns the list of items to display.
 	 */
@@ -73,7 +73,7 @@ export async function promptUser<L extends object, ID = string>(command: SmartTh
 	return await getIdFromUser(config, list, options.promptMessage ?? promptFromNaming(config))
 }
 
-export interface SelectOptions<L extends object, ID = string> extends PromptUserOptions<L, ID> {
+export type SelectOptions<L extends object, ID = string> = PromptUserOptions<L, ID> & {
 	/**
 	 * If the value passed here is truthy, it is simply returned and no further processing is done.
 	 */

--- a/packages/lib/src/smartthings-command.ts
+++ b/packages/lib/src/smartthings-command.ts
@@ -6,7 +6,7 @@ import { outputFlags } from './output-builder'
 import { DefaultTableGenerator, TableGenerator } from './table-generator'
 
 
-export interface Loggable {
+export type Loggable = {
 	readonly logger: log4js.Logger
 }
 

--- a/packages/lib/src/sse-io.ts
+++ b/packages/lib/src/sse-io.ts
@@ -5,7 +5,7 @@ import { CliUx } from '@oclif/core'
  */
 const FORMAT_TIME_PREFIX = '%s '
 
-export interface EventFormat {
+export type EventFormat = {
 	/**
 	 * A printf-like format string which can contain zero or more format specifiers.
 	 */

--- a/packages/lib/src/table-generator.ts
+++ b/packages/lib/src/table-generator.ts
@@ -5,7 +5,7 @@ import { table } from 'table'
 import { Logger } from '@smartthings/core-sdk'
 
 
-interface TableFieldDefinitionBase<T extends object> {
+type TableFieldDefinitionBase<T extends object> = {
 	/**
 	 * If included, overrides the default label for the column.
 	 */
@@ -44,7 +44,7 @@ export type SimpleTableFieldDefinition<T extends object> = keyof T
  * The default label (when not overridden with the `label` option) is the string version of `prop`
  * with the first letter made uppercase and spaces added before other uppercase letters.
  */
-export interface PropertyTableFieldDefinition<T extends object> extends TableFieldDefinitionBase<T> {
+export type PropertyTableFieldDefinition<T extends object> = TableFieldDefinitionBase<T> & {
 	/**
 	 * The name of the property from which to get data.
 	 */
@@ -58,7 +58,7 @@ export interface PropertyTableFieldDefinition<T extends object> extends TableFie
  * The default label is also derived from the final property of the path when the `label` option is
  * not included.
  */
-export interface PathTableFieldDefinition<T extends object> extends TableFieldDefinitionBase<T> {
+export type PathTableFieldDefinition<T extends object> = TableFieldDefinitionBase<T> & {
 	/**
 	 * The lodash path of property from which to get data. This is used to reference a nested
 	 * property. If you want to reference a non-nested property use `PropertyTableFieldDefinition`
@@ -77,7 +77,7 @@ export interface PathTableFieldDefinition<T extends object> extends TableFieldDe
  * `TableFieldDefinition` to specify a function which calculates the value of the field. Note
  * that for this type of `TableFieldDefinition`, the `label` option is required.
  */
-export interface ValueTableFieldDefinition<T extends object> extends TableFieldDefinitionBase<T> {
+export type ValueTableFieldDefinition<T extends object> = TableFieldDefinitionBase<T> & {
 	/**
 	 * If included, overrides the default label for the column.
 	 */
@@ -106,7 +106,7 @@ export interface ValueTableFieldDefinition<T extends object> extends TableFieldD
  */
 export type TableFieldDefinition<T extends object> = SimpleTableFieldDefinition<T> | PropertyTableFieldDefinition<T> | PathTableFieldDefinition<T> | ValueTableFieldDefinition<T>
 
-export interface TableGenerator {
+export type TableGenerator = {
 	newOutputTable(options?: Partial<TableOptions>): Table
 
 	/**
@@ -124,7 +124,7 @@ export interface TableGenerator {
 	buildTableFromList<T extends object>(items: T[], tableFieldDefinitions: TableFieldDefinition<T>[]): string
 }
 
-export interface TableOptions {
+export type TableOptions = {
 	/**
 	 * Separate groups of four rows by a line to make long rows easier to follow across the screen.
 	 */
@@ -157,7 +157,7 @@ export const stringFromUnknown = (input: unknown): string => {
 }
 
 export type TableCellData = string | number | boolean | undefined
-export interface Table {
+export type Table = {
 	push: (row: TableCellData[]) => void
 
 	toString: () => string

--- a/packages/lib/src/typings/index.d.ts
+++ b/packages/lib/src/typings/index.d.ts
@@ -2,6 +2,7 @@ export {}
 
 declare global {
 	namespace jest {
+		// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 		interface Matchers<R> {
 			toHaveLabel(label: string): R
 			toHaveValue(value: string): R


### PR DESCRIPTION
<!-- Describe your pull request. -->

* updated rule to require `type` rather than `interface`
* updated code to conform to this rule
* the one exception where we still need `interface` is for a Jest matcher since the way you add your own matchers is to extend the Jest `Matchers` interface

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
