### PR TITLE
chore: remove calls to jest.clearAllMocks in edge plugin

### DIFF
--- a/packages/edge/src/__tests__/commands/edge/channels.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/channels.test.ts
@@ -19,10 +19,6 @@ jest.mock('../../../../src/lib/commands/channels-util')
 describe('ChannelsCommand', () => {
 	const outputItemOrListMock = jest.mocked(outputItemOrList)
 
-	afterEach(() => {
-		jest.clearAllMocks()
-	})
-
 	it('uses outputItemOrList', async () => {
 		await expect(ChannelsCommand.run([])).resolves.not.toThrow()
 

--- a/packages/edge/src/__tests__/commands/edge/channels/drivers.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/channels/drivers.test.ts
@@ -26,10 +26,6 @@ describe('ChannelsDriversCommand', () => {
 	const driverChannelDetailsList = [] as DriverChannelDetailsWithName[]
 	outputListMock.mockResolvedValue(driverChannelDetailsList)
 
-	afterEach(() => {
-		jest.clearAllMocks()
-	})
-
 	it('calls outputList to do the work', async () => {
 		await expect(ChannelsDriversCommand.run([])).resolves.not.toThrow()
 

--- a/packages/edge/src/__tests__/commands/edge/channels/metainfo.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/channels/metainfo.test.ts
@@ -26,10 +26,6 @@ describe('ChannelsMetaInfoCommand', () => {
 	const listAssignedDriversSpy = jest.spyOn(ChannelsEndpoint.prototype, 'listAssignedDrivers')
 	const getDriverChannelMetaInfoSpy = jest.spyOn(ChannelsEndpoint.prototype, 'getDriverChannelMetaInfo')
 
-	afterEach(() => {
-		jest.clearAllMocks()
-	})
-
 	it('uses outputItemOrList', async () => {
 		await expect(ChannelsMetaInfoCommand.run([])).resolves.not.toThrow()
 

--- a/packages/edge/src/__tests__/commands/edge/drivers.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/drivers.test.ts
@@ -19,10 +19,6 @@ jest.mock('../../../../src/lib/commands/drivers-util')
 describe('DriversCommand', () => {
 	const outputItemOrListMock = jest.mocked(outputItemOrList)
 
-	afterEach(() => {
-		jest.clearAllMocks()
-	})
-
 	it('uses outputItemOrList', async () => {
 		await expect(DriversCommand.run([])).resolves.not.toThrow()
 

--- a/packages/edge/src/__tests__/commands/edge/drivers/default.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/drivers/default.test.ts
@@ -16,10 +16,6 @@ jest.mock('@smartthings/cli-lib', () => {
 jest.mock('../../../../../src/lib/commands/drivers-util')
 
 describe('DriversDefaultCommand', () => {
-	afterEach(() => {
-		jest.clearAllMocks()
-	})
-
 	const outputListMock = jest.mocked(outputList)
 
 	it('uses outputList', async () => {

--- a/packages/edge/src/__tests__/commands/edge/drivers/delete.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/drivers/delete.test.ts
@@ -10,10 +10,6 @@ describe('DriversDeleteCommand', () => {
 	const chooseDriverMock = jest.mocked(chooseDriver).mockResolvedValue('chosen-driver-id')
 	const apiDriversDeleteSpy = jest.spyOn(DriversEndpoint.prototype, 'delete').mockImplementation()
 
-	afterEach(() => {
-		jest.clearAllMocks()
-	})
-
 	it('deletes driver', async () => {
 		await expect(DriversDeleteCommand.run(['cmd-line-driver-id'])).resolves.not.toThrow()
 

--- a/packages/edge/src/__tests__/commands/edge/drivers/install.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/drivers/install.test.ts
@@ -31,10 +31,6 @@ describe('DriversInstallCommand', () => {
 		// empty
 	})
 
-	afterEach(() => {
-		jest.clearAllMocks()
-	})
-
 	it('installs driver and logs message', async () => {
 		await expect(DriversInstallCommand.run([])).resolves.not.toThrow()
 

--- a/packages/edge/src/__tests__/commands/edge/drivers/installed.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/drivers/installed.test.ts
@@ -28,10 +28,6 @@ describe('DriversInstalledCommand', () => {
 	const apiGetInstalledSpy = jest.spyOn(HubdevicesEndpoint.prototype, 'getInstalled').mockResolvedValue(driver1)
 	const outputItemOrListMock = jest.mocked(outputItemOrList)
 
-	afterEach(() => {
-		jest.clearAllMocks()
-	})
-
 	it('uses outputItemOrList', async () => {
 		await expect(DriversInstalledCommand.run([])).resolves.not.toThrow()
 

--- a/packages/edge/src/__tests__/commands/edge/drivers/logcat.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/drivers/logcat.test.ts
@@ -107,10 +107,6 @@ describe('LogCatCommand', () => {
 	})
 	jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
-	afterEach(() => {
-		jest.clearAllMocks()
-	})
-
 	describe('initialization', () => {
 		it('initializes SseCommand correctly', async () => {
 			const initSseSpy = jest.spyOn(SseCommand.prototype, 'init')

--- a/packages/edge/src/__tests__/commands/edge/drivers/package.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/drivers/package.test.ts
@@ -85,10 +85,6 @@ describe('PackageCommand', () => {
 
 	const logSpy = jest.spyOn(PackageCommand.prototype, 'log').mockImplementation()
 
-	afterEach(() => {
-		jest.clearAllMocks()
-	})
-
 	const mockProjectDirectoryProcessing = (): void => {
 		resolveProjectDirNameMock.mockResolvedValueOnce('project dir')
 		jsZipMock.mockReturnValueOnce(mockJSZip)

--- a/packages/edge/src/__tests__/commands/edge/drivers/switch.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/drivers/switch.test.ts
@@ -25,10 +25,6 @@ jest.mock('@smartthings/cli-lib', () => {
 jest.mock('../../../../../src/lib/commands/drivers-util')
 
 describe('DriversSwitchCommand', () => {
-	afterEach(() => {
-		jest.clearAllMocks()
-	})
-
 	const switchDriverSpy = jest.spyOn(HubdevicesEndpoint.prototype, 'switchDriver').mockImplementation()
 	const chooseHubMock = jest.mocked(chooseHub).mockResolvedValue('chosen-hub-id')
 	const chooseDeviceMock = jest.mocked(chooseDevice).mockResolvedValue('chosen-device-id')

--- a/packages/edge/src/__tests__/file-util.test.ts
+++ b/packages/edge/src/__tests__/file-util.test.ts
@@ -25,10 +25,6 @@ jest.mock('js-yaml')
 describe('file-util', () => {
 	const statMock = jest.mocked(fs.promises.stat)
 
-	afterEach(() => {
-		jest.clearAllMocks()
-	})
-
 	describe('fileExists', () => {
 		it('returns true when file exists', async () => {
 			statMock.mockResolvedValue({} as fs.Stats)

--- a/packages/edge/src/__tests__/lib/commands/drivers-util.test.ts
+++ b/packages/edge/src/__tests__/lib/commands/drivers-util.test.ts
@@ -23,10 +23,6 @@ describe('drivers-util', () => {
 	const selectFromListMock = jest.mocked(selectFromList)
 	const stringTranslateToIdMock = jest.mocked(stringTranslateToId)
 
-	afterEach(() => {
-		jest.clearAllMocks()
-	})
-
 	describe('permissionsValue', () => {
 		it('returns none with no permissions at all', () => {
 			expect(permissionsValue({} as EdgeDriver)).toBe('none')

--- a/packages/edge/src/__tests__/lib/commands/drivers/package-util.test.ts
+++ b/packages/edge/src/__tests__/lib/commands/drivers/package-util.test.ts
@@ -36,10 +36,6 @@ describe('package-utils', () => {
 
 	const errorSpy = jest.spyOn(CliUx.ux, 'error').mockImplementation()
 
-	afterEach(() => {
-		jest.clearAllMocks()
-	})
-
 	describe('resolveProjectDirName', () => {
 		it('returns directory from arg if it exists', async () => {
 			isDirMock.mockResolvedValueOnce(true)

--- a/packages/edge/src/__tests__/lib/live-logging.test.ts
+++ b/packages/edge/src/__tests__/lib/live-logging.test.ts
@@ -128,10 +128,6 @@ describe('live-logging', () => {
 			testClient = new LiveLogClient(config)
 		})
 
-		afterEach(() => {
-			jest.clearAllMocks()
-		})
-
 		it('returns log source for all drivers', () => {
 			const sourceURL = testClient.getLogSource()
 			expect(sourceURL).not.toContain('?')


### PR DESCRIPTION
<!-- Describe your pull request. -->

A while back we updated the jest config to automatically clear mocks after each test and removed calls to `clearAllMocks` in the code but we did not do this for the edge plugin. Then, when we merged the edge plugin into the CLI, it acquired this config setting but we did not remove the no-longer-necessary calls to `clearAllMocks`. This PR removes those calls.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
