### PR TITLE
feat: add Modes commands

### DIFF
--- a/.changeset/old-beds-reflect.md
+++ b/.changeset/old-beds-reflect.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": minor
+---
+
+add commands for location modes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -208,6 +208,12 @@ that map to the API spec.
 * [`smartthings locations:create`](#smartthings-locationscreate)
 * [`smartthings locations:delete [ID]`](#smartthings-locationsdelete-id)
 * [`smartthings locations:history [ID]`](#smartthings-locationshistory-id)
+* [`smartthings locations:modes [IDORINDEX]`](#smartthings-locationsmodes-idorindex)
+* [`smartthings locations:modes:create`](#smartthings-locationsmodescreate)
+* [`smartthings locations:modes:delete [ID]`](#smartthings-locationsmodesdelete-id)
+* [`smartthings locations:modes:getcurrent`](#smartthings-locationsmodesgetcurrent)
+* [`smartthings locations:modes:setcurrent [ID]`](#smartthings-locationsmodessetcurrent-id)
+* [`smartthings locations:modes:update [ID]`](#smartthings-locationsmodesupdate-id)
 * [`smartthings locations:rooms [IDORINDEX]`](#smartthings-locationsrooms-idorindex)
 * [`smartthings locations:rooms:create`](#smartthings-locationsroomscreate)
 * [`smartthings locations:rooms:delete [ID]`](#smartthings-locationsroomsdelete-id)
@@ -4108,6 +4114,260 @@ DESCRIPTION
 ```
 
 _See code: [src/commands/locations/history.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.1.3/packages/cli/src/commands/locations/history.ts)_
+
+## `smartthings locations:modes [IDORINDEX]`
+
+list modes or get information for a specific mode
+
+```
+USAGE
+  $ smartthings locations:modes [IDORINDEX] [-h] [-p <value>] [-t <value>] [--language <value>] [-l <value>] [-v]
+    [-j] [-y] [-o <value>]
+
+ARGUMENTS
+  IDORINDEX  mode UUID or index
+
+FLAGS
+  -l, --location=<UUID>  a specific location to query
+  -v, --verbose          include location name in output
+
+COMMON FLAGS
+  -h, --help             Show CLI help.
+  -j, --json             use JSON format of input and/or output
+  -o, --output=<value>   specify output file
+  -p, --profile=<value>  [default: default] configuration profile
+  -t, --token=<value>    the auth token to use
+  -y, --yaml             use YAML format of input and/or output
+  --language=<value>     ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+
+DESCRIPTION
+  list modes or get information for a specific mode
+
+EXAMPLES
+  list all modes in your location(s)
+
+    $ smartthings locations:modes
+
+  get details of the third mode in the list retrieved by running "smartthings locations:modes"
+
+    $ smartthings locations:modes 3
+
+  get details of a mode by its id
+
+    $ smartthings locations:modes 636169e4-8b9f-4438-a941-953b0d617231
+
+  include location name and ID in the output
+
+    $ smartthings locations:modes --verbose
+
+  list all modes in a particular location
+
+    $ smartthings locations:modes --location=5dfd6626-ab1d-42da-bb76-90def3153998
+```
+
+_See code: [src/commands/locations/modes.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.1.3/packages/cli/src/commands/locations/modes.ts)_
+
+## `smartthings locations:modes:create`
+
+create a mode
+
+```
+USAGE
+  $ smartthings locations:modes:create [-h] [-p <value>] [-t <value>] [--language <value>] [-j] [-y] [-i <value>] [-o
+    <value>] [-d] [-l <value>]
+
+FLAGS
+  -d, --dry-run          produce JSON but don't actually submit
+  -l, --location=<UUID>  a specific location to create the mode in
+
+COMMON FLAGS
+  -h, --help             Show CLI help.
+  -i, --input=<value>    specify input file
+  -j, --json             use JSON format of input and/or output
+  -o, --output=<value>   specify output file
+  -p, --profile=<value>  [default: default] configuration profile
+  -t, --token=<value>    the auth token to use
+  -y, --yaml             use YAML format of input and/or output
+  --language=<value>     ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+
+DESCRIPTION
+  create a mode
+
+EXAMPLES
+  create a new mode using the data in new-data.json
+
+    $ smartthings locations:modes:create -i=new-data.json
+
+  create a new mode in a specified location using the data in new-data.json
+
+    $ smartthings locations:modes:create --location=5dfd6626-ab1d-42da-bb76-90def3153998 -i=new-data.json
+```
+
+_See code: [src/commands/locations/modes/create.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.1.3/packages/cli/src/commands/locations/modes/create.ts)_
+
+## `smartthings locations:modes:delete [ID]`
+
+delete a mode
+
+```
+USAGE
+  $ smartthings locations:modes:delete [ID] [-h] [-p <value>] [-t <value>] [--language <value>] [-l <value>]
+
+ARGUMENTS
+  ID  mode UUID
+
+FLAGS
+  -l, --location=<UUID>  a specific location to query
+
+COMMON FLAGS
+  -h, --help             Show CLI help.
+  -p, --profile=<value>  [default: default] configuration profile
+  -t, --token=<value>    the auth token to use
+  --language=<value>     ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+
+DESCRIPTION
+  delete a mode
+
+EXAMPLES
+  select a mode from a list of all modes and delete it
+
+    $ smartthings locations:modes:delete
+
+  select a mode from a list of modes in a specified location and delete it
+
+    $ smartthings locations:modes:delete --location=5dfd6626-ab1d-42da-bb76-90def3153998
+
+  delete a specified mode
+
+    $ smartthings locations:modes:delete 636169e4-8b9f-4438-a941-953b0d617231
+```
+
+_See code: [src/commands/locations/modes/delete.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.1.3/packages/cli/src/commands/locations/modes/delete.ts)_
+
+## `smartthings locations:modes:getcurrent`
+
+get details of current mode
+
+```
+USAGE
+  $ smartthings locations:modes:getcurrent [-h] [-p <value>] [-t <value>] [--language <value>] [-l <value>] [-v] [-j] [-y] [-o
+    <value>]
+
+FLAGS
+  -l, --location=<UUID>  a specific location to query
+  -v, --verbose          include location name in output
+
+COMMON FLAGS
+  -h, --help             Show CLI help.
+  -j, --json             use JSON format of input and/or output
+  -o, --output=<value>   specify output file
+  -p, --profile=<value>  [default: default] configuration profile
+  -t, --token=<value>    the auth token to use
+  -y, --yaml             use YAML format of input and/or output
+  --language=<value>     ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+
+DESCRIPTION
+  get details of current mode
+
+EXAMPLES
+  get details of current mode
+
+    $ smartthings locations:modes:getcurrent
+
+  include location name and ID in the output
+
+    $ smartthings locations:modes:getcurrent --verbose
+
+  get the current mode for a specified location
+
+    $ smartthings locations:modes:getcurrent --location=5dfd6626-ab1d-42da-bb76-90def3153998
+```
+
+_See code: [src/commands/locations/modes/getcurrent.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.1.3/packages/cli/src/commands/locations/modes/getcurrent.ts)_
+
+## `smartthings locations:modes:setcurrent [ID]`
+
+set the current mode
+
+```
+USAGE
+  $ smartthings locations:modes:setcurrent [ID] [-h] [-p <value>] [-t <value>] [--language <value>] [-l <value>]
+
+ARGUMENTS
+  ID  mode UUID
+
+FLAGS
+  -l, --location=<UUID>  a specific location to query
+
+COMMON FLAGS
+  -h, --help             Show CLI help.
+  -p, --profile=<value>  [default: default] configuration profile
+  -t, --token=<value>    the auth token to use
+  --language=<value>     ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+
+DESCRIPTION
+  set the current mode
+
+EXAMPLES
+  select a mode from a list of all modes and set it to be current for its location
+
+    $ smartthings locations:modes:setcurrent
+
+  select a mode from a list of modes in a specified location and set it to be current
+
+    $ smartthings locations:modes:setcurrent --location=5dfd6626-ab1d-42da-bb76-90def3153998
+
+  set the specified mode to be current for its location
+
+    $ smartthings locations:modes:setcurrent 636169e4-8b9f-4438-a941-953b0d617231
+```
+
+_See code: [src/commands/locations/modes/setcurrent.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.1.3/packages/cli/src/commands/locations/modes/setcurrent.ts)_
+
+## `smartthings locations:modes:update [ID]`
+
+update a mode
+
+```
+USAGE
+  $ smartthings locations:modes:update [ID] [-h] [-p <value>] [-t <value>] [--language <value>] [-j] [-y] [-i <value>] [-o
+    <value>] [-d] [-l <value>]
+
+ARGUMENTS
+  ID  mode UUID
+
+FLAGS
+  -d, --dry-run          produce JSON but don't actually submit
+  -l, --location=<UUID>  a specific location to query
+
+COMMON FLAGS
+  -h, --help             Show CLI help.
+  -i, --input=<value>    specify input file
+  -j, --json             use JSON format of input and/or output
+  -o, --output=<value>   specify output file
+  -p, --profile=<value>  [default: default] configuration profile
+  -t, --token=<value>    the auth token to use
+  -y, --yaml             use YAML format of input and/or output
+  --language=<value>     ISO language code or "NONE" to not specify a language. Defaults to the OS locale
+
+DESCRIPTION
+  update a mode
+
+EXAMPLES
+  select a mode from a list of all modes and update it using the data in new-data.json
+
+    $ smartthings locations:modes:update -i=new-data.json
+
+  select a mode from a list of modes in a specified location and update it using the data in new-data.json
+
+    $ smartthings locations:modes:update --location=5dfd6626-ab1d-42da-bb76-90def3153998 -i=new-data.json
+
+  update a specified mode using the data in new-data.json
+
+    $ smartthings locations:modes:update 636169e4-8b9f-4438-a941-953b0d617231 -i=new-data.json
+```
+
+_See code: [src/commands/locations/modes/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.1.3/packages/cli/src/commands/locations/modes/update.ts)_
 
 ## `smartthings locations:rooms [IDORINDEX]`
 

--- a/packages/cli/src/__tests__/lib/commands/locations/modes-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/locations/modes-util.test.ts
@@ -1,0 +1,148 @@
+import { Config } from '@oclif/core'
+
+import { Location, LocationsEndpoint, NoOpAuthenticator, Mode, ModesEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
+
+import { APICommand, selectFromList } from '@smartthings/cli-lib'
+import * as locationsModule from '../../../../commands/locations'
+
+import { getModesByLocation, chooseMode } from '../../../../lib/commands/locations/modes-util'
+import * as modesUtil from '../../../../lib/commands/locations/modes-util'
+
+
+describe('modes-util', () => {
+	const locationId = 'locationId'
+	const locationName = 'test location'
+	const modeId = 'id'
+	const modeName = 'name'
+
+	describe('getModesByLocation', () => {
+		const testClient = new SmartThingsClient(new NoOpAuthenticator)
+		const listModesSpy = jest.spyOn(ModesEndpoint.prototype, 'list').mockImplementation()
+		const getLocationsSpy = jest.spyOn(LocationsEndpoint.prototype, 'get').mockImplementation()
+		const listLocationsSpy = jest.spyOn(LocationsEndpoint.prototype, 'list').mockImplementation()
+
+		it('throws error when no locations are found', async () => {
+			listLocationsSpy.mockResolvedValueOnce([])
+			const forbiddenError = new Error('Request failed with status code 403')
+			getLocationsSpy.mockRejectedValueOnce(forbiddenError)
+
+			await expect(getModesByLocation(testClient)).rejects.toThrow('could not find any locations')
+			await expect(getModesByLocation(testClient, locationId)).rejects.toThrow(forbiddenError)
+		})
+
+		it('returns modes with location ID and name added', async () => {
+			const location: Location = {
+				locationId,
+				name: locationName,
+				timeZoneId: '',
+				backgroundImage: '',
+				countryCode: '',
+				temperatureScale: 'C',
+			}
+			const modes: Mode[] = [
+				{
+					name: modeName,
+					id: modeId,
+					label: 'modeLabel',
+				},
+			]
+
+			getLocationsSpy.mockResolvedValueOnce(location)
+			listModesSpy.mockResolvedValueOnce(modes)
+
+			const modesWithLocations = await getModesByLocation(testClient, locationId)
+
+			expect(modesWithLocations[0]).toEqual(expect.objectContaining(modes[0]))
+			expect(modesWithLocations[0].locationId).toBe(locationId)
+			expect(modesWithLocations[0].location).toBe(locationName)
+		})
+	})
+
+	describe('chooseMode', () => {
+		const getModesByLocationSpy = jest.spyOn(modesUtil, 'getModesByLocation')
+		const chooseLocationSpy = jest.spyOn(locationsModule, 'chooseLocation')
+		class MockCommand extends APICommand<typeof MockCommand.flags> {
+			async run(): Promise<void> {
+				// eslint-disable-line @typescript-eslint/no-empty-function
+			}
+		}
+		const command = new MockCommand([], new Config({ root: '' }))
+		const mockSelectFromList = jest.mocked(selectFromList)
+
+		beforeAll(() => {
+			getModesByLocationSpy.mockResolvedValue([])
+			mockSelectFromList.mockResolvedValue(modeId)
+		})
+
+		it('throws error when mode not found', async () => {
+			await expect(modesUtil.chooseMode(command)).rejects.toThrow('could not find mode')
+
+			const modesWithLocation = [{
+				id: 'notFound',
+				locationId: locationId,
+				name: 'test',
+			}]
+			getModesByLocationSpy.mockResolvedValueOnce(modesWithLocation)
+
+			await expect(chooseMode(command)).rejects.toThrow('could not find mode')
+		})
+
+		it('throws error when locationId is missing', async () => {
+			const modesWithLocation = [{
+				id: modeId,
+				name: 'test',
+			}]
+			getModesByLocationSpy.mockResolvedValueOnce(modesWithLocation)
+
+			await expect(chooseMode(command)).rejects.toThrow('could not determine location id for mode')
+		})
+
+		it('returns mode tuple when mode is found', async () => {
+			const modesWithLocation = [{
+				id: modeId,
+				locationId: locationId,
+				name: 'test',
+			},
+			{
+				id: 'mode2',
+				locationId: locationId,
+				name: 'mode2',
+			}]
+
+			getModesByLocationSpy.mockResolvedValueOnce(modesWithLocation)
+
+			await expect(chooseMode(command, locationId)).resolves.toEqual([modeId, locationId])
+		})
+
+		it('calls selectFromList with correct config', async () => {
+			await expect(chooseMode(command, undefined, modeId)).rejects.toThrow('could not find mode')
+
+			expect(mockSelectFromList).toBeCalledWith(
+				expect.anything(),
+				expect.objectContaining({
+					itemName: 'mode',
+					primaryKeyName: 'id',
+					sortKeyName: 'label',
+					listTableFieldDefinitions: expect.anything(),
+				}),
+				expect.objectContaining({ preselectedId: modeId }),
+			)
+		})
+
+		it('passes on locationId when retrieving modes', async () => {
+			chooseLocationSpy.mockResolvedValueOnce('chosenLocation')
+			await expect(chooseMode(command)).rejects.toThrow('could not find mode')
+
+			expect(chooseLocationSpy).toBeCalledWith(command, undefined, true)
+			expect(getModesByLocationSpy).toBeCalledWith(expect.any(SmartThingsClient), 'chosenLocation')
+
+			getModesByLocationSpy.mockClear
+			chooseLocationSpy.mockResolvedValueOnce(locationId)
+
+			await expect(chooseMode(command, locationId)).rejects.toThrow('could not find mode')
+
+			expect(chooseLocationSpy).toBeCalledWith(command, locationId, true)
+			expect(getModesByLocationSpy).toBeCalledWith(expect.any(SmartThingsClient), locationId)
+		})
+	})
+})

--- a/packages/cli/src/commands/locations/modes.ts
+++ b/packages/cli/src/commands/locations/modes.ts
@@ -1,0 +1,67 @@
+import { Flags } from '@oclif/core'
+
+import { Mode } from '@smartthings/core-sdk'
+
+import { APICommand, OutputItemOrListConfig, outputItemOrList, WithNamedLocation } from '@smartthings/cli-lib'
+
+import { getModesByLocation, tableFieldDefinitions, tableFieldDefinitionsWithLocationName } from '../../lib/commands/locations/modes-util'
+
+
+export default class ModeCommand extends APICommand<typeof ModeCommand.flags> {
+	static description = 'list modes or get information for a specific mode'
+
+	static flags = {
+		...APICommand.flags,
+		location: Flags.string({
+			char: 'l',
+			description: 'a specific location to query',
+			helpValue: '<UUID>',
+		}),
+		verbose: Flags.boolean({
+			description: 'include location name in output',
+			char: 'v',
+		}),
+		...outputItemOrList.flags,
+	}
+
+	static args = [{
+		name: 'idOrIndex',
+		description: 'mode UUID or index',
+	}]
+
+	static examples = [
+		{ description: 'list all modes in your location(s)', command: 'smartthings locations:modes' },
+		{ description: 'get details of the third mode in the list retrieved by running "smartthings locations:modes"', command: 'smartthings locations:modes 3' },
+		{ description: 'get details of a mode by its id', command: 'smartthings locations:modes 636169e4-8b9f-4438-a941-953b0d617231' },
+		{ description: 'include location name and ID in the output', command: 'smartthings locations:modes --verbose' },
+		{ description: 'list all modes in a particular location', command: 'smartthings locations:modes --location=5dfd6626-ab1d-42da-bb76-90def3153998' },
+	]
+
+	async run(): Promise<void> {
+		const config: OutputItemOrListConfig<Mode & WithNamedLocation> = {
+			primaryKeyName: 'id',
+			sortKeyName: 'label',
+			listTableFieldDefinitions: tableFieldDefinitions,
+			tableFieldDefinitions: tableFieldDefinitions,
+		}
+		if (this.flags.verbose) {
+			config.listTableFieldDefinitions = tableFieldDefinitionsWithLocationName
+			config.tableFieldDefinitions = tableFieldDefinitionsWithLocationName
+		}
+		const modes = await getModesByLocation(this.client, this.flags.location)
+		await outputItemOrList(this, config, this.args.idOrIndex,
+			async () => modes,
+			async id => {
+				const mode = modes.find(mode => mode.id === id)
+				if (!mode) {
+					throw Error(`could not find mode with id ${id}`)
+				}
+				if (this.flags.verbose) {
+					return mode
+				}
+				// If we aren't using `verbose` flag, get the raw mode again
+				// so there aren't extra fields in JSON/YAML output
+				return this.client.modes.get(id, mode.locationId)
+			})
+	}
+}

--- a/packages/cli/src/commands/locations/modes/create.ts
+++ b/packages/cli/src/commands/locations/modes/create.ts
@@ -1,0 +1,32 @@
+import { Flags } from '@oclif/core'
+import { Mode, ModeRequest } from '@smartthings/core-sdk'
+import { APICommand, CommonOutputProducer, inputAndOutputItem } from '@smartthings/cli-lib'
+import { chooseLocation } from '../../locations'
+import { tableFieldDefinitions } from '../../../lib/commands/locations/modes-util'
+
+
+export default class ModesCreateCommand extends APICommand<typeof ModesCreateCommand.flags> {
+	static description = 'create a mode'
+
+	static flags = {
+		...APICommand.flags,
+		...inputAndOutputItem.flags,
+		location: Flags.string({
+			char: 'l',
+			description: 'a specific location to create the mode in',
+			helpValue: '<UUID>',
+		}),
+	}
+
+	static examples = [
+		{ description: 'create a new mode using the data in new-data.json', command: 'smartthings locations:modes:create -i=new-data.json' },
+		{ description: 'create a new mode in a specified location using the data in new-data.json', command: 'smartthings locations:modes:create --location=5dfd6626-ab1d-42da-bb76-90def3153998 -i=new-data.json' },
+	]
+
+	async run(): Promise<void> {
+		const locationId = await chooseLocation(this, this.flags.location)
+		const config: CommonOutputProducer<Mode> = { tableFieldDefinitions }
+		await inputAndOutputItem<ModeRequest, Mode>(this, config,
+			(_, mode) => this.client.modes.create(mode, locationId))
+	}
+}

--- a/packages/cli/src/commands/locations/modes/delete.ts
+++ b/packages/cli/src/commands/locations/modes/delete.ts
@@ -1,0 +1,39 @@
+import { Flags } from '@oclif/core'
+import { APICommand } from '@smartthings/cli-lib'
+import { chooseMode } from '../../../lib/commands/locations/modes-util'
+
+
+export default class ModesDeleteCommand extends APICommand<typeof ModesDeleteCommand.flags> {
+	static description = 'delete a mode'
+
+	static flags = {
+		...APICommand.flags,
+		location: Flags.string({
+			char: 'l',
+			description: 'a specific location to query',
+			helpValue: '<UUID>',
+		}),
+	}
+
+	static args = [{
+		name: 'id',
+		description: 'mode UUID',
+	}]
+
+	static examples = [
+		{ description: 'select a mode from a list of all modes and delete it', command: 'smartthings locations:modes:delete' },
+		{ description: 'select a mode from a list of modes in a specified location and delete it', command: 'smartthings locations:modes:delete --location=5dfd6626-ab1d-42da-bb76-90def3153998' },
+		{ description: 'delete a specified mode', command: 'smartthings locations:modes:delete 636169e4-8b9f-4438-a941-953b0d617231' },
+	]
+
+	async run(): Promise<void> {
+		const [modeId, locationId] = await chooseMode(this, this.flags.location, this.args.id)
+
+		const mode = await this.client.modes.get(modeId, locationId)
+		const modeString = mode.label ?? mode.name ?? 'unnamed mode'
+
+		await this.client.modes.delete(modeId, locationId)
+
+		this.log(`${modeString} (${mode.id}) deleted`)
+	}
+}

--- a/packages/cli/src/commands/locations/modes/getcurrent.ts
+++ b/packages/cli/src/commands/locations/modes/getcurrent.ts
@@ -1,0 +1,51 @@
+import { Flags } from '@oclif/core'
+
+import { Mode } from '@smartthings/core-sdk'
+
+import { APICommand, OutputItemOrListConfig, outputItemOrList, WithNamedLocation, formatAndWriteItem, withLocation } from '@smartthings/cli-lib'
+
+import { chooseLocation } from '../../locations'
+
+import { tableFieldDefinitions, tableFieldDefinitionsWithLocationName } from '../../../lib/commands/locations/modes-util'
+
+
+export default class GetCurrentModeCommand extends APICommand<typeof GetCurrentModeCommand.flags> {
+	static description = 'get details of current mode'
+
+	static flags = {
+		...APICommand.flags,
+		location: Flags.string({
+			char: 'l',
+			description: 'a specific location to query',
+			helpValue: '<UUID>',
+		}),
+		verbose: Flags.boolean({
+			description: 'include location name in output',
+			char: 'v',
+		}),
+		...outputItemOrList.flags,
+	}
+
+	static examples = [
+		{ description: 'get details of current mode', command: 'smartthings locations:modes:getcurrent' },
+		{ description: 'include location name and ID in the output', command: 'smartthings locations:modes:getcurrent --verbose' },
+		{ description: 'get the current mode for a specified location', command: 'smartthings locations:modes:getcurrent --location=5dfd6626-ab1d-42da-bb76-90def3153998' },
+	]
+
+	async run(): Promise<void> {
+		const config: OutputItemOrListConfig<Mode & WithNamedLocation> = {
+			primaryKeyName: 'id',
+			sortKeyName: 'label',
+			listTableFieldDefinitions: tableFieldDefinitions,
+			tableFieldDefinitions: tableFieldDefinitions,
+		}
+		if (this.flags.verbose) {
+			config.listTableFieldDefinitions = tableFieldDefinitionsWithLocationName
+			config.tableFieldDefinitions = tableFieldDefinitionsWithLocationName
+		}
+		const locationId = await chooseLocation(this, this.flags.location, true)
+		const currentMode = await this.client.modes.getCurrent(locationId)
+		const mode = this.flags.verbose ? await withLocation(this.client, { ...currentMode, locationId }) : currentMode
+		await formatAndWriteItem(this, config, mode)
+	}
+}

--- a/packages/cli/src/commands/locations/modes/setcurrent.ts
+++ b/packages/cli/src/commands/locations/modes/setcurrent.ts
@@ -1,0 +1,39 @@
+import { Flags } from '@oclif/core'
+import { APICommand } from '@smartthings/cli-lib'
+import { chooseMode } from '../../../lib/commands/locations/modes-util'
+
+
+export default class SetCurrentModeCommand extends APICommand<typeof SetCurrentModeCommand.flags> {
+	static description = 'set the current mode'
+
+	static flags = {
+		...APICommand.flags,
+		location: Flags.string({
+			char: 'l',
+			description: 'a specific location to query',
+			helpValue: '<UUID>',
+		}),
+	}
+
+	static args = [{
+		name: 'id',
+		description: 'mode UUID',
+	}]
+
+	static examples = [
+		{ description: 'select a mode from a list of all modes and set it to be current for its location', command: 'smartthings locations:modes:setcurrent' },
+		{ description: 'select a mode from a list of modes in a specified location and set it to be current', command: 'smartthings locations:modes:setcurrent --location=5dfd6626-ab1d-42da-bb76-90def3153998' },
+		{ description: 'set the specified mode to be current for its location', command: 'smartthings locations:modes:setcurrent 636169e4-8b9f-4438-a941-953b0d617231' },
+	]
+
+	async run(): Promise<void> {
+		const [modeId, locationId] = await chooseMode(this, this.flags.location, this.args.id)
+		await this.client.modes.setCurrent(modeId, locationId)
+
+		const mode = await this.client.modes.get(modeId, locationId)
+		const modeString = mode.label ?? mode.name ?? 'unnamed mode'
+		const location = await this.client.locations.get(locationId)
+
+		this.log(`current mode for ${location.name} (${location.locationId}) set to ${modeString} (${mode.id})`)
+	}
+}

--- a/packages/cli/src/commands/locations/modes/update.ts
+++ b/packages/cli/src/commands/locations/modes/update.ts
@@ -1,0 +1,37 @@
+import { Flags } from '@oclif/core'
+import { Mode, ModeRequest } from '@smartthings/core-sdk'
+import { APICommand, CommonOutputProducer, inputAndOutputItem } from '@smartthings/cli-lib'
+import { chooseMode, tableFieldDefinitions } from '../../../lib/commands/locations/modes-util'
+
+
+export default class ModesUpdateCommand extends APICommand<typeof ModesUpdateCommand.flags> {
+	static description = 'update a mode'
+
+	static flags = {
+		...APICommand.flags,
+		...inputAndOutputItem.flags,
+		location: Flags.string({
+			char: 'l',
+			description: 'a specific location to query',
+			helpValue: '<UUID>',
+		}),
+	}
+
+	static args = [{
+		name: 'id',
+		description: 'mode UUID',
+	}]
+
+	static examples = [
+		{ description: 'select a mode from a list of all modes and update it using the data in new-data.json', command: 'smartthings locations:modes:update -i=new-data.json' },
+		{ description: 'select a mode from a list of modes in a specified location and update it using the data in new-data.json', command: 'smartthings locations:modes:update --location=5dfd6626-ab1d-42da-bb76-90def3153998 -i=new-data.json' },
+		{ description: 'update a specified mode using the data in new-data.json', command: 'smartthings locations:modes:update 636169e4-8b9f-4438-a941-953b0d617231 -i=new-data.json' },
+	]
+
+	async run(): Promise<void> {
+		const [modeId, locationId] = await chooseMode(this, this.flags.location, this.args.id)
+		const config: CommonOutputProducer<Mode> = { tableFieldDefinitions }
+		await inputAndOutputItem<ModeRequest, Mode>(this, config,
+			(_, data) => this.client.modes.update(modeId, data, locationId))
+	}
+}

--- a/packages/cli/src/lib/commands/locations/modes-util.ts
+++ b/packages/cli/src/lib/commands/locations/modes-util.ts
@@ -1,0 +1,53 @@
+import { Errors } from '@oclif/core'
+
+import { Mode, SmartThingsClient } from '@smartthings/core-sdk'
+
+import * as modesUtil from './modes-util'
+import { APICommand, selectFromList, SelectFromListConfig, TableFieldDefinition, WithNamedLocation } from '@smartthings/cli-lib'
+import { chooseLocation } from '../../../commands/locations'
+
+
+export const tableFieldDefinitions: TableFieldDefinition<Mode>[] = ['label', 'id', 'name' ]
+export const tableFieldDefinitionsWithLocationName: TableFieldDefinition<Mode & WithNamedLocation>[] = ['label', 'id', 'name', 'location', 'locationId' ]
+
+export async function getModesByLocation(client: SmartThingsClient, locationId?: string): Promise<(Mode & WithNamedLocation)[]> {
+	const locations = locationId ? [await client.locations.get(locationId)] : await client.locations.list()
+
+	if (!locations || locations.length == 0) {
+		throw new Errors.CLIError('could not find any locations for your account. Perhaps ' +
+			"you haven't created any locations yet.")
+	}
+
+	return (await Promise.all(locations.map(async location => {
+		const locationModes = await client.modes.list(location.locationId)
+		return locationModes.map(mode => ({ ...mode, locationId: location.locationId, location: location.name }) )
+	}))).flat()
+}
+
+export async function chooseMode(command: APICommand<typeof APICommand.flags>, locationId?: string, preselectedId?: string, autoChoose?: boolean): Promise<[string, string]> {
+	// ask user to choose a location, if appropriate, so they aren't mixed together in the modes table
+	if (!preselectedId) {
+		locationId = await chooseLocation(command, locationId, true)
+	}
+	const modes = await modesUtil.getModesByLocation(command.client, locationId)
+
+	const config: SelectFromListConfig<Mode & WithNamedLocation> = {
+		itemName: 'mode',
+		primaryKeyName: 'id',
+		sortKeyName: 'label',
+		listTableFieldDefinitions: tableFieldDefinitions,
+	}
+	const modeId = await selectFromList(command, config, {
+		preselectedId,
+		autoChoose,
+		listItems: async () => modes,
+	})
+	const mode = modes.find(mode => mode.id === modeId)
+	if (!mode) {
+		throw new Errors.CLIError(`could not find mode with id ${modeId}`)
+	}
+	if (!mode.locationId) {
+		throw new Errors.CLIError(`could not determine location id for mode ${modeId}`)
+	}
+	return [modeId, mode.locationId]
+}


### PR DESCRIPTION
Add commands for working with location modes:
- list/get
- create
- update
- delete
- get current
- set current

## Checklist

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
