### PR TITLE
feat: add support for Q&A mode to apps:aouth:generate command

### DIFF
--- a/.changeset/silent-mirrors-carry.md
+++ b/.changeset/silent-mirrors-carry.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": minor
+---
+
+add Q&A mode to apps:oauth:generate command

--- a/packages/cli/src/__tests__/commands/apps/oauth/generate.test.ts
+++ b/packages/cli/src/__tests__/commands/apps/oauth/generate.test.ts
@@ -1,4 +1,4 @@
-import { inputAndOutputItem } from '@smartthings/cli-lib'
+import { inputAndOutputItem, IOFormat } from '@smartthings/cli-lib'
 import { GenerateAppOAuthRequest, AppsEndpoint } from '@smartthings/core-sdk'
 import AppOauthGenerateCommand from '../../../../commands/apps/oauth/generate'
 import { chooseApp } from '../../../../lib/commands/apps-util'
@@ -30,6 +30,7 @@ describe('AppOauthGenerateCommand', () => {
 				tableFieldDefinitions: expect.arrayContaining(['oauthClientId', 'oauthClientSecret']),
 			}),
 			expect.any(Function),
+			expect.objectContaining({ ioFormat: IOFormat.COMMON }),
 		)
 	})
 

--- a/packages/cli/src/commands/apps/create.ts
+++ b/packages/cli/src/commands/apps/create.ts
@@ -7,7 +7,6 @@ import { AppClassification, AppCreateRequest, AppCreationResponse, AppType, Prin
 import {
 	APICommand,
 	arrayDef,
-	checkboxDef,
 	computedDef,
 	createFromUserInput,
 	httpsURLValidate,
@@ -24,7 +23,7 @@ import {
 } from '@smartthings/cli-lib'
 
 import { addPermission } from '../../lib/aws-utils'
-import { tableFieldDefinitions } from '../../lib/commands/apps-util'
+import { oauthAppScopeDef, tableFieldDefinitions } from '../../lib/commands/apps-util'
 
 
 const appNameDef = computedDef((context?: unknown[]): string => {
@@ -45,24 +44,6 @@ const clientNameDef = computedDef((context?: unknown[]): string => {
 	return (context[1] as Pick<AppCreateRequest, 'displayName'>).displayName
 })
 
-const availableScopes = [
-	'r:devices:*',
-	'w:devices:*',
-	'x:devices:*',
-	'r:hubs:*',
-	'r:locations:*',
-	'w:locations:*',
-	'x:locations:*',
-	'r:scenes:*',
-	'x:scenes:*',
-	'r:rules:*',
-	'w:rules:*',
-	'r:installedapps',
-	'w:installedapps',
-]
-
-const scopeDef = checkboxDef<string>('Scopes', availableScopes)
-
 const oauthAppCreateRequestInputDefinition = objectDef<AppCreateRequest>('OAuth-In SmartApp', {
 	displayName: stringDef('Display Name', stringValidateFn({ maxLength: 75 })),
 	description: stringDef('Description', stringValidateFn({ maxLength: 250 })),
@@ -77,7 +58,7 @@ const oauthAppCreateRequestInputDefinition = objectDef<AppCreateRequest>('OAuth-
 	principalType: staticDef(PrincipalType.LOCATION),
 	oauth: objectDef('OAuth', {
 		clientName: clientNameDef,
-		scope: scopeDef,
+		scope: oauthAppScopeDef,
 		redirectUris: arrayDef(
 			'Redirect URIs',
 			stringDef('Redirect URI', localhostOrHTTPSValidate),

--- a/packages/cli/src/lib/commands/apps-util.ts
+++ b/packages/cli/src/lib/commands/apps-util.ts
@@ -2,6 +2,7 @@ import { AppListOptions, AppOAuthRequest, AppResponse, AppSettingsResponse, Page
 
 import {
 	APICommand,
+	checkboxDef,
 	ChooseOptions,
 	chooseOptionsWithDefaults,
 	selectFromList,
@@ -85,3 +86,21 @@ export const shortARNorURL = (app: PagedApp & Partial<AppResponse>): string => {
 
 	return uri.length < 96 ? uri : uri.slice(0, 95) + '...'
 }
+
+const availableScopes = [
+	'r:devices:*',
+	'w:devices:*',
+	'x:devices:*',
+	'r:hubs:*',
+	'r:locations:*',
+	'w:locations:*',
+	'x:locations:*',
+	'r:scenes:*',
+	'x:scenes:*',
+	'r:rules:*',
+	'w:rules:*',
+	'r:installedapps',
+	'w:installedapps',
+]
+
+export const oauthAppScopeDef = checkboxDef<string>('Scopes', availableScopes)

--- a/packages/lib/src/item-input/defs.ts
+++ b/packages/lib/src/item-input/defs.ts
@@ -83,5 +83,8 @@ export const finishAction = Symbol('finish')
 export type FinishAction = typeof finishAction
 export const finishOption = (name: string): DistinctChoice => ({ name: `Finish editing ${name}.`, value: finishAction })
 
+export const previewJSONAction = Symbol('previewJSON')
+export const previewYAMLAction = Symbol('previewYAML')
+
 export const maxItemValueLength = 60
 export const inquirerPageSize = 20


### PR DESCRIPTION
<!-- Describe your pull request. -->

* Added Q & A mode to `apps:oauth:generate` command.
* Since this is the first "update" style Q & A command, added `updateFromUserInput` function to `item-input/command-helpers.ts`.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
