### PR TITLE
fix: make icon optional in apps:create Q&A mode

### DIFF
--- a/.changeset/shy-balloons-unite.md
+++ b/.changeset/shy-balloons-unite.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+make icon optional in apps:create command

--- a/packages/cli/src/commands/apps/create.ts
+++ b/packages/cli/src/commands/apps/create.ts
@@ -71,7 +71,7 @@ const oauthAppCreateRequestInputDefinition = objectDef<AppCreateRequest>('OAuth-
 	classifications: staticDef([AppClassification.CONNECTED_SERVICE]),
 	singleInstance: staticDef(true),
 	iconImage: objectDef('Icon Image', {
-		url: stringDef('Icon Image URL', httpsURLValidate),
+		url: optionalStringDef('Icon Image URL', httpsURLValidate),
 	}),
 	apiOnly: objectDef('API Only', { targetUrl: optionalStringDef('Target URL', httpsURLValidate) }),
 	principalType: staticDef(PrincipalType.LOCATION),


### PR DESCRIPTION
<!-- Describe your pull request. -->

* Minor fix to make the icon URL optional in the Q&A create mode.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
