### PR TITLE
feat: support Q&A input for apps and app OAuth data

### DIFF
--- a/.changeset/six-pants-press.md
+++ b/.changeset/six-pants-press.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+support Q&A input for apps and app OAuth data

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -551,13 +551,17 @@ DESCRIPTION
   https://developer.smartthings.com/docs/api/public/#operation/updateAppOauth
 
 EXAMPLES
+  prompt for an app and update its OAuth settings interactively"
+
+    $ smartthings apps:oauth:update
+
+  prompt for an app and update its OAuth settings using the data in "oauth-settings.json"
+
+    $ smartthings apps:oauth:update -i oauth-settings.json
+
   update the OAuth settings for the app with the given id using the data in "oauth-settings.json"
 
     $ smartthings apps:oauth:update 392bcb11-e251-44f3-b58b-17f93015f3aa -i oauth-settings.json
-
-  ask for the ID of an app to update and then update it using the data in "oauth-settings.json"
-
-    $ smartthings apps:oauth:update -i oauth-settings.json
 ```
 
 _See code: [src/commands/apps/oauth/update.ts](https://github.com/SmartThingsCommunity/smartthings-cli/blob/@smartthings/cli@1.2.0/packages/cli/src/commands/apps/oauth/update.ts)_
@@ -712,14 +716,20 @@ COMMON FLAGS
 DESCRIPTION
   update the settings of the app
 
+  See apps:oauth:update and apps:oauth:generate for updating oauth-related data.
+
   For API information, see:
 
   https://developer.smartthings.com/docs/api/public/#operation/updateApp
 
 EXAMPLES
-  ask for the ID of an app and update it using the data in "my-app.json"
+  prompt for an app and edit it interactively
 
-    $ smartthings apps:update -i  my-app.json
+    $ smartthings apps:update
+
+  prompt for an app and update it using the data in "my-app.json"
+
+    $ smartthings apps:update -i my-app.json
 
   update the app with the given id using the data in "my-app.json"
 

--- a/packages/cli/src/__tests__/commands/apps/update.test.ts
+++ b/packages/cli/src/__tests__/commands/apps/update.test.ts
@@ -1,4 +1,4 @@
-import { inputAndOutputItem } from '@smartthings/cli-lib'
+import { inputAndOutputItem, IOFormat } from '@smartthings/cli-lib'
 import { AppUpdateRequest, AppsEndpoint } from '@smartthings/core-sdk'
 import AppUpdateCommand from '../../../commands/apps/update'
 import { chooseApp, tableFieldDefinitions } from '../../../lib/commands/apps-util'
@@ -38,6 +38,11 @@ describe('AppUpdateCommand', () => {
 				tableFieldDefinitions,
 			}),
 			expect.any(Function),
+			{
+				ioFormat: IOFormat.COMMON,
+				hasInput: expect.any(Function),
+				read: expect.any(Function),
+			},
 		)
 	})
 

--- a/packages/cli/src/commands/apps/create.ts
+++ b/packages/cli/src/commands/apps/create.ts
@@ -6,13 +6,11 @@ import { AppClassification, AppCreateRequest, AppCreationResponse, AppType, Prin
 
 import {
 	APICommand,
-	arrayDef,
 	computedDef,
 	createFromUserInput,
 	httpsURLValidate,
 	inputAndOutputItem,
 	lambdaAuthFlags,
-	localhostOrHTTPSValidate,
 	objectDef,
 	optionalStringDef,
 	sanitize,
@@ -23,7 +21,7 @@ import {
 } from '@smartthings/cli-lib'
 
 import { addPermission } from '../../lib/aws-utils'
-import { oauthAppScopeDef, tableFieldDefinitions } from '../../lib/commands/apps-util'
+import { oauthAppScopeDef, redirectUrisDef, tableFieldDefinitions } from '../../lib/commands/apps-util'
 
 
 const appNameDef = computedDef((context?: unknown[]): string => {
@@ -59,11 +57,7 @@ const oauthAppCreateRequestInputDefinition = objectDef<AppCreateRequest>('OAuth-
 	oauth: objectDef('OAuth', {
 		clientName: clientNameDef,
 		scope: oauthAppScopeDef,
-		redirectUris: arrayDef(
-			'Redirect URIs',
-			stringDef('Redirect URI', localhostOrHTTPSValidate),
-			{ minItems: 0, maxItems: 10 },
-		),
+		redirectUris: redirectUrisDef,
 	}),
 })
 

--- a/packages/cli/src/commands/apps/oauth/generate.ts
+++ b/packages/cli/src/commands/apps/oauth/generate.ts
@@ -1,5 +1,7 @@
 import { GenerateAppOAuthRequest, GenerateAppOAuthResponse } from '@smartthings/core-sdk'
+
 import { APICommand, inputAndOutputItem, InputAndOutputItemConfig, inputProcessor, objectDef, stringDef, TableFieldDefinition, updateFromUserInput } from '@smartthings/cli-lib'
+
 import { chooseApp, oauthAppScopeDef } from '../../../lib/commands/apps-util'
 
 
@@ -26,6 +28,7 @@ export default class AppOauthGenerateCommand extends APICommand<typeof AppOauthG
 
 	async run(): Promise<void> {
 		const appId = await chooseApp(this, this.args.id)
+
 		const tableFieldDefinitions: TableFieldDefinition<GenerateAppOAuthResponse>[] = [
 			{ path: 'oauthClientDetails.clientName' },
 			{ path: 'oauthClientDetails.scope' },
@@ -37,10 +40,10 @@ export default class AppOauthGenerateCommand extends APICommand<typeof AppOauthG
 			tableFieldDefinitions,
 		}
 		const getInputFromUser = async (): Promise<GenerateAppOAuthRequest> => {
-			const oauth = await this.client.apps.getOauth(appId)
+			const origOauth = await this.client.apps.getOauth(appId)
 			const startingRequest: GenerateAppOAuthRequest = {
-				clientName: oauth.clientName,
-				scope: oauth.scope,
+				clientName: origOauth.clientName,
+				scope: origOauth.scope,
 			}
 			const inputDef = objectDef('Generate Request', {
 				clientName: stringDef('Client Name'),
@@ -49,6 +52,7 @@ export default class AppOauthGenerateCommand extends APICommand<typeof AppOauthG
 
 			return updateFromUserInput(this, inputDef, startingRequest, { dryRun: this.flags['dry-run'] })
 		}
+
 		await inputAndOutputItem(this, config,
 			(_, data: GenerateAppOAuthRequest) => this.client.apps.regenerateOauth(appId, data),
 			inputProcessor(() => true, getInputFromUser))

--- a/packages/cli/src/commands/apps/oauth/update.ts
+++ b/packages/cli/src/commands/apps/oauth/update.ts
@@ -1,6 +1,6 @@
 import { AppOAuthRequest } from '@smartthings/core-sdk'
-import { APICommand, inputAndOutputItem } from '@smartthings/cli-lib'
-import { chooseApp, oauthTableFieldDefinitions } from '../../../lib/commands/apps-util'
+import { APICommand, inputAndOutputItem, inputProcessor, objectDef, stringDef, updateFromUserInput } from '@smartthings/cli-lib'
+import { chooseApp, oauthAppScopeDef, oauthTableFieldDefinitions, redirectUrisDef } from '../../../lib/commands/apps-util'
 
 
 export default class AppOauthUpdateCommand extends APICommand<typeof AppOauthUpdateCommand.flags> {
@@ -19,18 +19,35 @@ export default class AppOauthUpdateCommand extends APICommand<typeof AppOauthUpd
 
 	static examples = [
 		{
-			description: 'update the OAuth settings for the app with the given id using the data in "oauth-settings.json"',
-			command: 'smartthings apps:oauth:update 392bcb11-e251-44f3-b58b-17f93015f3aa -i oauth-settings.json',
+			description: 'prompt for an app and update its OAuth settings interactively"',
+			command: 'smartthings apps:oauth:update',
 		},
 		{
-			description: 'ask for the ID of an app to update and then update it using the data in "oauth-settings.json"',
+			description: 'prompt for an app and update its OAuth settings using the data in "oauth-settings.json"',
 			command: 'smartthings apps:oauth:update -i oauth-settings.json',
+		},
+		{
+			description: 'update the OAuth settings for the app with the given id using the data in "oauth-settings.json"',
+			command: 'smartthings apps:oauth:update 392bcb11-e251-44f3-b58b-17f93015f3aa -i oauth-settings.json',
 		},
 	]
 
 	async run(): Promise<void> {
 		const appId = await chooseApp(this, this.args.id)
+
+		const getInputFromUser = async (): Promise<AppOAuthRequest> => {
+			const startingRequest: AppOAuthRequest = await this.client.apps.getOauth(appId)
+			const inputDef = objectDef('Generate Request', {
+				clientName: stringDef('Client Name'),
+				scope: oauthAppScopeDef,
+				redirectUris: redirectUrisDef,
+			})
+
+			return updateFromUserInput(this, inputDef, startingRequest, { dryRun: this.flags['dry-run'] })
+		}
+
 		await inputAndOutputItem(this, { tableFieldDefinitions: oauthTableFieldDefinitions },
-			(_, data: AppOAuthRequest) => this.client.apps.updateOauth(appId, data))
+			(_, data: AppOAuthRequest) => this.client.apps.updateOauth(appId, data),
+			inputProcessor(() => true, getInputFromUser))
 	}
 }

--- a/packages/cli/src/commands/apps/update.ts
+++ b/packages/cli/src/commands/apps/update.ts
@@ -1,12 +1,28 @@
 import { Flags } from '@oclif/core'
-import { AppUpdateRequest, AppResponse } from '@smartthings/core-sdk'
-import { ActionFunction, APICommand, inputAndOutputItem, TableCommonOutputProducer, lambdaAuthFlags } from '@smartthings/cli-lib'
+import { AppUpdateRequest, AppResponse, AppType } from '@smartthings/core-sdk'
+import {
+	ActionFunction,
+	APICommand,
+	inputAndOutputItem,
+	TableCommonOutputProducer,
+	lambdaAuthFlags,
+	inputProcessor,
+	objectDef,
+	stringDef,
+	updateFromUserInput,
+	staticDef,
+	optionalStringDef,
+	httpsURLValidate,
+	arrayDef,
+	InputDefsByProperty,
+} from '@smartthings/cli-lib'
 import { addPermission } from '../../lib/aws-utils'
 import { chooseApp, tableFieldDefinitions } from '../../lib/commands/apps-util'
 
 
 export default class AppUpdateCommand extends APICommand<typeof AppUpdateCommand.flags> {
 	static description = 'update the settings of the app' +
+		'\nSee apps:oauth:update and apps:oauth:generate for updating oauth-related data.\n\n' +
 		this.apiDocsURL('updateApp')
 
 	static flags = {
@@ -25,8 +41,12 @@ export default class AppUpdateCommand extends APICommand<typeof AppUpdateCommand
 
 	static examples = [
 		{
-			description: 'ask for the ID of an app and update it using the data in "my-app.json"',
-			command: 'smartthings apps:update -i  my-app.json',
+			description: 'prompt for an app and edit it interactively',
+			command: 'smartthings apps:update',
+		},
+		{
+			description: 'prompt for an app and update it using the data in "my-app.json"',
+			command: 'smartthings apps:update -i my-app.json',
 		},
 		{
 			description: 'update the app with the given id using the data in "my-app.json"',
@@ -41,6 +61,42 @@ export default class AppUpdateCommand extends APICommand<typeof AppUpdateCommand
 
 	async run(): Promise<void> {
 		const appId = await chooseApp(this, this.args.id)
+
+		const getInputFromUser = async (): Promise<AppUpdateRequest> => {
+			const {
+				singleInstance, lambdaSmartApp, webhookSmartApp, apiOnly, ui, iconImage, appName,
+				appType, classifications, displayName, description,
+			} = await this.client.apps.get(appId)
+			const startingRequest: AppUpdateRequest = {
+				appName, appType, classifications, displayName, description, singleInstance, iconImage, ui,
+			}
+			const propertyInputDefs: InputDefsByProperty<AppUpdateRequest> = {
+				displayName: stringDef('Display Name'),
+				description: stringDef('Description'),
+				appName: staticDef(startingRequest.appName),
+				appType: staticDef(appType),
+				classifications: staticDef(startingRequest.classifications),
+				singleInstance: staticDef(startingRequest.singleInstance),
+				iconImage: objectDef('Icon Image URL', { url: optionalStringDef('Icon Image URL', httpsURLValidate) }),
+				ui: staticDef(ui),
+			}
+			if (appType === AppType.LAMBDA_SMART_APP) {
+				startingRequest.lambdaSmartApp = lambdaSmartApp
+				propertyInputDefs.lambdaSmartApp = objectDef('Lambda SmartApp',
+					{ functions: arrayDef('Lambda Functions', stringDef('Lambda Function')) })
+			}
+			if (appType === AppType.WEBHOOK_SMART_APP) {
+				startingRequest.webhookSmartApp = { targetUrl: webhookSmartApp?.targetUrl ?? '' }
+				propertyInputDefs.webhookSmartApp = objectDef('Webhook SmartApp', { targetUrl: stringDef('Target URL') })
+			}
+			if (appType === AppType.API_ONLY) {
+				startingRequest.apiOnly = { targetUrl: apiOnly?.subscription?.targetUrl }
+				propertyInputDefs.apiOnly = objectDef('API-Only SmartApp', { targetUrl: stringDef('Target URL') })
+			}
+			const appInputDef = objectDef('App Update', propertyInputDefs)
+
+			return updateFromUserInput(this, appInputDef, startingRequest, { dryRun: this.flags['dry-run'] })
+		}
 
 		const executeUpdate: ActionFunction<void, AppUpdateRequest, AppResponse> = async (_, data) => {
 			if (this.flags.authorize) {
@@ -59,6 +115,6 @@ export default class AppUpdateCommand extends APICommand<typeof AppUpdateCommand
 		}
 
 		const config: TableCommonOutputProducer<AppResponse> = { tableFieldDefinitions }
-		await inputAndOutputItem(this, config, executeUpdate)
+		await inputAndOutputItem(this, config, executeUpdate, inputProcessor(() => true, getInputFromUser))
 	}
 }

--- a/packages/cli/src/lib/commands/apps-util.ts
+++ b/packages/cli/src/lib/commands/apps-util.ts
@@ -2,11 +2,14 @@ import { AppListOptions, AppOAuthRequest, AppResponse, AppSettingsResponse, Page
 
 import {
 	APICommand,
+	arrayDef,
 	checkboxDef,
 	ChooseOptions,
 	chooseOptionsWithDefaults,
+	localhostOrHTTPSValidate,
 	selectFromList,
 	SelectFromListConfig,
+	stringDef,
 	stringTranslateToId,
 	TableFieldDefinition,
 	TableGenerator,
@@ -104,3 +107,9 @@ const availableScopes = [
 ]
 
 export const oauthAppScopeDef = checkboxDef<string>('Scopes', availableScopes)
+
+export const redirectUrisDef = arrayDef(
+	'Redirect URIs',
+	stringDef('Redirect URI', localhostOrHTTPSValidate),
+	{ minItems: 0, maxItems: 10 },
+)

--- a/packages/lib/src/__tests__/item-input/command-helpers.test.ts
+++ b/packages/lib/src/__tests__/item-input/command-helpers.test.ts
@@ -1,0 +1,259 @@
+import { Interfaces } from '@oclif/core'
+import inquirer from 'inquirer'
+
+import { Profile } from '../../cli-config'
+import { cancelAction, editAction, finishAction, previewJSONAction, previewYAMLAction } from '../../item-input/defs'
+import { createFromUserInput, updateFromUserInput } from '../../item-input/command-helpers'
+import * as commandHelpers from '../../item-input/command-helpers'
+import { jsonFormatter, yamlFormatter } from '../../output'
+import { SmartThingsCommandInterface } from '../../smartthings-command'
+
+
+jest.mock('inquirer')
+jest.mock('../../output')
+
+const promptMock = jest.mocked(inquirer.prompt)
+
+const cancelMock = jest.fn().mockImplementation(() => { throw Error('canceled') })
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const buildCommandMock = (flags: Interfaces.OutputFlags<any> = {}, profile: Profile = {}): SmartThingsCommandInterface =>
+	({ flags, cliConfig: { profile }, cancel: cancelMock } as unknown as SmartThingsCommandInterface)
+const commandMock = buildCommandMock()
+
+const buildFromUserInputMock = jest.fn()
+const summarizeForEditMock = jest.fn()
+const updateFromUserInputMock = jest.fn()
+const inputDefMock = {
+	name: 'Item-to-Input',
+	buildFromUserInput: buildFromUserInputMock,
+	summarizeForEdit: summarizeForEditMock,
+	updateFromUserInput: updateFromUserInputMock,
+}
+const jsonOutputFormatterMock = jest.fn().mockReturnValue('formatted JSON')
+const yamlOutputFormatterMock = jest.fn().mockReturnValue('formatted YAML')
+const jsonFormatterMock = jest.mocked(jsonFormatter).mockReturnValue(jsonOutputFormatterMock)
+const yamlFormatterMock = jest.mocked(yamlFormatter).mockReturnValue(yamlOutputFormatterMock)
+
+describe('updateFromUserInput', () => {
+	it('returns input when no further updates requested', async () => {
+		promptMock.mockResolvedValueOnce({ action: finishAction })
+
+		expect(await updateFromUserInput(commandMock, inputDefMock, 'input value', { dryRun: false }))
+			.toStrictEqual('input value')
+
+		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
+			message: 'Choose an action.',
+			default: finishAction,
+			choices: [
+				{ name: 'Edit Item-to-Input.', value: editAction },
+				{ name: 'Preview JSON.', value: expect.any(Symbol) },
+				{ name: 'Preview YAML.', value: expect.any(Symbol) },
+				{ name: 'Finish and update Item-to-Input.', value: finishAction },
+				{ name: 'Cancel creating Item-to-Input.', value: cancelAction },
+			],
+		}))
+
+		expect(buildFromUserInputMock).toHaveBeenCalledTimes(0)
+		expect(summarizeForEditMock).toHaveBeenCalledTimes(0)
+		expect(updateFromUserInputMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('uses "output" text when in dry-run mode', async () => {
+		promptMock.mockResolvedValueOnce({ action: finishAction })
+
+		expect(await updateFromUserInput(commandMock, inputDefMock, 'input value', { dryRun: true }))
+			.toBe('input value')
+
+		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
+			choices: expect.arrayContaining([
+				{ name: 'Finish and output Item-to-Input.', value: finishAction },
+			]),
+		}))
+	})
+
+	it('uses specified finishVerb', async () => {
+		promptMock.mockResolvedValueOnce({ action: finishAction })
+
+		expect(await updateFromUserInput(commandMock, inputDefMock, 'input value', { dryRun: false, finishVerb: 'run' }))
+			.toBe('input value')
+
+		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
+			choices: expect.arrayContaining([
+				{ name: 'Finish and run Item-to-Input.', value: finishAction },
+			]),
+		}))
+	})
+
+	it('allows editing from main menu', async () => {
+		promptMock.mockResolvedValueOnce({ action: editAction })
+		updateFromUserInputMock.mockResolvedValueOnce('updated result')
+		promptMock.mockResolvedValueOnce({ action: finishAction })
+
+		expect(await updateFromUserInput(commandMock, inputDefMock, 'input value', { dryRun: false })).toBe('updated result')
+
+		expect(promptMock).toHaveBeenCalledTimes(2)
+		expect(updateFromUserInputMock).toHaveBeenCalledTimes(1)
+		expect(updateFromUserInputMock).toHaveBeenCalledWith('input value')
+	})
+
+	it('accepts cancelation of editing from main menu', async () => {
+		promptMock.mockResolvedValueOnce({ action: editAction })
+		updateFromUserInputMock.mockResolvedValueOnce(cancelAction)
+		promptMock.mockResolvedValueOnce({ action: finishAction })
+
+		expect(await updateFromUserInput(commandMock, inputDefMock, 'input value', { dryRun: false })).toBe('input value')
+
+		expect(promptMock).toHaveBeenCalledTimes(2)
+		expect(updateFromUserInputMock).toHaveBeenCalledTimes(1)
+		expect(updateFromUserInputMock).toHaveBeenCalledWith('input value')
+	})
+
+	it('allows previewing JSON', async () => {
+		promptMock.mockResolvedValueOnce({ action: previewJSONAction })
+		promptMock.mockResolvedValueOnce({ editAgain: false })
+		promptMock.mockResolvedValueOnce({ action: finishAction })
+
+		expect(await updateFromUserInput(commandMock, inputDefMock, 'input value', { dryRun: false })).toBe('input value')
+
+		expect(promptMock).toHaveBeenCalledTimes(3)
+		expect(jsonFormatterMock).toHaveBeenCalledTimes(1)
+		expect(jsonFormatterMock).toHaveBeenCalledWith(4)
+		expect(jsonOutputFormatterMock).toHaveBeenCalledTimes(1)
+		expect(jsonOutputFormatterMock).toHaveBeenCalledWith('input value')
+		expect(promptMock).toHaveBeenCalledWith({
+			type: 'confirm',
+			name: 'editAgain',
+			message: 'formatted JSON\n\nWould you like to edit further?',
+			default: false,
+		})
+	})
+
+	it('allows editing after preview', async () => {
+		promptMock.mockResolvedValueOnce({ action: previewJSONAction })
+		promptMock.mockResolvedValueOnce({ editAgain: true })
+		updateFromUserInputMock.mockResolvedValueOnce('updated result')
+		promptMock.mockResolvedValueOnce({ action: finishAction })
+
+		expect(await updateFromUserInput(commandMock, inputDefMock, 'input value', { dryRun: false })).toBe('updated result')
+
+		expect(promptMock).toHaveBeenCalledTimes(3)
+		expect(jsonFormatterMock).toHaveBeenCalledTimes(1)
+		expect(jsonOutputFormatterMock).toHaveBeenCalledTimes(1)
+		expect(updateFromUserInputMock).toHaveBeenCalledTimes(1)
+		expect(updateFromUserInputMock).toHaveBeenCalledWith('input value')
+	})
+
+	it('sticks to original upon cancelation after editing after preview', async () => {
+		promptMock.mockResolvedValueOnce({ action: previewJSONAction })
+		promptMock.mockResolvedValueOnce({ editAgain: true })
+		updateFromUserInputMock.mockResolvedValueOnce(cancelAction)
+		promptMock.mockResolvedValueOnce({ action: finishAction })
+
+		expect(await updateFromUserInput(commandMock, inputDefMock, 'input value', { dryRun: false })).toBe('input value')
+
+		expect(promptMock).toHaveBeenCalledTimes(3)
+		expect(jsonFormatterMock).toHaveBeenCalledTimes(1)
+		expect(jsonOutputFormatterMock).toHaveBeenCalledTimes(1)
+		expect(updateFromUserInputMock).toHaveBeenCalledTimes(1)
+		expect(updateFromUserInputMock).toHaveBeenCalledWith('input value')
+	})
+
+	it('allows previewing YAML', async () => {
+		promptMock.mockResolvedValueOnce({ action: previewYAMLAction })
+		promptMock.mockResolvedValueOnce({ editAgain: false })
+		promptMock.mockResolvedValueOnce({ action: finishAction })
+
+		expect(await updateFromUserInput(commandMock, inputDefMock, 'input value', { dryRun: false })).toBe('input value')
+
+		expect(promptMock).toHaveBeenCalledTimes(3)
+		expect(yamlFormatterMock).toHaveBeenCalledTimes(1)
+		expect(yamlFormatterMock).toHaveBeenCalledWith(2)
+		expect(yamlOutputFormatterMock).toHaveBeenCalledTimes(1)
+		expect(yamlOutputFormatterMock).toHaveBeenCalledWith('input value')
+		expect(promptMock).toHaveBeenCalledWith({
+			type: 'confirm',
+			name: 'editAgain',
+			message: 'formatted YAML\n\nWould you like to edit further?',
+			default: false,
+		})
+	})
+
+	it('accepts indent level from config', async () => {
+		const commandMock = buildCommandMock({}, { indent: 13 })
+		promptMock.mockResolvedValueOnce({ action: previewYAMLAction })
+		promptMock.mockResolvedValueOnce({ editAgain: false })
+		promptMock.mockResolvedValueOnce({ action: finishAction })
+
+		expect(await updateFromUserInput(commandMock, inputDefMock, 'input value', { dryRun: false })).toBe('input value')
+
+		expect(promptMock).toHaveBeenCalledTimes(3)
+		expect(yamlFormatterMock).toHaveBeenCalledTimes(1)
+		expect(yamlFormatterMock).toHaveBeenCalledWith(13)
+		expect(yamlOutputFormatterMock).toHaveBeenCalledTimes(1)
+	})
+
+	it('accepts indent level from command line', async () => {
+		const commandMock = buildCommandMock({ indent: 14 })
+		promptMock.mockResolvedValueOnce({ action: previewJSONAction })
+		promptMock.mockResolvedValueOnce({ editAgain: false })
+		promptMock.mockResolvedValueOnce({ action: finishAction })
+
+		expect(await updateFromUserInput(commandMock, inputDefMock, 'input value', { dryRun: false })).toBe('input value')
+
+		expect(promptMock).toHaveBeenCalledTimes(3)
+		expect(jsonFormatterMock).toHaveBeenCalledTimes(1)
+		expect(jsonFormatterMock).toHaveBeenCalledWith(14)
+		expect(jsonOutputFormatterMock).toHaveBeenCalledTimes(1)
+	})
+
+	it('command line indent overrides value from config', async () => {
+		const commandMock = buildCommandMock({ indent: 15 }, { indent: 14 })
+		promptMock.mockResolvedValueOnce({ action: previewYAMLAction })
+		promptMock.mockResolvedValueOnce({ editAgain: false })
+		promptMock.mockResolvedValueOnce({ action: finishAction })
+
+		expect(await updateFromUserInput(commandMock, inputDefMock, 'input value', { dryRun: false })).toBe('input value')
+
+		expect(promptMock).toHaveBeenCalledTimes(3)
+		expect(yamlFormatterMock).toHaveBeenCalledTimes(1)
+		expect(yamlFormatterMock).toHaveBeenCalledWith(15)
+		expect(yamlOutputFormatterMock).toHaveBeenCalledTimes(1)
+	})
+
+	it('calls cancel when user cancels', async () => {
+		promptMock.mockResolvedValueOnce({ action: cancelAction })
+
+		await expect(updateFromUserInput(commandMock, inputDefMock, 'input value', { dryRun: false })).rejects.toThrow('canceled')
+
+		expect(cancelMock).toHaveBeenCalledTimes(1)
+	})
+})
+
+describe('createFromUserInput', () => {
+	it('calls buildFromUserInput and updateFromUserInput', async () => {
+		const updateFromUserInputSpy = jest.spyOn(commandHelpers, 'updateFromUserInput')
+
+		buildFromUserInputMock.mockResolvedValueOnce('wizard value')
+		updateFromUserInputSpy.mockResolvedValueOnce({ value: 'updated value' })
+
+		expect(await createFromUserInput(commandMock, inputDefMock, { dryRun: false })).toStrictEqual({ value: 'updated value' })
+
+		expect(buildFromUserInputMock).toHaveBeenCalledTimes(1)
+		expect(buildFromUserInputMock).toHaveBeenCalledWith()
+		expect(updateFromUserInputSpy).toHaveBeenCalledTimes(1)
+		expect(updateFromUserInputSpy).toHaveBeenCalledWith(commandMock, inputDefMock, 'wizard value',
+			{ finishVerb: 'create', dryRun: false })
+	})
+
+	it('cancels when initial initial wizard mode is canceled', async () => {
+		buildFromUserInputMock.mockReturnValueOnce(cancelAction)
+
+		await expect(createFromUserInput(commandMock, inputDefMock, { dryRun: false })).rejects.toThrow('canceled')
+
+		expect(buildFromUserInputMock).toHaveBeenCalledTimes(1)
+		expect(cancelMock).toHaveBeenCalledTimes(1)
+	})
+})

--- a/packages/lib/src/__tests__/item-input/defs.test.ts
+++ b/packages/lib/src/__tests__/item-input/defs.test.ts
@@ -1,0 +1,27 @@
+import {
+	addAction,
+	addOption,
+	deleteAction,
+	deleteOption,
+	editAction,
+	editOption,
+	finishAction,
+	finishOption,
+} from '../../item-input/defs'
+
+
+test('addOption', () => {
+	expect(addOption('Thing')).toStrictEqual({ name: 'Add Thing.', value: addAction })
+})
+
+test('editAction', () => {
+	expect(editOption('Thing')).toStrictEqual({ name: 'Edit Thing.', value: editAction })
+})
+
+test('deleteOption', () => {
+	expect(deleteOption('Thing')).toStrictEqual({ name: 'Delete Thing.', value: deleteAction })
+})
+
+test('finishOption', () => {
+	expect(finishOption('Thing')).toStrictEqual({ name: 'Finish editing Thing.', value: finishAction })
+})

--- a/packages/lib/src/item-input/misc.ts
+++ b/packages/lib/src/item-input/misc.ts
@@ -2,7 +2,6 @@ import { askForRequiredString, askForString, ValidateFunction } from '../user-qu
 import { InputDefinition, InputDefinitionValidateFunction, Uneditable, uneditable } from './defs'
 
 
-
 export const validateWithContextFn = (validate?: InputDefinitionValidateFunction, context?: unknown[]): ValidateFunction | undefined =>
 	validate
 		? (input: string): true | string | Promise<string | true> => validate(input, context)
@@ -21,7 +20,7 @@ export const optionalStringDef = (name: string, validate?: InputDefinitionValida
 export const stringDef = (name: string, validate?: InputDefinitionValidateFunction): InputDefinition<string> => {
 	const buildFromUserInput = async (context?: unknown[]): Promise<string> =>
 		askForRequiredString(name, validateWithContextFn(validate, context))
-	const summarizeForEdit = (original: string): string => original
+	const summarizeForEdit = (value: string): string => value
 	const updateFromUserInput = (original: string, context?: unknown[]): Promise<string> =>
 		askForRequiredString(name, validateWithContextFn(validate, context), { default: original })
 


### PR DESCRIPTION
<!-- Describe your pull request. -->

* add support for Q&A input to `apps:update` command
* add support for Q&A input to `apps:oauth:update` command
* misc. cleanup

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
