### PR TITLE
fix: correct capabilities:presentation and deviceprofiles:view commands

### DIFF
--- a/.changeset/violet-moles-think.md
+++ b/.changeset/violet-moles-think.md
@@ -1,0 +1,7 @@
+---
+"@smartthings/cli": patch
+---
+
+fix  commands to prompt for required inputs when not supplied on the command line
+  * `capabilities:presentation` asks for a capability
+  * `deviceprofiles:view` asks for a deviceprofile

--- a/packages/cli/src/__tests__/lib/commands/capabilities-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/capabilities-util.test.ts
@@ -568,6 +568,30 @@ describe('chooseCapability', () => {
 		)
 	})
 
+	it('passes on namespace', async () => {
+		expect(await chooseCapability(command, undefined, undefined, undefined, 'namespace')).toBe(selectedCapabilityId)
+
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(
+			command,
+			expect.objectContaining({ itemName: 'capability' }),
+			expect.objectContaining({
+				preselectedId: undefined,
+				getIdFromUser,
+				promptMessage: undefined,
+			}),
+		)
+
+		const getCustomByNamespaceSpy = jest.spyOn(capabilitiesUtil, 'getCustomByNamespace')
+			.mockResolvedValueOnce(customCapabilitiesWithNamespaces)
+		const listItems = selectFromListMock.mock.calls[0][2].listItems
+
+		expect(await listItems()).toBe(customCapabilitiesWithNamespaces)
+
+		expect(getCustomByNamespaceSpy).toHaveBeenCalledTimes(1)
+		expect(getCustomByNamespaceSpy).toHaveBeenCalledWith(client, 'namespace')
+	})
+
 	it('uses list function that returns custom capabilities', async () => {
 		expect(await chooseCapability(command)).toBe(selectedCapabilityId)
 
@@ -585,7 +609,7 @@ describe('chooseCapability', () => {
 		expect(await listItems()).toBe(customCapabilitiesWithNamespaces)
 
 		expect(getCustomByNamespaceSpy).toHaveBeenCalledTimes(1)
-		expect(getCustomByNamespaceSpy).toHaveBeenCalledWith(client)
+		expect(getCustomByNamespaceSpy).toHaveBeenCalledWith(client, undefined)
 	})
 })
 

--- a/packages/cli/src/commands/capabilities/presentation.ts
+++ b/packages/cli/src/commands/capabilities/presentation.ts
@@ -2,9 +2,9 @@ import { Flags } from '@oclif/core'
 
 import { CapabilityPresentation } from '@smartthings/core-sdk'
 
-import { APIOrganizationCommand, OutputItemOrListConfig, outputItemOrListGeneric, TableGenerator } from '@smartthings/cli-lib'
+import { APIOrganizationCommand, formatAndWriteItem, TableGenerator } from '@smartthings/cli-lib'
 
-import { CapabilityId, capabilityIdOrIndexInputArgs, CapabilitySummaryWithNamespace, getCustomByNamespace, translateToId } from '../../lib/commands/capabilities-util'
+import { capabilityIdOrIndexInputArgs, chooseCapability } from '../../lib/commands/capabilities-util'
 
 
 export function buildTableOutput(tableGenerator: TableGenerator, presentation: CapabilityPresentation): string {
@@ -72,7 +72,7 @@ export default class PresentationsCommand extends APIOrganizationCommand<typeof 
 
 	static flags = {
 		...APIOrganizationCommand.flags,
-		...outputItemOrListGeneric.flags,
+		...formatAndWriteItem.flags,
 		namespace: Flags.string({
 			char: 'n',
 			description: 'a specific namespace to query; will use all by default',
@@ -82,19 +82,8 @@ export default class PresentationsCommand extends APIOrganizationCommand<typeof 
 	static args = capabilityIdOrIndexInputArgs
 
 	async run(): Promise<void> {
-		const idOrIndex = this.args.version
-			? { id: this.args.id, version: this.args.version }
-			: this.args.id
-		const sortKeyName = 'id'
-		const config: OutputItemOrListConfig<CapabilityPresentation, CapabilitySummaryWithNamespace> = {
-			primaryKeyName: 'id',
-			sortKeyName,
-			listTableFieldDefinitions: ['id', 'version', 'status'],
-			buildTableOutput: (data: CapabilityPresentation) => buildTableOutput(this.tableGenerator, data),
-		}
-		await outputItemOrListGeneric(this, config, idOrIndex,
-			() => getCustomByNamespace(this.client, this.flags.namespace),
-			(id: CapabilityId) =>  this.client.capabilities.getPresentation(id.id, id.version),
-			(idOrIndex, listFunction) => translateToId(sortKeyName, idOrIndex, listFunction))
+		const capabilityId = await chooseCapability(this, this.args.id, this.args.version, undefined, this.flags.namespace)
+		const presentation = await this.client.capabilities.getPresentation(capabilityId.id, capabilityId.version)
+		await formatAndWriteItem(this, { buildTableOutput: data => buildTableOutput(this.tableGenerator, data) }, presentation)
 	}
 }

--- a/packages/cli/src/lib/commands/capabilities-util.ts
+++ b/packages/cli/src/lib/commands/capabilities-util.ts
@@ -224,7 +224,7 @@ export const translateToId = async (sortKeyName: Extract<keyof CapabilitySummary
 }
 
 export const chooseCapability = async (command: APICommand<typeof APICommand.flags>, idFromArgs?: string,
-		versionFromArgs?: number, promptMessage?: string): Promise<CapabilityId> => {
+		versionFromArgs?: number, promptMessage?: string, namespace?: string): Promise<CapabilityId> => {
 	const preselectedId: CapabilityId | undefined = idFromArgs
 		? { id: idFromArgs, version: versionFromArgs ?? 1 }
 		: undefined
@@ -237,7 +237,7 @@ export const chooseCapability = async (command: APICommand<typeof APICommand.fla
 	}
 	return selectFromList(command, config, {
 		preselectedId,
-		listItems: () => getCustomByNamespace(command.client),
+		listItems: () => getCustomByNamespace(command.client, namespace),
 		getIdFromUser,
 		promptMessage,
 	})


### PR DESCRIPTION
- fix `capabilities:presentation` and `deviceprofiles:view` commands to prompt for user selection if no ID provided
- minor update to utility library for capabilities

<!-- Describe your pull request. -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
