### PR TITLE
feat: add help text when entering a redirect URI

### DIFF
--- a/.changeset/selfish-ghosts-chew.md
+++ b/.changeset/selfish-ghosts-chew.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli-lib": minor
+---
+
+add support for help text to item input definitions

--- a/.changeset/shiny-sheep-sort.md
+++ b/.changeset/shiny-sheep-sort.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+add help text to several Q & A format input items

--- a/packages/cli/src/commands/apps/create.ts
+++ b/packages/cli/src/commands/apps/create.ts
@@ -21,7 +21,7 @@ import {
 } from '@smartthings/cli-lib'
 
 import { addPermission } from '../../lib/aws-utils'
-import { oauthAppScopeDef, redirectUrisDef, tableFieldDefinitions } from '../../lib/commands/apps-util'
+import { oauthAppScopeDef, redirectUrisDef, smartAppHelpText, tableFieldDefinitions } from '../../lib/commands/apps-util'
 
 
 const appNameDef = computedDef((context?: unknown[]): string => {
@@ -43,23 +43,23 @@ const clientNameDef = computedDef((context?: unknown[]): string => {
 })
 
 const oauthAppCreateRequestInputDefinition = objectDef<AppCreateRequest>('OAuth-In SmartApp', {
-	displayName: stringDef('Display Name', stringValidateFn({ maxLength: 75 })),
-	description: stringDef('Description', stringValidateFn({ maxLength: 250 })),
+	displayName: stringDef('Display Name', { validate: stringValidateFn({ maxLength: 75 }) }),
+	description: stringDef('Description', { validate: stringValidateFn({ maxLength: 250 }) }),
 	appName: appNameDef,
 	appType: staticDef(AppType.API_ONLY),
 	classifications: staticDef([AppClassification.CONNECTED_SERVICE]),
 	singleInstance: staticDef(true),
 	iconImage: objectDef('Icon Image', {
-		url: optionalStringDef('Icon Image URL', httpsURLValidate),
+		url: optionalStringDef('Icon Image URL', { validate: httpsURLValidate }),
 	}),
-	apiOnly: objectDef('API Only', { targetUrl: optionalStringDef('Target URL', httpsURLValidate) }),
+	apiOnly: objectDef('API Only', { targetUrl: optionalStringDef('Target URL', { validate: httpsURLValidate }) }),
 	principalType: staticDef(PrincipalType.LOCATION),
 	oauth: objectDef('OAuth', {
 		clientName: clientNameDef,
 		scope: oauthAppScopeDef,
 		redirectUris: redirectUrisDef,
 	}),
-})
+}, { helpText: smartAppHelpText })
 
 export default class AppCreateCommand extends APICommand<typeof AppCreateCommand.flags> {
 	static description = 'create an app' +

--- a/packages/cli/src/commands/apps/oauth/generate.ts
+++ b/packages/cli/src/commands/apps/oauth/generate.ts
@@ -6,8 +6,9 @@ import { chooseApp, oauthAppScopeDef } from '../../../lib/commands/apps-util'
 
 
 export default class AppOauthGenerateCommand extends APICommand<typeof AppOauthGenerateCommand.flags> {
+	static docNames = 'generateAppOauth'
 	static description = 'regenerate the OAuth clientId and clientSecret of an app' +
-		this.apiDocsURL('generateAppOauth')
+		this.apiDocsURL(AppOauthGenerateCommand.docNames)
 
 	static flags = {
 		...APICommand.flags,
@@ -48,7 +49,7 @@ export default class AppOauthGenerateCommand extends APICommand<typeof AppOauthG
 			const inputDef = objectDef('Generate Request', {
 				clientName: stringDef('Client Name'),
 				scope: oauthAppScopeDef,
-			})
+			}, { helpText: APICommand.itemInputHelpText(AppOauthGenerateCommand.docNames) })
 
 			return updateFromUserInput(this, inputDef, startingRequest, { dryRun: this.flags['dry-run'] })
 		}

--- a/packages/cli/src/commands/apps/oauth/update.ts
+++ b/packages/cli/src/commands/apps/oauth/update.ts
@@ -4,8 +4,9 @@ import { chooseApp, oauthAppScopeDef, oauthTableFieldDefinitions, redirectUrisDe
 
 
 export default class AppOauthUpdateCommand extends APICommand<typeof AppOauthUpdateCommand.flags> {
+	static docNames = 'updateAppOauth'
 	static description = 'update the OAuth settings of an app' +
-		this.apiDocsURL('updateAppOauth')
+		this.apiDocsURL(AppOauthUpdateCommand.docNames)
 
 	static flags = {
 		...APICommand.flags,
@@ -37,11 +38,11 @@ export default class AppOauthUpdateCommand extends APICommand<typeof AppOauthUpd
 
 		const getInputFromUser = async (): Promise<AppOAuthRequest> => {
 			const startingRequest: AppOAuthRequest = await this.client.apps.getOauth(appId)
-			const inputDef = objectDef('Generate Request', {
+			const inputDef = objectDef('OAuth Settings', {
 				clientName: stringDef('Client Name'),
 				scope: oauthAppScopeDef,
 				redirectUris: redirectUrisDef,
-			})
+			}, { helpText: APICommand.itemInputHelpText(AppOauthUpdateCommand.docNames) })
 
 			return updateFromUserInput(this, inputDef, startingRequest, { dryRun: this.flags['dry-run'] })
 		}

--- a/packages/cli/src/commands/apps/update.ts
+++ b/packages/cli/src/commands/apps/update.ts
@@ -17,7 +17,7 @@ import {
 	InputDefsByProperty,
 } from '@smartthings/cli-lib'
 import { addPermission } from '../../lib/aws-utils'
-import { chooseApp, tableFieldDefinitions } from '../../lib/commands/apps-util'
+import { chooseApp, smartAppHelpText, tableFieldDefinitions } from '../../lib/commands/apps-util'
 
 
 export default class AppUpdateCommand extends APICommand<typeof AppUpdateCommand.flags> {
@@ -77,13 +77,15 @@ export default class AppUpdateCommand extends APICommand<typeof AppUpdateCommand
 				appType: staticDef(appType),
 				classifications: staticDef(startingRequest.classifications),
 				singleInstance: staticDef(startingRequest.singleInstance),
-				iconImage: objectDef('Icon Image URL', { url: optionalStringDef('Icon Image URL', httpsURLValidate) }),
+				iconImage: objectDef('Icon Image URL', { url: optionalStringDef('Icon Image URL', { validate: httpsURLValidate }) }),
 				ui: staticDef(ui),
 			}
 			if (appType === AppType.LAMBDA_SMART_APP) {
 				startingRequest.lambdaSmartApp = lambdaSmartApp
+				const helpText = 'More information on AWS Lambdas can be found at:\n' +
+					'  https://docs.aws.amazon.com/lambda/latest/dg/welcome.html'
 				propertyInputDefs.lambdaSmartApp = objectDef('Lambda SmartApp',
-					{ functions: arrayDef('Lambda Functions', stringDef('Lambda Function')) })
+					{ functions: arrayDef('Lambda Functions', stringDef('Lambda Function', { helpText }), { helpText }) })
 			}
 			if (appType === AppType.WEBHOOK_SMART_APP) {
 				startingRequest.webhookSmartApp = { targetUrl: webhookSmartApp?.targetUrl ?? '' }
@@ -93,7 +95,7 @@ export default class AppUpdateCommand extends APICommand<typeof AppUpdateCommand
 				startingRequest.apiOnly = { targetUrl: apiOnly?.subscription?.targetUrl }
 				propertyInputDefs.apiOnly = objectDef('API-Only SmartApp', { targetUrl: stringDef('Target URL') })
 			}
-			const appInputDef = objectDef('App Update', propertyInputDefs)
+			const appInputDef = objectDef('App Update', propertyInputDefs, { helpText: smartAppHelpText })
 
 			return updateFromUserInput(this, appInputDef, startingRequest, { dryRun: this.flags['dry-run'] })
 		}

--- a/packages/cli/src/lib/commands/apps-util.ts
+++ b/packages/cli/src/lib/commands/apps-util.ts
@@ -106,10 +106,20 @@ const availableScopes = [
 	'w:installedapps',
 ]
 
-export const oauthAppScopeDef = checkboxDef<string>('Scopes', availableScopes)
+export const oauthAppScopeDef = checkboxDef<string>('Scopes', availableScopes, {
+	helpText: 'More information on OAuth 2 Scopes can be found at:\n' +
+	'  https://www.oauth.com/oauth2-servers/scope/\n\n' +
+	'To determine which scopes you need for the application, see documentation for the individual endpoints you will use in your app:\n' +
+	'  https://developer.smartthings.com/docs/api/public/',
+})
 
+const redirectUriHelpText = 'More information on redirect URIs can be found at:\n' +
+	'  https://www.oauth.com/oauth2-servers/redirect-uris/'
 export const redirectUrisDef = arrayDef(
 	'Redirect URIs',
-	stringDef('Redirect URI', localhostOrHTTPSValidate),
-	{ minItems: 0, maxItems: 10 },
+	stringDef('Redirect URI', { validate: localhostOrHTTPSValidate, helpText: redirectUriHelpText }),
+	{ minItems: 0, maxItems: 10, helpText: redirectUriHelpText },
 )
+
+export const smartAppHelpText = 'More information on writing SmartApps can be found at\n' +
+	'  https://developer.smartthings.com/docs/connected-services/smartapp-basics'

--- a/packages/edge/src/__tests__/commands/edge/drivers/logcat.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/drivers/logcat.test.ts
@@ -55,7 +55,7 @@ jest.mock('@smartthings/cli-lib', () => {
 		...originalLib,
 		stringTranslateToId: jest.fn(),
 		selectFromList: jest.fn(),
-		askForRequiredString: jest.fn(),
+		askForString: jest.fn(),
 		logEvent: jest.fn(),
 		convertToId: jest.fn().mockResolvedValue('driverId'),
 		handleSignals: jest.fn(),

--- a/packages/lib/src/__tests__/item-input/array.test.ts
+++ b/packages/lib/src/__tests__/item-input/array.test.ts
@@ -7,6 +7,8 @@ import {
 	deleteAction,
 	editAction,
 	finishAction,
+	helpAction,
+	helpOption,
 	InputDefinition,
 	maxItemValueLength,
 	uneditable,
@@ -324,6 +326,29 @@ describe('arrayDef', () => {
 			expect(promptMock).toHaveBeenCalledTimes(1)
 			expect(itemBuildFromUserInputMock).toHaveBeenCalledTimes(0)
 		})
+
+		it('includes help option when helpText is supplied', async () => {
+			promptMock.mockResolvedValueOnce({ action: helpAction })
+			promptMock.mockResolvedValueOnce({ action: cancelAction })
+
+			const def = arrayDef('Array Def', itemDefMock, { helpText: 'help text' })
+
+			expect(await def.buildFromUserInput()).toBe(cancelAction)
+
+			expect(promptMock).toHaveBeenCalledTimes(2)
+			expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
+				message: 'Add or edit Array Def.',
+				default: addAction,
+				choices: [
+					helpOption,
+					{ name: 'Add Item Def.', value: addAction },
+					cancelOption,
+				],
+			}))
+
+			expect(consoleLogSpy).toHaveBeenCalledTimes(1)
+			expect(consoleLogSpy).toHaveBeenCalledWith('\nhelp text\n')
+		})
 	})
 
 	describe('summarizeForEdit', () => {
@@ -548,6 +573,26 @@ describe('checkboxDef', () => {
 			expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
 				validate,
 			}))
+		})
+
+		it('includes help option when helpText is supplied', async () => {
+			const def = checkboxDef<string>('Checkbox Def', ['Item 1', 'Item 2'], { helpText: 'help text' })
+			promptMock.mockResolvedValueOnce({ values: ['Item 1'] })
+
+			expect(await def.buildFromUserInput()).toStrictEqual(['Item 1'])
+
+			expect(promptMock).toHaveBeenCalledTimes(1)
+			expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
+				type: 'checkbox',
+				name: 'values',
+				message: 'Select Checkbox Def.',
+				choices: ['Item 1', 'Item 2'],
+				default: finishAction,
+				validate: undefined,
+			}))
+
+			expect(consoleLogSpy).toHaveBeenCalledTimes(1)
+			expect(consoleLogSpy).toHaveBeenCalledWith('\nhelp text\n')
 		})
 	})
 

--- a/packages/lib/src/__tests__/item-input/misc.test.ts
+++ b/packages/lib/src/__tests__/item-input/misc.test.ts
@@ -1,5 +1,5 @@
 import { computedDef, optionalStringDef, staticDef, stringDef, uneditable, validateWithContextFn } from '../../item-input'
-import { askForRequiredString, askForString, ValidateFunction } from '../../user-query'
+import { askForString, askForOptionalString, ValidateFunction } from '../../user-query'
 
 
 jest.mock('../../user-query')
@@ -28,7 +28,7 @@ describe('validateWithContext', () => {
 })
 
 describe('optionalStringDef', () => {
-	const askForStringMock = jest.mocked(askForString)
+	const askForOptionalStringMock = jest.mocked(askForOptionalString)
 
 	describe('without validation', () => {
 		const def = optionalStringDef('String Def')
@@ -38,12 +38,13 @@ describe('optionalStringDef', () => {
 		})
 
 		test('build', async () => {
-			askForStringMock.mockResolvedValueOnce('user input')
+			askForOptionalStringMock.mockResolvedValueOnce('user input')
 
 			expect(await def.buildFromUserInput()).toBe('user input')
 
-			expect(askForStringMock).toHaveBeenCalledTimes(1)
-			expect(askForStringMock).toHaveBeenCalledWith('String Def (optional)', undefined)
+			expect(askForOptionalStringMock).toHaveBeenCalledTimes(1)
+			expect(askForOptionalStringMock).toHaveBeenCalledWith('String Def (optional)',
+				{ validate: undefined })
 		})
 
 		test('summarize', async () => {
@@ -51,29 +52,31 @@ describe('optionalStringDef', () => {
 		})
 
 		test('update', async () => {
-			askForStringMock.mockResolvedValueOnce('updated')
+			askForOptionalStringMock.mockResolvedValueOnce('updated')
 
 			expect(await def.updateFromUserInput('original')).toBe('updated')
 
-			expect(askForStringMock).toHaveBeenCalledTimes(1)
-			expect(askForStringMock).toHaveBeenCalledWith('String Def (optional)', undefined, { default: 'original' })
+			expect(askForOptionalStringMock).toHaveBeenCalledTimes(1)
+			expect(askForOptionalStringMock).toHaveBeenCalledWith('String Def (optional)',
+				{ default: 'original', validate: undefined })
 		})
 	})
 
 	describe('with validation', () => {
 		const validateMock = jest.fn()
-		const def = optionalStringDef('String Def', validateMock)
+		const def = optionalStringDef('String Def', { validate: validateMock })
 
 		test('build', async () => {
 			const context = ['context item']
-			askForStringMock.mockResolvedValueOnce('user input')
+			askForOptionalStringMock.mockResolvedValueOnce('user input')
 
 			expect(await def.buildFromUserInput(context)).toBe('user input')
 
-			expect(askForStringMock).toHaveBeenCalledTimes(1)
-			expect(askForStringMock).toHaveBeenCalledWith('String Def (optional)', expect.any(Function))
+			expect(askForOptionalStringMock).toHaveBeenCalledTimes(1)
+			expect(askForOptionalStringMock).toHaveBeenCalledWith('String Def (optional)',
+				{ validate: expect.any(Function) })
 
-			const validateFn = askForStringMock.mock.calls[0][1] as ValidateFunction
+			const validateFn = askForOptionalStringMock.mock.calls[0][1]?.validate as ValidateFunction
 			validateMock.mockReturnValueOnce('validation answer')
 			expect(validateFn('input string')).toBe('validation answer')
 			expect(validateMock).toHaveBeenCalledTimes(1)
@@ -82,14 +85,15 @@ describe('optionalStringDef', () => {
 
 		test('update', async () => {
 			const context = ['context item']
-			askForStringMock.mockResolvedValueOnce('updated')
+			askForOptionalStringMock.mockResolvedValueOnce('updated')
 
 			expect(await def.updateFromUserInput('original', context)).toBe('updated')
 
-			expect(askForStringMock).toHaveBeenCalledTimes(1)
-			expect(askForStringMock).toHaveBeenCalledWith('String Def (optional)', expect.any(Function), { default: 'original' })
+			expect(askForOptionalStringMock).toHaveBeenCalledTimes(1)
+			expect(askForOptionalStringMock).toHaveBeenCalledWith('String Def (optional)',
+				{ default: 'original', validate: expect.any(Function) })
 
-			const validateFn = askForStringMock.mock.calls[0][1] as ValidateFunction
+			const validateFn = askForOptionalStringMock.mock.calls[0][1]?.validate as ValidateFunction
 			validateMock.mockReturnValueOnce('validation answer')
 			expect(validateFn('input string')).toBe('validation answer')
 			expect(validateMock).toHaveBeenCalledTimes(1)
@@ -99,7 +103,7 @@ describe('optionalStringDef', () => {
 })
 
 describe('stringDef', () => {
-	const askForRequiredStringMock = jest.mocked(askForRequiredString)
+	const askForStringMock = jest.mocked(askForString)
 
 	describe('without validation', () => {
 		const def = stringDef('String Def')
@@ -109,12 +113,12 @@ describe('stringDef', () => {
 		})
 
 		test('build', async () => {
-			askForRequiredStringMock.mockResolvedValueOnce('user input')
+			askForStringMock.mockResolvedValueOnce('user input')
 
 			expect(await def.buildFromUserInput()).toBe('user input')
 
-			expect(askForRequiredStringMock).toHaveBeenCalledTimes(1)
-			expect(askForRequiredStringMock).toHaveBeenCalledWith('String Def', undefined)
+			expect(askForStringMock).toHaveBeenCalledTimes(1)
+			expect(askForStringMock).toHaveBeenCalledWith('String Def', { validate: undefined })
 		})
 
 		test('summarize', async () => {
@@ -122,29 +126,30 @@ describe('stringDef', () => {
 		})
 
 		test('update', async () => {
-			askForRequiredStringMock.mockResolvedValueOnce('updated')
+			askForStringMock.mockResolvedValueOnce('updated')
 
 			expect(await def.updateFromUserInput('original')).toBe('updated')
 
-			expect(askForRequiredStringMock).toHaveBeenCalledTimes(1)
-			expect(askForRequiredStringMock).toHaveBeenCalledWith('String Def', undefined, { default: 'original' })
+			expect(askForStringMock).toHaveBeenCalledTimes(1)
+			expect(askForStringMock).toHaveBeenCalledWith('String Def', { default: 'original' })
 		})
 	})
 
 	describe('with validation', () => {
 		const validateMock = jest.fn()
-		const def = stringDef('String Def', validateMock)
+		const def = stringDef('String Def', { validate: validateMock })
 
 		test('build', async () => {
 			const context = ['context item']
-			askForRequiredStringMock.mockResolvedValueOnce('user input')
+			askForStringMock.mockResolvedValueOnce('user input')
 
 			expect(await def.buildFromUserInput(context)).toBe('user input')
 
-			expect(askForRequiredStringMock).toHaveBeenCalledTimes(1)
-			expect(askForRequiredStringMock).toHaveBeenCalledWith('String Def', expect.any(Function))
+			expect(askForStringMock).toHaveBeenCalledTimes(1)
+			expect(askForStringMock).toHaveBeenCalledWith('String Def',
+				{ validate: expect.any(Function) })
 
-			const validateFn = askForRequiredStringMock.mock.calls[0][1] as ValidateFunction
+			const validateFn = askForStringMock.mock.calls[0][1]?.validate as ValidateFunction
 			validateMock.mockReturnValueOnce('validation answer')
 			expect(validateFn('input string')).toBe('validation answer')
 			expect(validateMock).toHaveBeenCalledTimes(1)
@@ -153,14 +158,15 @@ describe('stringDef', () => {
 
 		test('update', async () => {
 			const context = ['context item']
-			askForRequiredStringMock.mockResolvedValueOnce('updated')
+			askForStringMock.mockResolvedValueOnce('updated')
 
 			expect(await def.updateFromUserInput('original', context)).toBe('updated')
 
-			expect(askForRequiredStringMock).toHaveBeenCalledTimes(1)
-			expect(askForRequiredStringMock).toHaveBeenCalledWith('String Def', expect.any(Function), { default: 'original' })
+			expect(askForStringMock).toHaveBeenCalledTimes(1)
+			expect(askForStringMock).toHaveBeenCalledWith('String Def',
+				{ default: 'original', validate: expect.any(Function) })
 
-			const validateFn = askForRequiredStringMock.mock.calls[0][1] as ValidateFunction
+			const validateFn = askForStringMock.mock.calls[0][1]?.validate as ValidateFunction
 			validateMock.mockReturnValueOnce('validation answer')
 			expect(validateFn('input string')).toBe('validation answer')
 			expect(validateMock).toHaveBeenCalledTimes(1)

--- a/packages/lib/src/api-command.ts
+++ b/packages/lib/src/api-command.ts
@@ -28,8 +28,15 @@ export abstract class APICommand<T extends typeof APICommand.flags> extends Smar
 		}),
 	}
 
+	static toURL = (nameOrURL: string): string => nameOrURL.startsWith('http')
+		? nameOrURL
+		: `https://developer.smartthings.com/docs/api/public/#operation/${nameOrURL}`
+
 	static apiDocsURL = (...names: string[]): string => '\nFor API information, see:\n\n' +
-		names.map(name => `https://developer.smartthings.com/docs/api/public/#operation/${name}`).join(', ')
+		names.map(name => APICommand.toURL(name)).join(', ')
+
+	static itemInputHelpText = (...namesOrURLs: string[]): string => 'More information can be found at:\n  ' +
+		namesOrURLs.map(nameOrURL => APICommand.toURL(nameOrURL)).join('\n  ')
 
 	protected clientIdProvider = defaultClientIdProvider
 	protected token?: string

--- a/packages/lib/src/item-input/array.ts
+++ b/packages/lib/src/item-input/array.ts
@@ -14,6 +14,8 @@ import {
 	FinishAction,
 	finishAction,
 	finishOption,
+	helpAction,
+	helpOption,
 	InputDefinition,
 	inquirerPageSize,
 	maxItemValueLength,
@@ -44,6 +46,8 @@ export type ArrayDefOptions<T> = {
 	 * The maximum number of items allowed. The default is to not have a limit.
 	 */
 	maxItems?: number
+
+	helpText?: string
 }
 
 /**
@@ -113,6 +117,9 @@ export function arrayDef<T>(name: string, itemDef: InputDefinition<T>, options?:
 				choices.push(new Separator())
 			}
 
+			if (options?.helpText) {
+				choices.push(helpOption)
+			}
 			if (!options?.maxItems || list.length < options.maxItems) {
 				choices.push(addOption(itemDef.name))
 			}
@@ -135,6 +142,8 @@ export function arrayDef<T>(name: string, itemDef: InputDefinition<T>, options?:
 				if (newValue !== cancelAction && checkForDuplicate(list, newValue, -1)) {
 					list.push(newValue)
 				}
+			} else if (action === helpAction) {
+				console.log(`\n${options?.helpText}\n`)
 			} else if (typeof action === 'number') {
 				await editItem(itemDef, list, action, context)
 			} else if (action === finishAction) {
@@ -185,6 +194,8 @@ export type CheckboxDefOptions<T> = {
 	validate?: (item: T[]) => string | true
 
 	default?: T[]
+
+	helpText?: string
 }
 
 type ComplexCheckboxDefItem<T> = {
@@ -195,6 +206,11 @@ export type CheckboxDefItem<T> = T extends string ? string | ComplexCheckboxDefI
 
 export function checkboxDef<T>(name: string, items: CheckboxDefItem<T>[], options?: CheckboxDefOptions<T>): InputDefinition<T[]> {
 	const editValues = async (values: T[]): Promise<T[] | CancelAction> => {
+		// We can't add help to the inquirer `checkbox` so, at least for now, we'll just display
+		// the help before we display the checkbox.
+		if (options?.helpText) {
+			console.log(`\n${options.helpText}\n`)
+		}
 		const choices: ChoiceCollection = items.map(item => {
 			const value = typeof item === 'string' ? item as T : item.value
 			if (values.includes(value)) {

--- a/packages/lib/src/item-input/defs.ts
+++ b/packages/lib/src/item-input/defs.ts
@@ -83,6 +83,10 @@ export const finishAction = Symbol('finish')
 export type FinishAction = typeof finishAction
 export const finishOption = (name: string): DistinctChoice => ({ name: `Finish editing ${name}.`, value: finishAction })
 
+export const helpAction = Symbol('help')
+export type HelpAction = typeof helpAction
+export const helpOption: DistinctChoice = ({ name: 'Help', value: helpAction })
+
 export const previewJSONAction = Symbol('previewJSON')
 export const previewYAMLAction = Symbol('previewYAML')
 

--- a/packages/lib/src/item-input/misc.ts
+++ b/packages/lib/src/item-input/misc.ts
@@ -1,4 +1,4 @@
-import { askForRequiredString, askForString, ValidateFunction } from '../user-query'
+import { askForString, askForOptionalString, AskForStringOptions, ValidateFunction } from '../user-query'
 import { InputDefinition, InputDefinitionValidateFunction, Uneditable, uneditable } from './defs'
 
 
@@ -7,22 +7,29 @@ export const validateWithContextFn = (validate?: InputDefinitionValidateFunction
 		? (input: string): true | string | Promise<string | true> => validate(input, context)
 		: undefined
 
-export const optionalStringDef = (name: string, validate?: InputDefinitionValidateFunction): InputDefinition<string | undefined> => {
+export type StringDefOptions = Omit<AskForStringOptions, 'validate'> & {
+	validate?: InputDefinitionValidateFunction
+}
+export const optionalStringDef = (name: string, options?: StringDefOptions): InputDefinition<string | undefined> => {
 	const buildFromUserInput = async (context?: unknown[]): Promise<string | undefined> =>
-		askForString(`${name} (optional)`, validateWithContextFn(validate, context))
+		askForOptionalString(`${name} (optional)`,
+			{ ...options, validate: validateWithContextFn(options?.validate, context) })
 	const summarizeForEdit = (original: string): string => original
 	const updateFromUserInput = (original: string, context?: unknown[]): Promise<string | undefined> =>
-		askForString(`${name} (optional)`, validateWithContextFn(validate, context), { default: original })
+		askForOptionalString(`${name} (optional)`,
+			{ ...options, default: original, validate: validateWithContextFn(options?.validate, context) })
 
 	return { name, buildFromUserInput, summarizeForEdit, updateFromUserInput }
 }
 
-export const stringDef = (name: string, validate?: InputDefinitionValidateFunction): InputDefinition<string> => {
+export const stringDef = (name: string, options?: StringDefOptions): InputDefinition<string> => {
 	const buildFromUserInput = async (context?: unknown[]): Promise<string> =>
-		askForRequiredString(name, validateWithContextFn(validate, context))
+		askForString(name,
+			{ ...options, validate: validateWithContextFn(options?.validate, context) })
 	const summarizeForEdit = (value: string): string => value
 	const updateFromUserInput = (original: string, context?: unknown[]): Promise<string> =>
-		askForRequiredString(name, validateWithContextFn(validate, context), { default: original })
+		askForString(name,
+			{ ...options, default: original, validate: validateWithContextFn(options?.validate, context) })
 
 	return { name, buildFromUserInput, summarizeForEdit, updateFromUserInput }
 }


### PR DESCRIPTION
<!-- Describe your pull request. -->

This adds support for help text on inputs in the new `item-input` module.

Primary changes:

* added support for `helpText` to `askForString` to `askForOptionalString` functions which adds " (? for help)" text to prompt and displays value of `helpText` if the user enters "?"
* added support for `helpText` to `arrayDef`, `checkboxDef` and `objectDef`
* used new `helpText` for these functions in several places
* updated unit tests for updated code

Secondary cleanup:

* renamed `askForString` to `askForOptionalString` and updated calls to it (now matches naming convention used for `optionalStringDef`)
* renamed `askForRequiredString` to `askForString` and updated calls to it (now matches naming convention used for `stringDef`)
* combined code for `askForOptionalString` and `askForString` into a function called by both
* moved `validate` argument into `options` argument for both `askForOptionalString` and `askForString`
* moved `validate` argument into `options` argument for both `optionalStringDef` and `stringDef`
* created `AskForStringOptions` type for `options` argument to `askForString` to `askForOptionalString`
* use new `AskForStringOptions` as base for `StringDefOptions` type for `optionalStringDef` and `stringDef` functions

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
