### PR TITLE
feat: include search-parameters.yaml in edge driver package

### DIFF
--- a/.changeset/shiny-bananas-add.md
+++ b/.changeset/shiny-bananas-add.md
@@ -1,0 +1,6 @@
+---
+"@smartthings/plugin-cli-edge": minor
+"@smartthings/cli": minor
+---
+
+include search-parameters.yaml (or .yml) in edge driver package

--- a/packages/edge/src/commands/edge/drivers/package.ts
+++ b/packages/edge/src/commands/edge/drivers/package.ts
@@ -5,8 +5,15 @@ import JSZip from 'jszip'
 
 import { outputItem, OutputItemConfig, readFile } from '@smartthings/cli-lib'
 
-import { buildTestFileMatchers, processConfigFile, processFingerprintsFile, processProfiles,
-	processSrcDir, resolveProjectDirName } from '../../../lib/commands/drivers/package-util'
+import {
+	buildTestFileMatchers,
+	processConfigFile,
+	processFingerprintsFile,
+	processProfiles,
+	processSearchParametersFile,
+	processSrcDir,
+	resolveProjectDirName,
+} from '../../../lib/commands/drivers/package-util'
 import { chooseChannel } from '../../../lib/commands/channels-util'
 import { chooseHub } from '../../../lib/commands/drivers-util'
 import { EdgeCommand } from '../../../lib/edge-command'
@@ -125,6 +132,7 @@ $ smartthings edge:drivers:package -u driver.zip`]
 			await processConfigFile(projectDirectory, zip)
 
 			await processFingerprintsFile(projectDirectory, zip)
+			await processSearchParametersFile(projectDirectory, zip)
 			const edgeDriverTestDirs = this.stringArrayConfigValue('edgeDriverTestDirs', ['test/**', 'tests/**'])
 			const testFileMatchers = buildTestFileMatchers(edgeDriverTestDirs)
 			if (!await processSrcDir(projectDirectory, zip, testFileMatchers)) {

--- a/packages/edge/src/lib/commands/drivers/package-util.ts
+++ b/packages/edge/src/lib/commands/drivers/package-util.ts
@@ -35,14 +35,20 @@ export const processConfigFile = async (projectDirectory: string, zip: JSZip): P
 	return parsedConfig
 }
 
-export const processFingerprintsFile = async (projectDirectory: string, zip: JSZip): Promise<void> => {
-	const fingerprintsFile = await findYAMLFilename(`${projectDirectory}/fingerprints`)
-	if (fingerprintsFile !== false) {
+export const processOptionalYAMLFile = async (baseFilename: string, projectDirectory: string, zip: JSZip): Promise<void> => {
+	const yamlFile = await findYAMLFilename(`${projectDirectory}/${baseFilename}`)
+	if (yamlFile !== false) {
 		// validate file is at least parsable as a YAML file
-		readYAMLFile(fingerprintsFile)
-		zip.file('fingerprints.yml', fs.createReadStream(fingerprintsFile))
+		readYAMLFile(yamlFile)
+		zip.file(`${baseFilename}.yml`, fs.createReadStream(yamlFile))
 	}
 }
+
+export const processFingerprintsFile = async (projectDirectory: string, zip: JSZip): Promise<void> =>
+	processOptionalYAMLFile('fingerprints', projectDirectory, zip)
+
+export const processSearchParametersFile = async (projectDirectory: string, zip: JSZip): Promise<void> =>
+	processOptionalYAMLFile('search-parameters', projectDirectory, zip)
 
 export const buildTestFileMatchers = (matchersFromConfig: string[]): picomatch.Matcher[] =>
 	matchersFromConfig.map(glob => picomatch(glob))


### PR DESCRIPTION
<!-- Describe your pull request. -->

Optionally include `search-parameters.yaml` (or `search-parameters.yml`) in edge driver packages.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
