### PR TITLE
feat: added detail command for default edge drivers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4800,9 +4800,9 @@
 			"link": true
 		},
 		"node_modules/@smartthings/core-sdk": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-7.1.0.tgz",
-			"integrity": "sha512-lWm9EPEgKeFPa5UAaOHJwfCtO12U7rfTNHTx0uFXJr4FcEucuzoN/OhAyDnw7UZtAaPU2UGT+dX0wwEzOTqXvw==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-7.1.1.tgz",
+			"integrity": "sha512-ICTyNNu6yF2hsuKKFfftKnChDcMajUCgVFW4xTpJQzUdCgjZFaj2znF4J+ZnxTbyPxgk5Rq9hcQnVecTK2Zm3g==",
 			"dependencies": {
 				"async-mutex": "^0.4.0",
 				"axios": "^0.27.2",
@@ -19810,7 +19810,7 @@
 				"@oclif/plugin-not-found": "^2.3.1",
 				"@oclif/plugin-plugins": "^2.1.0",
 				"@smartthings/cli-lib": "^2.1.0",
-				"@smartthings/core-sdk": "^7.1.0",
+				"@smartthings/core-sdk": "^7.1.1",
 				"@smartthings/plugin-cli-edge": "^3.2.0",
 				"inquirer": "^8.2.4",
 				"js-yaml": "^4.1.0",
@@ -19865,7 +19865,7 @@
 				"@log4js-node/log4js-api": "^1.0.2",
 				"@oclif/core": "^1.16.3",
 				"@smartthings/cli-lib": "^2.1.0",
-				"@smartthings/core-sdk": "^7.1.0",
+				"@smartthings/core-sdk": "^7.1.1",
 				"axios": "^0.27.2",
 				"inquirer": "^8.2.4",
 				"js-yaml": "^4.1.0",
@@ -19911,7 +19911,7 @@
 			"dependencies": {
 				"@log4js-node/log4js-api": "^1.0.2",
 				"@oclif/core": "^1.16.3",
-				"@smartthings/core-sdk": "^7.1.0",
+				"@smartthings/core-sdk": "^7.1.1",
 				"@types/eventsource": "^1.1.9",
 				"axios": "^0.27.2",
 				"chalk": "^4.1.2",
@@ -19977,7 +19977,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smartthings/cli-lib": "^2.1.0",
-				"@smartthings/core-sdk": "^7.1.0"
+				"@smartthings/core-sdk": "^7.1.1"
 			},
 			"devDependencies": {
 				"@types/jest": "^28.1.5",
@@ -23939,7 +23939,7 @@
 				"@oclif/plugin-plugins": "^2.1.0",
 				"@smartthings/cli-lib": "^2.1.0",
 				"@smartthings/cli-testlib": "^2.0.2",
-				"@smartthings/core-sdk": "^7.1.0",
+				"@smartthings/core-sdk": "^7.1.1",
 				"@smartthings/plugin-cli-edge": "^3.2.0",
 				"@types/inquirer": "^8.2.1",
 				"@types/jest": "^28.1.5",
@@ -23980,7 +23980,7 @@
 			"requires": {
 				"@log4js-node/log4js-api": "^1.0.2",
 				"@oclif/core": "^1.16.3",
-				"@smartthings/core-sdk": "^7.1.0",
+				"@smartthings/core-sdk": "^7.1.1",
 				"@types/eventsource": "^1.1.9",
 				"@types/express": "^4.17.13",
 				"@types/inquirer": "^8.2.1",
@@ -24034,7 +24034,7 @@
 			"version": "file:packages/testlib",
 			"requires": {
 				"@smartthings/cli-lib": "^2.1.0",
-				"@smartthings/core-sdk": "^7.1.0",
+				"@smartthings/core-sdk": "^7.1.1",
 				"@types/jest": "^28.1.5",
 				"@types/js-yaml": "^4.0.5",
 				"@types/node": "^18.15.11",
@@ -24054,9 +24054,9 @@
 			}
 		},
 		"@smartthings/core-sdk": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-7.1.0.tgz",
-			"integrity": "sha512-lWm9EPEgKeFPa5UAaOHJwfCtO12U7rfTNHTx0uFXJr4FcEucuzoN/OhAyDnw7UZtAaPU2UGT+dX0wwEzOTqXvw==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-7.1.1.tgz",
+			"integrity": "sha512-ICTyNNu6yF2hsuKKFfftKnChDcMajUCgVFW4xTpJQzUdCgjZFaj2znF4J+ZnxTbyPxgk5Rq9hcQnVecTK2Zm3g==",
 			"requires": {
 				"async-mutex": "^0.4.0",
 				"axios": "^0.27.2",
@@ -24084,7 +24084,7 @@
 				"@oclif/core": "^1.16.3",
 				"@smartthings/cli-lib": "^2.1.0",
 				"@smartthings/cli-testlib": "^2.0.2",
-				"@smartthings/core-sdk": "^7.1.0",
+				"@smartthings/core-sdk": "^7.1.1",
 				"@types/cli-table": "^0.3.0",
 				"@types/eventsource": "^1.1.8",
 				"@types/inquirer": "^8.2.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,7 +77,7 @@
 		"@oclif/plugin-not-found": "^2.3.1",
 		"@oclif/plugin-plugins": "^2.1.0",
 		"@smartthings/cli-lib": "^2.1.0",
-		"@smartthings/core-sdk": "^7.1.0",
+		"@smartthings/core-sdk": "^7.1.1",
 		"@smartthings/plugin-cli-edge": "^3.2.0",
 		"inquirer": "^8.2.4",
 		"js-yaml": "^4.1.0",

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -48,7 +48,7 @@
 		"@log4js-node/log4js-api": "^1.0.2",
 		"@oclif/core": "^1.16.3",
 		"@smartthings/cli-lib": "^2.1.0",
-		"@smartthings/core-sdk": "^7.1.0",
+		"@smartthings/core-sdk": "^7.1.1",
 		"axios": "^0.27.2",
 		"inquirer": "^8.2.4",
 		"js-yaml": "^4.1.0",

--- a/packages/edge/src/__tests__/commands/edge/drivers/default.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/drivers/default.test.ts
@@ -1,6 +1,6 @@
 import { DriversEndpoint, EdgeDriverSummary } from '@smartthings/core-sdk'
 
-import { outputList } from '@smartthings/cli-lib'
+import { outputItemOrList } from '@smartthings/cli-lib'
 
 import DriversDefaultCommand from '../../../../commands/edge/drivers/default'
 
@@ -10,21 +10,36 @@ jest.mock('@smartthings/cli-lib', () => {
 
 	return {
 		...originalLib,
-		outputList: jest.fn(),
+		outputItemOrList: jest.fn(),
 	}
 })
 jest.mock('../../../../../src/lib/commands/drivers-util')
 
 describe('DriversDefaultCommand', () => {
-	const outputListMock = jest.mocked(outputList)
+	const outputItemOrListMock = jest.mocked(outputItemOrList)
 
-	it('uses outputList', async () => {
+	it('uses outputItemOrList', async () => {
 		await expect(DriversDefaultCommand.run([])).resolves.not.toThrow()
 
-		expect(outputListMock).toHaveBeenCalledTimes(1)
-		expect(outputListMock).toHaveBeenCalledWith(
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
 			expect.any(DriversDefaultCommand),
 			expect.objectContaining({ primaryKeyName: 'driverId' }),
+			undefined,
+			expect.any(Function),
+			expect.any(Function),
+		)
+	})
+
+	it('accepts index or ID', async () => {
+		await expect(DriversDefaultCommand.run(['id'])).resolves.not.toThrow()
+
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledWith(
+			expect.any(DriversDefaultCommand),
+			expect.objectContaining({ primaryKeyName: 'driverId' }),
+			'id',
+			expect.any(Function),
 			expect.any(Function),
 		)
 	})
@@ -32,9 +47,9 @@ describe('DriversDefaultCommand', () => {
 	it('uses listDefaultDrivers to list drivers', async () => {
 		await expect(DriversDefaultCommand.run([])).resolves.not.toThrow()
 
-		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(outputItemOrListMock).toHaveBeenCalledTimes(1)
 
-		const listFunction = outputListMock.mock.calls[0][2]
+		const listFunction = outputItemOrListMock.mock.calls[0][3]
 
 		const driverList = [{ driverId: 'driver-in-list-id' }] as EdgeDriverSummary[]
 		const listDefaultSpy = jest.spyOn(DriversEndpoint.prototype, 'listDefault')

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -30,7 +30,7 @@
 	"dependencies": {
 		"@log4js-node/log4js-api": "^1.0.2",
 		"@oclif/core": "^1.16.3",
-		"@smartthings/core-sdk": "^7.1.0",
+		"@smartthings/core-sdk": "^7.1.1",
 		"@types/eventsource": "^1.1.9",
 		"axios": "^0.27.2",
 		"chalk": "^4.1.2",

--- a/packages/testlib/package.json
+++ b/packages/testlib/package.json
@@ -29,7 +29,7 @@
 	},
 	"dependencies": {
 		"@smartthings/cli-lib": "^2.1.0",
-		"@smartthings/core-sdk": "^7.1.0"
+		"@smartthings/core-sdk": "^7.1.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.5",


### PR DESCRIPTION
Added the ability to display details of standard default edge drivers

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
