### PR TITLE
feat: locally executing virtual devices

### DIFF
--- a/.changeset/lemon-bottles-beam.md
+++ b/.changeset/lemon-bottles-beam.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+feat: locally executing virtual devices

--- a/packages/cli/src/__tests__/commands/virtualdevices/create-standard.test.ts
+++ b/packages/cli/src/__tests__/commands/virtualdevices/create-standard.test.ts
@@ -83,6 +83,7 @@ describe('VirtualDeviceStandardCreateCommand', () => {
 			},
 			roomId: 'room-id',
 			prototype: 'VIRTUAL_SWITCH',
+			executionTarget: 'CLOUD',
 		}
 
 		mockChooseDeviceName.mockResolvedValueOnce('DeviceName')

--- a/packages/cli/src/lib/commands/hubs-util.ts
+++ b/packages/cli/src/lib/commands/hubs-util.ts
@@ -1,0 +1,54 @@
+import {
+	APICommand,
+	selectFromList,
+	SelectFromListConfig,
+	stringTranslateToId,
+} from '@smartthings/cli-lib'
+import { Device, DeviceIntegrationType } from '@smartthings/core-sdk'
+import { DriverChoice, listDrivers } from '@smartthings/plugin-cli-edge/lib/lib/commands/drivers-util'
+
+
+export const chooseHub = async (command: APICommand<typeof APICommand.flags>,
+		promptMessage: string,
+		locationId: string,
+		commandLineHubId: string | undefined,
+		autoChoose?: boolean): Promise<string> => {
+
+	const config: SelectFromListConfig<Device> = {
+		itemName: 'hub',
+		primaryKeyName: 'deviceId',
+		sortKeyName: 'name',
+		listTableFieldDefinitions: ['label', 'name', 'deviceId'],
+	}
+
+	const listItems = (): Promise<Device[]> => {
+		return command.client.devices.list({ type: DeviceIntegrationType.HUB, locationId })
+	}
+
+	const preselectedId = await stringTranslateToId(config, commandLineHubId, listItems)
+
+	return selectFromList(command, config,
+		{ preselectedId, listItems, promptMessage, autoChoose })
+}
+
+export type AllDriverChoice = DriverChoice & { organization: string }
+
+// TODO - consider default org?
+export async function chooseDriver(
+		command: APICommand<typeof APICommand.flags>,
+		promptMessage: string,
+		commandLineDriverId?: string): Promise<string> {
+
+	const config: SelectFromListConfig<DriverChoice> = {
+		itemName: 'driver',
+		primaryKeyName: 'driverId',
+		sortKeyName: 'name',
+		listTableFieldDefinitions: ['name', 'driverId'],
+	}
+
+	const listItems = (): Promise<DriverChoice[]> => listDrivers(command.client, true)
+
+	const preselectedId = await stringTranslateToId(config, commandLineDriverId, listItems)
+
+	return selectFromList(command, config, { preselectedId, listItems, promptMessage })
+}

--- a/packages/cli/src/lib/commands/virtualdevices-util.ts
+++ b/packages/cli/src/lib/commands/virtualdevices-util.ts
@@ -16,7 +16,7 @@ import {
 	SelectFromListConfig,
 } from '@smartthings/cli-lib'
 
-import { chooseDeviceProfile } from '../../lib/commands/deviceprofiles-util'
+import { chooseDeviceProfile } from './deviceprofiles-util'
 
 
 export type DevicePrototype = {
@@ -26,13 +26,16 @@ export type DevicePrototype = {
 
 export const locallyExecutingPrototypes = [
 	{ name: 'Switch', id: 'VIRTUAL_SWITCH' },
-	{ name: 'Dimmer', id: 'VIRTUAL_DIMMER_SWITCH' },
+	{ name: 'Dimmer Switch', id: 'VIRTUAL_DIMMER_SWITCH' },
+]
+
+export const commonPrototypes = [
+	...locallyExecutingPrototypes,
 	{ name: 'More...', id: 'more' },
 ]
 
 export const allPrototypes = [
-	{ name: 'Switch', id: 'VIRTUAL_SWITCH' },
-	{ name: 'Dimmer Switch', id: 'VIRTUAL_DIMMER_SWITCH' },
+	...locallyExecutingPrototypes,
 	{ name: 'Button', id: 'VIRTUAL_BUTTON' },
 	{ name: 'Camera', id: 'VIRTUAL_CAMERA' },
 	{ name: 'Color Bulb', id: 'VIRTUAL_COLOR_BULB' },
@@ -100,7 +103,7 @@ export async function chooseDevicePrototype(command: APICommand<typeof APIComman
 	}
 	let prototype = await selectFromList(command, config, {
 		preselectedId,
-		listItems: () => Promise.resolve(locallyExecutingPrototypes),
+		listItems: () => Promise.resolve(commonPrototypes),
 	})
 
 	if (prototype === 'more') {
@@ -110,6 +113,18 @@ export async function chooseDevicePrototype(command: APICommand<typeof APIComman
 	}
 
 	return prototype
+}
+
+export async function chooseLocallyExecutingDevicePrototype(command: APICommand<typeof APICommand.flags>, preselectedId?: string): Promise<string> {
+	const config: SelectFromListConfig<DevicePrototype> = {
+		itemName: 'device prototype',
+		primaryKeyName: 'id',
+		listTableFieldDefinitions: ['name', 'id'],
+	}
+	return await selectFromList(command, config, {
+		preselectedId,
+		listItems: () => Promise.resolve(locallyExecutingPrototypes),
+	})
 }
 
 export const chooseComponent = async (command: APICommand<typeof APICommand.flags>, device: Device): Promise<Component> => {


### PR DESCRIPTION
Added support for locally executing virtual devices

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
