### PR TITLE
chore: reverted minimum node version to 18.5.0

### DIFF
--- a/.changeset/twelve-rings-draw.md
+++ b/.changeset/twelve-rings-draw.md
@@ -1,0 +1,8 @@
+---
+"@smartthings/cli-lib": patch
+"@smartthings/cli-testlib": patch
+"@smartthings/plugin-cli-edge": patch
+"@smartthings/cli": patch
+---
+
+chore: reverted minimum node version to 18.5.0

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.15.0
+          node-version: 18.5.0
 
       - name: Install Dependencies
         run: npm ci
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.15.0
+          node-version: 18.5.0
 
       - run: npm ci
       - run: npm run build
@@ -172,7 +172,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.15.0
+          node-version: 18.5.0
 
       - run: npm ci
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.15.0
+          node-version: 18.5.0
       - run: npm ci --workspaces=false
       - run: npx commitlint --from HEAD~${{ github.event.pull_request.commits }} --to HEAD
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
 	"license": "Apache-2.0",
 	"main": "lib/index.js",
 	"engines": {
-		"node": ">=18.15.0 <19",
+		"node": ">=18.5.0 <19",
 		"npm": ">=9.5"
 	},
 	"files": [

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -11,7 +11,7 @@
 	"main": "lib/index",
 	"types": "lib/index",
 	"engines": {
-		"node": ">=18.15.0 <19",
+		"node": ">=18.5.0 <19",
 		"npm": ">=9.5"
 	},
 	"files": [

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -11,7 +11,7 @@
 	"main": "dist/index",
 	"types": "dist/index",
 	"engines": {
-		"node": ">=18.15.0 <19",
+		"node": ">=18.5.0 <19",
 		"npm": ">=9.5"
 	},
 	"files": [

--- a/packages/testlib/package.json
+++ b/packages/testlib/package.json
@@ -11,7 +11,7 @@
 	"main": "dist/index",
 	"types": "dist/index",
 	"engines": {
-		"node": ">=18.15.0 <19",
+		"node": ">=18.5.0 <19",
 		"npm": ">=9.5"
 	},
 	"files": [


### PR DESCRIPTION
Reverted minimum node version to 18.5.0 for consistency with packaging

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
