### PR TITLE
fix: make cancel action actually cancel even when there are validation errors

### DIFF
--- a/.changeset/short-timers-exercise.md
+++ b/.changeset/short-timers-exercise.md
@@ -1,0 +1,6 @@
+---
+"@smartthings/cli-lib": patch
+"@smartthings/cli": patch
+---
+
+Fixed cancel action on schema:create command when validation errors exist.

--- a/packages/lib/src/item-input/command-helpers.ts
+++ b/packages/lib/src/item-input/command-helpers.ts
@@ -1,6 +1,7 @@
 import inquirer, { ChoiceCollection } from 'inquirer'
 
 import { jsonFormatter, OutputFormatter, yamlFormatter } from '../output'
+import { red } from '../colors'
 import { SmartThingsCommandInterface } from '../smartthings-command'
 import {
 	cancelAction,
@@ -11,7 +12,6 @@ import {
 	previewJSONAction,
 	previewYAMLAction,
 } from './defs'
-import { red } from 'chalk'
 
 
 export type UpdateFromUserInputOptions = {
@@ -55,9 +55,10 @@ export const updateFromUserInput = async <T extends object>(command: SmartThings
 		if (validationResult !== true) {
 			console.log(red(validationResult))
 			const answer = await inputDefinition.updateFromUserInput(retVal)
-			if (answer !== cancelAction) {
-				retVal = answer
+			if (answer === cancelAction) {
+				command.cancel()
 			}
+			retVal = answer
 			continue
 		}
 		const choices: ChoiceCollection = [
@@ -76,7 +77,7 @@ export const updateFromUserInput = async <T extends object>(command: SmartThings
 			name: 'action',
 			message: 'Choose an action.',
 			choices,
-			default: validationResult === true ? finishAction : editAction,
+			default: finishAction,
 		})).action
 
 		if (action === editAction) {

--- a/packages/lib/src/item-input/defs.ts
+++ b/packages/lib/src/item-input/defs.ts
@@ -84,7 +84,8 @@ export type InputDefinition<T> = {
  */
 export type InputDefinitionValidateFunction = (input: string,
 	context?: unknown[]) => true | string | Promise<true | string>
-export type InputDefinitionDefaultValueOrFn<T> = T | ((context?: unknown[]) => T)
+export type DefaultValueFunction<T> = (context?: unknown[]) => T
+export type InputDefinitionDefaultValueOrFn<T> = T | DefaultValueFunction<T>
 
 export const addAction = Symbol('add')
 export type AddAction = typeof addAction

--- a/packages/lib/src/item-input/misc.ts
+++ b/packages/lib/src/item-input/misc.ts
@@ -1,5 +1,13 @@
 import inquirer, { ChoiceCollection } from 'inquirer'
-import { askForString, askForOptionalString, AskForStringOptions, ValidateFunction, AskForBooleanOptions, askForBoolean, DefaultValueOrFn } from '../user-query'
+import {
+	askForString,
+	askForOptionalString,
+	AskForStringOptions,
+	ValidateFunction,
+	AskForBooleanOptions,
+	askForBoolean,
+	DefaultValueOrFn,
+} from '../user-query'
 import {
 	CancelAction,
 	InputDefinition,

--- a/packages/lib/src/item-input/object.ts
+++ b/packages/lib/src/item-input/object.ts
@@ -162,7 +162,7 @@ export function objectDef<T extends object>(name: string, inputDefsByProperty: I
 			if (action === helpAction) {
 				console.log(`\n${options?.helpText}\n`)
 			} else if (action === cancelAction) {
-				return original
+				return cancelAction
 			} else if (action === finishAction) {
 				return updated
 			} else {
@@ -190,10 +190,6 @@ export function objectDef<T extends object>(name: string, inputDefsByProperty: I
 							} else if (propertyName === updatedPropertyName) {
 								afterUpdatedProperty = true
 							}
-							const propertyInputDefinition = inputDefsByProperty[propertyName]
-							if (!propertyInputDefinition) {
-								continue
-							}
 						}
 					}
 				} else {
@@ -218,7 +214,7 @@ export function objectDef<T extends object>(name: string, inputDefsByProperty: I
 								const laterPropertyInputDefinition = inputDefsByProperty[propertyName]
 								const updateIfNeeded = laterPropertyInputDefinition.updateIfNeeded
 								if (updateIfNeeded) {
-									const laterPropertyValue = await updateIfNeeded(updated[propertyName], updatedPropertyName, [{ ...updated }, ...context])
+									const laterPropertyValue = await updateIfNeeded(updated[propertyName], action, [{ ...updated }, ...context])
 									if (laterPropertyValue !== cancelAction) {
 										updated[propertyName] = laterPropertyValue
 									}
@@ -227,10 +223,6 @@ export function objectDef<T extends object>(name: string, inputDefsByProperty: I
 								// TODO: also do rolled up properties in `propertyName` after nested property
 								// (Once this is implemented, remove note from documentation for this function.)
 								afterUpdatedProperty = true
-							}
-							const propertyInputDefinition = inputDefsByProperty[propertyName]
-							if (!propertyInputDefinition) {
-								continue
 							}
 						}
 					}


### PR DESCRIPTION
* Fixed cancel action to actually cancel even when validation errors exist.

<!-- Describe your pull request. -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
