### PR TITLE
fix: fix issue with ctrl-c not working while connecting

### DIFF
--- a/.changeset/weak-eagles-drop.md
+++ b/.changeset/weak-eagles-drop.md
@@ -1,0 +1,6 @@
+---
+"@smartthings/plugin-cli-edge": patch
+"@smartthings/cli-lib": patch
+---
+
+fixed issue where ctrl-c wouldn't work while connecting

--- a/packages/edge/src/__tests__/commands/edge/drivers/logcat.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/drivers/logcat.test.ts
@@ -124,6 +124,7 @@ describe('LogCatCommand', () => {
 		})
 
 		it('sets a timeout for eventsource that is cleared when connected', async () => {
+			const setupSignalHandlerSpy = jest.spyOn(SseCommand.prototype, 'setupSignalHandler')
 			await expect(LogCatCommand.run([`--hub-address=${MOCK_IPV4}`, '--all'])).resolves.not.toThrow()
 
 			expect(setTimeoutSpy).toBeCalledWith(expect.any(Function), 30000)
@@ -138,7 +139,9 @@ describe('LogCatCommand', () => {
 
 			const timeoutID: NodeJS.Timeout = setTimeoutSpy.mock.results[0].value
 
-			expect(clearTimeoutSpy).toBeCalledWith(timeoutID)
+			expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+			expect(clearTimeoutSpy).toHaveBeenCalledWith(timeoutID)
+			expect(setupSignalHandlerSpy).toHaveBeenCalledTimes(1)
 		})
 
 		it('initializes a LogClient with a host verifier function and timeout', async () => {

--- a/packages/edge/src/commands/edge/drivers/logcat.ts
+++ b/packages/edge/src/commands/edge/drivers/logcat.ts
@@ -236,6 +236,7 @@ export default class LogCatCommand extends SseCommand<typeof LogCatCommand.flags
 			}
 
 			CliUx.ux.action.stop(green('connected'))
+			this.setupSignalHandler()
 		}
 
 		this.source.onerror = (error: EventSourceError) => {

--- a/packages/lib/src/__tests__/sse-command.test.ts
+++ b/packages/lib/src/__tests__/sse-command.test.ts
@@ -76,9 +76,9 @@ describe('SseCommand', () => {
 		)
 	})
 
-	it('registers signal handler on initialization', async () => {
+	test('setupSignalHandler', async () => {
 		parseSpy.mockResolvedValueOnce({ args: {}, flags } as ParserOutputType)
-		await sseCommand.init()
+		sseCommand.setupSignalHandler()
 
 		expect(handleSignalsSpy).toBeCalled()
 	})

--- a/packages/lib/src/sse-command.ts
+++ b/packages/lib/src/sse-command.ts
@@ -66,9 +66,7 @@ export abstract class SseCommand<T extends typeof SseCommand.flags> extends APIC
 		}
 	}
 
-	async init(): Promise<void> {
-		await super.init()
-
+	setupSignalHandler(): void {
 		handleSignals(signal => {
 			this.logger.debug(`handling ${signal} and tearing down SseCommand`)
 


### PR DESCRIPTION
<!-- Describe your pull request. -->

Moved trapping of interrupt signal (user pressing ctrl-c) to after a connection is made to prevent a hangup trying to tear down close a connection that isn't open yet.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
