### PR TITLE
fix: fix channel name lookup bug for edge drivers

### DIFF
--- a/.changeset/chilled-dodos-attack.md
+++ b/.changeset/chilled-dodos-attack.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/plugin-cli-edge": patch
+---
+
+fix channel name lookup bug for edge:drivers:installed command

--- a/packages/edge/src/__tests__/lib/commands/channels-util.test.ts
+++ b/packages/edge/src/__tests__/lib/commands/channels-util.test.ts
@@ -305,5 +305,20 @@ describe('channels-util', () => {
 			expect(apiListChannelsMock).toHaveBeenCalledWith(expect.objectContaining({ includeReadOnly: true }))
 			expect(apiGetChannelsMock).toHaveBeenCalledTimes(0)
 		})
+
+		it('looks up and adds channel name when missing from list', async () => {
+			apiListChannelsMock.mockResolvedValueOnce([channel1])
+			apiGetChannelsMock.mockResolvedValueOnce(channel2)
+
+			expect(await withChannelNames(client, [thingWithChannel1, thingWithChannel2])).toStrictEqual([
+				{ channelId: 'channel-id-1', channelName: 'Channel 1' },
+				{ channelId: 'channel-id-2', channelName: 'Channel 2' },
+			])
+
+			expect(apiListChannelsMock).toHaveBeenCalledTimes(1)
+			expect(apiListChannelsMock).toHaveBeenCalledWith(expect.objectContaining({ includeReadOnly: true }))
+			expect(apiGetChannelsMock).toHaveBeenCalledTimes(1)
+			expect(apiGetChannelsMock).toHaveBeenCalledWith('channel-id-2')
+		})
 	})
 })

--- a/packages/edge/src/lib/commands/channels-util.ts
+++ b/packages/edge/src/lib/commands/channels-util.ts
@@ -95,6 +95,14 @@ export async function withChannelNames<T extends WithChannel>(client: SmartThing
 	if (Array.isArray(input)) {
 		const channels = await listChannels(client, { includeReadOnly: true })
 		const channelNamesById = new Map(channels.map(channel => [channel.channelId, channel.name]))
+
+		for (const inputItem of input) {
+			if (!channelNamesById.get(inputItem.channelId)) {
+				const channelName = (await client.channels.get(inputItem.channelId)).name
+				channelNamesById.set(inputItem.channelId, channelName)
+			}
+		}
+
 		return input.map(input => ({ ...input, channelName: channelNamesById.get(input.channelId) }))
 	}
 


### PR DESCRIPTION
fix bug that was preventing channel name from being displayed in some cases

## Checklist


- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
