### PR TITLE
ci: set specific versions for all functional tests tools

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -127,7 +127,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.9.6'
           cache: 'pip'
 
       # make sure 'smartthings' is available to child processes
@@ -143,7 +143,7 @@ jobs:
 
       - name: Install Dependencies and Run Tests
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --force-reinstall -v pip==23.3.1
           pip install -r requirements.txt
           pytest
         working-directory: packages/cli/functional-tests

--- a/packages/cli/functional-tests/requirements.txt
+++ b/packages/cli/functional-tests/requirements.txt
@@ -1,2 +1,2 @@
-pexpect == 4.*
-pytest == 7.*
+pexpect == 4.8.0
+pytest == 7.4.2


### PR DESCRIPTION
<!-- Describe your pull request. -->

Require specific versions of all Python tools used to run functional tests.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
