### PR TITLE
ci: try Python 3.11.5

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -127,7 +127,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9.6'
+          python-version: '3.11.5'
           cache: 'pip'
 
       # make sure 'smartthings' is available to child processes


### PR DESCRIPTION
<!-- Describe your pull request. -->

Try Python 3.11.5 since it was the last version that succeeded in running functional tests.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
