### PR TITLE
fix: minor history fixes

### DIFF
--- a/.changeset/brave-cars-grin.md
+++ b/.changeset/brave-cars-grin.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+handle epoch timestamps for history, honor `after` flag strictly in JSON and YAML output


### PR DESCRIPTION
<!-- Describe your pull request. -->

* treat integer values for `before` and `after` flags as seconds since the epoch as describe in the help
* refactor: simplified sort function
* refactor: minor reformatting
* refactor: use `confirm` inquirer input type for y/n question instead of text input
* in JSON/YAML output, strictly obey `after`
  * the API first returns items after the specified `after` but allows the user to continue on with the "next" page link
  * the interactive table format output still allows the user to continue on to view items, as the API does
  * when asking for JSON or YAML output, we now strictly obey the `after` flag

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
