### PR TITLE
test: cleanup and fill-in login-authenticator tests a bit

### DIFF
--- a/src/lib/login-authenticator.ts
+++ b/src/lib/login-authenticator.ts
@@ -4,13 +4,14 @@ import path from 'path'
 import axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
 import { createHash, randomBytes, BinaryLike } from 'crypto'
 import express from 'express'
+import { getPort } from 'get-port-please'
 import log4js from 'log4js'
 import open from 'open'
 import ora from 'ora'
 import qs from 'qs'
 
 import { SmartThingsURLProvider, defaultSmartThingsURLProvider, Authenticator } from '@smartthings/core-sdk'
-import { getPort } from 'get-port-please'
+
 import { delay } from './util.js'
 
 


### PR DESCRIPTION
<!-- Describe your pull request. -->

* use plain old mock instead of log4js recording logger
* fill in a few missed tests (one block of unreachable code still untested because it's, well, unreachable)
