### PR TITLE
refactor: convert IOFormat enum to simple type

### DIFF
--- a/packages/cli/src/__tests__/commands/apps/create.test.ts
+++ b/packages/cli/src/__tests__/commands/apps/create.test.ts
@@ -33,7 +33,7 @@ describe('AppCreateCommand', () => {
 			}),
 			expect.any(Function),
 			expect.objectContaining({
-				ioFormat: IOFormat.COMMON,
+				ioFormat: 'common',
 				hasInput: expect.any(Function),
 				read: expect.any(Function),
 			}),

--- a/packages/cli/src/__tests__/commands/apps/oauth/generate.test.ts
+++ b/packages/cli/src/__tests__/commands/apps/oauth/generate.test.ts
@@ -30,7 +30,7 @@ describe('AppOauthGenerateCommand', () => {
 				tableFieldDefinitions: expect.arrayContaining(['oauthClientId', 'oauthClientSecret']),
 			}),
 			expect.any(Function),
-			expect.objectContaining({ ioFormat: IOFormat.COMMON }),
+			expect.objectContaining({ ioFormat: 'common' }),
 		)
 	})
 

--- a/packages/cli/src/__tests__/commands/apps/update.test.ts
+++ b/packages/cli/src/__tests__/commands/apps/update.test.ts
@@ -39,7 +39,7 @@ describe('AppUpdateCommand', () => {
 			}),
 			expect.any(Function),
 			{
-				ioFormat: IOFormat.COMMON,
+				ioFormat: 'common',
 				hasInput: expect.any(Function),
 				read: expect.any(Function),
 			},

--- a/packages/cli/src/__tests__/commands/devices/history.test.ts
+++ b/packages/cli/src/__tests__/commands/devices/history.test.ts
@@ -16,7 +16,7 @@ describe('DeviceHistoryCommand', () => {
 	const chooseDeviceMock = jest.mocked(chooseDevice).mockResolvedValue('deviceId')
 	const getDeviceSpy = jest.spyOn(DevicesEndpoint.prototype, 'get').mockImplementation()
 	const historySpy = jest.spyOn(HistoryEndpoint.prototype, 'devices').mockImplementation()
-	const calculateOutputFormatMock = jest.mocked(calculateOutputFormat).mockReturnValue(IOFormat.COMMON)
+	const calculateOutputFormatMock = jest.mocked(calculateOutputFormat).mockReturnValue('common')
 	const writeDeviceEventsTableMock = jest.mocked(writeDeviceEventsTable)
 	const calculateRequestLimitMock = jest.mocked(calculateRequestLimit)
 	const getHistoryMock = jest.mocked(getHistory)
@@ -54,7 +54,7 @@ describe('DeviceHistoryCommand', () => {
 
 		calculateRequestLimitMock.mockReturnValueOnce(20)
 		getDeviceSpy.mockResolvedValueOnce({ locationId: 'locationId' } as Device)
-		calculateOutputFormatMock.mockReturnValueOnce(IOFormat.JSON)
+		calculateOutputFormatMock.mockReturnValueOnce('json')
 		buildOutputFormatterMock.mockReturnValueOnce(outputFormatterMock)
 		getHistoryMock.mockResolvedValueOnce(items)
 

--- a/packages/cli/src/__tests__/commands/locations/history.test.ts
+++ b/packages/cli/src/__tests__/commands/locations/history.test.ts
@@ -19,7 +19,7 @@ jest.mock('../../../commands/locations')
 describe('LocationHistoryCommand', () => {
 	const chooseLocationMock = jest.mocked(chooseLocation).mockResolvedValue('locationId')
 	const historySpy = jest.spyOn(HistoryEndpoint.prototype, 'devices').mockImplementation()
-	const calculateOutputFormatMock = jest.mocked(calculateOutputFormat).mockReturnValue(IOFormat.COMMON)
+	const calculateOutputFormatMock = jest.mocked(calculateOutputFormat).mockReturnValue('common')
 	const writeDeviceEventsTableMock = jest.mocked(writeDeviceEventsTable)
 	const calculateRequestLimitMock = jest.mocked(calculateRequestLimit)
 	const getHistoryMock = jest.mocked(getHistory)
@@ -53,7 +53,7 @@ describe('LocationHistoryCommand', () => {
 		const items = [{ deviceId: 'device-1' }] as DeviceActivity[]
 
 		calculateRequestLimitMock.mockReturnValueOnce(20)
-		calculateOutputFormatMock.mockReturnValueOnce(IOFormat.JSON)
+		calculateOutputFormatMock.mockReturnValueOnce('json')
 		buildOutputFormatterMock.mockReturnValueOnce(outputFormatterMock)
 		getHistoryMock.mockResolvedValueOnce(items)
 

--- a/packages/cli/src/__tests__/commands/schema/update.test.ts
+++ b/packages/cli/src/__tests__/commands/schema/update.test.ts
@@ -13,7 +13,7 @@ describe('SchemaUpdateCommand', () => {
 	const logSpy = jest.spyOn(SchemaUpdateCommand.prototype, 'log').mockImplementation()
 
 	const schemaAppRequest = { appName: 'schemaApp' } as SchemaAppRequest
-	const inputItemMock = jest.mocked(inputItem).mockResolvedValue([schemaAppRequest, IOFormat.JSON])
+	const inputItemMock = jest.mocked(inputItem).mockResolvedValue([schemaAppRequest, 'json'])
 	const addSchemaPermissionMock = jest.mocked(addSchemaPermission)
 	const selectFromListMock = jest.mocked(selectFromList).mockResolvedValue('schemaAppId')
 
@@ -73,7 +73,7 @@ describe('SchemaUpdateCommand', () => {
 			lambdaArnAP: 'lambdaArnAP',
 		} as SchemaAppRequest
 
-		inputItemMock.mockResolvedValueOnce([schemaAppRequest, IOFormat.JSON])
+		inputItemMock.mockResolvedValueOnce([schemaAppRequest, 'json'])
 
 		await expect(SchemaUpdateCommand.run(['--authorize'])).resolves.not.toThrow()
 
@@ -90,7 +90,7 @@ describe('SchemaUpdateCommand', () => {
 			hostingType: 'webhook',
 		} as SchemaAppRequest
 
-		inputItemMock.mockResolvedValueOnce([webhookSchemaRequest, IOFormat.JSON])
+		inputItemMock.mockResolvedValueOnce([webhookSchemaRequest, 'json'])
 
 		await expect(SchemaUpdateCommand.run(['--authorize'])).rejects.toThrow('Authorization is not applicable to WebHook schema connectors')
 		expect(updateSpy).not.toBeCalled()
@@ -102,7 +102,7 @@ describe('SchemaUpdateCommand', () => {
 			hostingType: 'lambda',
 		} as SchemaAppRequest
 
-		inputItemMock.mockResolvedValueOnce([noArnSchemaRequest, IOFormat.JSON])
+		inputItemMock.mockResolvedValueOnce([noArnSchemaRequest, 'json'])
 
 		await expect(SchemaUpdateCommand.run(['--authorize'])).resolves.not.toThrow()
 

--- a/packages/cli/src/commands/devices/history.ts
+++ b/packages/cli/src/commands/devices/history.ts
@@ -48,7 +48,7 @@ export default class DeviceHistoryCommand extends APICommand<typeof DeviceHistor
 			after: toEpochTime(this.flags.after),
 		}
 
-		if (calculateOutputFormat(this) === IOFormat.COMMON) {
+		if (calculateOutputFormat(this) === 'common') {
 			if (limit > perRequestLimit) {
 				this.log(`History is limited to ${maxItemsPerRequest} items per request.`)
 			}

--- a/packages/cli/src/commands/locations/history.ts
+++ b/packages/cli/src/commands/locations/history.ts
@@ -46,7 +46,7 @@ export default class LocationDeviceHistoryCommand extends APICommand<typeof Loca
 			after: toEpochTime(this.flags.after),
 		}
 
-		if (calculateOutputFormat(this) === IOFormat.COMMON) {
+		if (calculateOutputFormat(this) === 'common') {
 			if (limit > perRequestLimit) {
 				this.log(`History is limited to ${maxItemsPerRequest} items per request.`)
 			}

--- a/src/__tests__/commands/config.test.ts
+++ b/src/__tests__/commands/config.test.ts
@@ -1,7 +1,6 @@
 import { ArgumentsCamelCase } from 'yargs'
 
 import { Profile, ProfilesByName } from '../../lib/cli-config'
-import { IOFormat } from '../../lib/io-util'
 import cmd, { CommandArgs, ProfileWithName } from '../../commands/config.js'
 import { outputItem, outputList } from '../../lib/command/basic-io.js'
 import { stringTranslateToId } from '../../lib/command/command-util.js'
@@ -32,7 +31,7 @@ describe('handler', () => {
 	const outputItemMock = jest.mocked(outputItem<ProfileWithName>).mockResolvedValue(profile1WithName)
 	const outputListMock = jest.mocked(outputList<ProfileWithName>).mockResolvedValue([profile1WithName, profile2WithName])
 	const stringTranslateToIdMock = jest.mocked(stringTranslateToId).mockResolvedValue('translated-id')
-	const calculateOutputFormatMock = jest.mocked(calculateOutputFormat).mockReturnValue(IOFormat.COMMON)
+	const calculateOutputFormatMock = jest.mocked(calculateOutputFormat).mockReturnValue('common')
 	const writeOutputMock = jest.mocked(writeOutput)
 	const outputFormatterMock = jest.fn().mockReturnValue('formatted output')
 	const buildOutputFormatterMock = jest.mocked(buildOutputFormatter).mockReturnValue(outputFormatterMock)
@@ -108,7 +107,7 @@ describe('handler', () => {
 		} as SmartThingsCommand<SmartThingsCommandFlags>
 		smartThingsCommandMock.mockResolvedValue(command)
 
-		calculateOutputFormatMock.mockReturnValue(IOFormat.JSON)
+		calculateOutputFormatMock.mockReturnValue('json')
 
 		await expect(cmd.handler(inputArgv)).resolves.not.toThrow()
 
@@ -134,7 +133,7 @@ describe('handler', () => {
 		} as SmartThingsCommand<SmartThingsCommandFlags>
 		smartThingsCommandMock.mockResolvedValue(command)
 
-		calculateOutputFormatMock.mockReturnValue(IOFormat.JSON)
+		calculateOutputFormatMock.mockReturnValue('json')
 		stringTranslateToIdMock.mockResolvedValue('profile2')
 
 		await expect(cmd.handler(inputArgv)).resolves.not.toThrow()

--- a/src/__tests__/lib/cli-config.test.ts
+++ b/src/__tests__/lib/cli-config.test.ts
@@ -1,6 +1,6 @@
-import { readFile, writeFile } from 'fs/promises'
-
 import { jest } from '@jest/globals'
+
+import { readFile, writeFile } from 'fs/promises'
 
 import yaml from 'js-yaml'
 

--- a/src/__tests__/lib/command/basic-io.test.ts
+++ b/src/__tests__/lib/command/basic-io.test.ts
@@ -43,7 +43,7 @@ describe('inputItem', () => {
 	}
 
 	const inputProcessor: InputProcessor<SimpleType> = {
-		get ioFormat(): IOFormat.COMMON {
+		get ioFormat(): 'common' {
 			return ioFormatMock()
 		},
 		hasInput: hasInputMock,
@@ -51,13 +51,13 @@ describe('inputItem', () => {
 	}
 
 	it('accepts input and returns input', async () => {
-		ioFormatMock.mockReturnValue(IOFormat.COMMON)
+		ioFormatMock.mockReturnValue('common')
 		hasInputMock.mockReturnValue(true)
 		readMock.mockResolvedValue(item1)
 
 		buildInputProcessorMock.mockReturnValue(inputProcessor)
 
-		expect(await inputItem(flags)).toEqual([item1, IOFormat.COMMON])
+		expect(await inputItem(flags)).toEqual([item1, 'common'])
 
 		expect(buildInputProcessorMock).toHaveBeenCalledTimes(1)
 		expect(buildInputProcessorMock).toHaveBeenCalledWith(flags)
@@ -70,7 +70,7 @@ describe('inputItem', () => {
 
 	it('throws exception when there is no input', async () => {
 		const inputProcessor = {
-			ioFormat: IOFormat.COMMON,
+			ioFormat: 'common',
 			hasInput: () => false,
 			read: async () => item1,
 		}
@@ -87,7 +87,7 @@ describe('inputItem', () => {
 
 		buildInputProcessorMock.mockReturnValue(inputProcessor)
 
-		expect(await inputItem(flags)).toEqual([item1, IOFormat.COMMON])
+		expect(await inputItem(flags)).toEqual([item1, 'common'])
 
 		expect(buildInputProcessorMock).toHaveBeenCalledTimes(1)
 		expect(buildInputProcessorMock).toHaveBeenCalledWith(flags)
@@ -170,7 +170,7 @@ describe('outputList', () => {
 describe('inputAndOutputItem', () => {
 	it('accepts input, executes command and writes output', async () => {
 		const inputProcessor: InputProcessor<SimpleType> = {
-			get ioFormat(): IOFormat.COMMON {
+			get ioFormat(): 'common' {
 				return ioFormatMock()
 			},
 			hasInput: hasInputMock,
@@ -180,7 +180,7 @@ describe('inputAndOutputItem', () => {
 
 		hasInputMock.mockReturnValue(true)
 		readMock.mockResolvedValue(item1)
-		ioFormatMock.mockReturnValue(IOFormat.COMMON)
+		ioFormatMock.mockReturnValue('common')
 
 		const executeCommandMock = jest.fn().mockResolvedValue(item1)
 
@@ -203,7 +203,7 @@ describe('inputAndOutputItem', () => {
 
 	it('accepts and writes input in dry run mode', async () => {
 		const inputProcessor: InputProcessor<SimpleType> = {
-			get ioFormat(): IOFormat.YAML {
+			get ioFormat(): 'yaml' {
 				return ioFormatMock()
 			},
 			hasInput: hasInputMock,
@@ -213,7 +213,7 @@ describe('inputAndOutputItem', () => {
 
 		hasInputMock.mockReturnValue(true)
 		readMock.mockResolvedValue(item1)
-		ioFormatMock.mockReturnValue(IOFormat.YAML)
+		ioFormatMock.mockReturnValue('yaml')
 
 		const formatterMock = jest.fn().mockReturnValueOnce('formatted output')
 		const buildOutputFormatterMock = buildOutputFormatter as unknown as
@@ -240,7 +240,7 @@ describe('inputAndOutputItem', () => {
 		expect(readMock).toHaveBeenCalledBefore(ioFormatMock)
 
 		expect(buildOutputFormatterMock).toHaveBeenCalledTimes(1)
-		expect(buildOutputFormatterMock).toHaveBeenCalledWith(flags, cliConfig, IOFormat.YAML)
+		expect(buildOutputFormatterMock).toHaveBeenCalledWith(flags, cliConfig, 'yaml')
 		expect(formatterMock).toHaveBeenCalledTimes(1)
 		expect(formatterMock).toHaveBeenCalledWith(item1)
 		expect(writeOutputMock).toHaveBeenCalledTimes(1)
@@ -251,7 +251,7 @@ describe('inputAndOutputItem', () => {
 
 	it('throws exception when input could not be found', async () => {
 		const inputProcessor = {
-			ioFormat: IOFormat.COMMON,
+			ioFormat: 'common',
 			hasInput: () => false,
 			read: async () => item1,
 		}

--- a/src/__tests__/lib/command/format.test.ts
+++ b/src/__tests__/lib/command/format.test.ts
@@ -1,4 +1,3 @@
-import { IOFormat } from '../../../lib/io-util.js'
 import { TableGenerator } from '../../../lib/table-generator.js'
 import { Naming } from '../../../lib/command/basic-io.js'
 import { CommonListOutputProducer, formatAndWriteItem, formatAndWriteList } from '../../../lib/command/format.js'
@@ -40,12 +39,12 @@ describe('formatAndWriteItem', () => {
 		const commonFormatter = jest.fn()
 		itemTableFormatterMock.mockReturnValue(commonFormatter)
 
-		await formatAndWriteItem(command, config, item, IOFormat.COMMON)
+		await formatAndWriteItem(command, config, item, 'common')
 
 		expect(itemTableFormatterMock).toHaveBeenCalledTimes(1)
 		expect(itemTableFormatterMock).toHaveBeenCalledWith(command.tableGenerator, config.tableFieldDefinitions)
 		expect(buildOutputFormatterMock).toHaveBeenCalledTimes(1)
-		expect(buildOutputFormatterMock).toHaveBeenCalledWith(flags, cliConfig, IOFormat.COMMON, commonFormatter)
+		expect(buildOutputFormatterMock).toHaveBeenCalledWith(flags, cliConfig, 'common', commonFormatter)
 		expect(outputFormatter).toHaveBeenCalledTimes(1)
 		expect(outputFormatter).toHaveBeenCalledWith(item)
 		expect(writeOutputMock).toHaveBeenCalledTimes(1)
@@ -57,11 +56,11 @@ describe('formatAndWriteItem', () => {
 			buildTableOutput: jest.fn(),
 		}
 
-		await formatAndWriteItem<SimpleType>(command, config, item, IOFormat.JSON)
+		await formatAndWriteItem<SimpleType>(command, config, item, 'json')
 
 		expect(itemTableFormatterMock).toHaveBeenCalledTimes(0)
 		expect(buildOutputFormatterMock).toHaveBeenCalledTimes(1)
-		expect(buildOutputFormatterMock).toHaveBeenCalledWith(flags, cliConfig, IOFormat.JSON, expect.anything())
+		expect(buildOutputFormatterMock).toHaveBeenCalledWith(flags, cliConfig, 'json', expect.anything())
 		expect(outputFormatter).toHaveBeenCalledTimes(1)
 		expect(outputFormatter).toHaveBeenCalledWith(item)
 		expect(writeOutputMock).toHaveBeenCalledTimes(1)
@@ -80,11 +79,11 @@ describe('formatAndWriteItem', () => {
 			buildTableOutput: jest.fn(),
 		}
 
-		await formatAndWriteItem<SimpleType>(command, config, item, IOFormat.JSON)
+		await formatAndWriteItem<SimpleType>(command, config, item, 'json')
 
 		expect(itemTableFormatterMock).toHaveBeenCalledTimes(0)
 		expect(buildOutputFormatterMock).toHaveBeenCalledTimes(1)
-		expect(buildOutputFormatterMock).toHaveBeenCalledWith(flags, cliConfig, IOFormat.JSON, expect.anything())
+		expect(buildOutputFormatterMock).toHaveBeenCalledWith(flags, cliConfig, 'json', expect.anything())
 		expect(outputFormatter).toHaveBeenCalledTimes(1)
 		expect(outputFormatter).toHaveBeenCalledWith(item)
 		expect(writeOutputMock).toHaveBeenCalledTimes(1)

--- a/src/__tests__/lib/command/input-builder.test.ts
+++ b/src/__tests__/lib/command/input-builder.test.ts
@@ -1,4 +1,3 @@
-import { IOFormat } from '../../../lib/io-util.js'
 import { CombinedInputProcessor, FileInputProcessor, InputProcessor, StdinInputProcessor }
 	from '../../../lib/command/input-processor.js'
 import { buildInputProcessor } from '../../../lib/command/input-builder.js'
@@ -25,7 +24,7 @@ describe('buildInputProcessor', () => {
 		const flags = { input: 'fn' }
 		function makeProcessor(): InputProcessor<SimpleType> {
 			return {
-				ioFormat: IOFormat.JSON,
+				ioFormat: 'json',
 				hasInput: () => false,
 				read(): Promise<SimpleType> {
 					throw Error('Method not implemented.')

--- a/src/__tests__/lib/command/input-processor.test.ts
+++ b/src/__tests__/lib/command/input-processor.test.ts
@@ -11,7 +11,6 @@ import {
 } from '../../../lib/command/input-processor.js'
 import {
 	formatFromFilename,
-	IOFormat,
 	parseJSONOrYAML,
 	readDataFromStdin,
 	readFile,
@@ -24,8 +23,8 @@ jest.mock('../../../lib/io-util.js')
 
 describe('FileInputProcessor', () => {
 	it('gets format from filename', () => {
-		const formatFromFilenameMock = jest.mocked(formatFromFilename).mockReturnValue(IOFormat.JSON)
-		expect(new FileInputProcessor('fn').ioFormat).toBe(IOFormat.JSON)
+		const formatFromFilenameMock = jest.mocked(formatFromFilename).mockReturnValue('json')
+		expect(new FileInputProcessor('fn').ioFormat).toBe('json')
 		expect(formatFromFilenameMock).toHaveBeenCalledWith('fn')
 	})
 
@@ -62,7 +61,7 @@ describe('StdinInputProcessor', () => {
 	const parseJSONOrYAMLMock = jest.mocked(parseJSONOrYAML)
 
 	it('specifies JSON format', () =>  {
-		expect(new StdinInputProcessor().ioFormat).toBe(IOFormat.JSON)
+		expect(new StdinInputProcessor().ioFormat).toBe('json')
 	})
 
 	it('hasInput returns false for TTY input', async () =>  {
@@ -121,18 +120,18 @@ describe('simple input processor builder functions', () => {
 
 		expect(result.hasInput).toBe(hasInputMock)
 		expect(result.read).toBe(readMock)
-		expect(result.ioFormat).toBe(IOFormat.COMMON)
+		expect(result.ioFormat).toBe('common')
 	})
 
 	it('inputBuilder uses specified ioFormat', () => {
 		const hasInputMock = jest.fn()
 		const readMock = jest.fn()
 
-		const result = inputProcessor(hasInputMock, readMock, IOFormat.JSON)
+		const result = inputProcessor(hasInputMock, readMock, 'json')
 
 		expect(result.hasInput).toBe(hasInputMock)
 		expect(result.read).toBe(readMock)
-		expect(result.ioFormat).toBe(IOFormat.JSON)
+		expect(result.ioFormat).toBe('json')
 	})
 
 	it('commandLineInputProcessor uses proper methods from command', async () => {
@@ -145,7 +144,7 @@ describe('simple input processor builder functions', () => {
 
 		const inputProcessor = commandLineInputProcessor(command)
 
-		expect(inputProcessor.ioFormat).toBe(IOFormat.COMMON)
+		expect(inputProcessor.ioFormat).toBe('common')
 
 		hasInputMock.mockReturnValue(true)
 		expect(inputProcessor.hasInput()).toBeTrue()
@@ -164,7 +163,7 @@ describe('simple input processor builder functions', () => {
 
 		const inputProcessor = userInputProcessor(command)
 
-		expect(inputProcessor.ioFormat).toBe(IOFormat.COMMON)
+		expect(inputProcessor.ioFormat).toBe('common')
 
 		expect(inputProcessor.hasInput()).toBeTrue()
 
@@ -177,7 +176,7 @@ describe('simple input processor builder functions', () => {
 describe('CombinedInputProcessor', () => {
 	function makeProcessor(hasInputMock: () => boolean | Promise<boolean>, readMock?: () => Promise<SimpleType>): InputProcessor<SimpleType> {
 		return {
-			ioFormat: IOFormat.COMMON,
+			ioFormat: 'common',
 			hasInput: hasInputMock,
 			read: readMock ? readMock : () => { throw Error('should not be called') },
 		}
@@ -327,9 +326,9 @@ describe('CombinedInputProcessor', () => {
 		const readMock2 = jest.fn()
 		const readMock3 = jest.fn()
 
-		const processor1 = { ...makeProcessor(hasInputMock1, readMock1), ioFormat: IOFormat.JSON }
-		const processor2 = { ...makeProcessor(hasInputMock2, readMock2), ioFormat: IOFormat.YAML }
-		const processor3 = { ...makeProcessor(hasInputMock3, readMock3), ioFormat: IOFormat.COMMON }
+		const processor1 = { ...makeProcessor(hasInputMock1, readMock1), ioFormat: 'json' }
+		const processor2 = { ...makeProcessor(hasInputMock2, readMock2), ioFormat: 'yaml' }
+		const processor3 = { ...makeProcessor(hasInputMock3, readMock3), ioFormat: 'common' }
 		const processor = new CombinedInputProcessor(processor1, processor2, processor3)
 		hasInputMock1.mockReturnValue(false)
 		hasInputMock2.mockReturnValue(true)
@@ -347,7 +346,7 @@ describe('CombinedInputProcessor', () => {
 		expect(readMock2).toHaveBeenCalledTimes(1)
 		expect(readMock3).toHaveBeenCalledTimes(0)
 
-		expect(processor.ioFormat).toBe(IOFormat.YAML)
+		expect(processor.ioFormat).toBe('yaml')
 	})
 
 	it('throws exception on read with no filename', async () =>  {

--- a/src/__tests__/lib/command/output-builder.test.ts
+++ b/src/__tests__/lib/command/output-builder.test.ts
@@ -1,6 +1,5 @@
 import yargs, { Argv } from 'yargs'
 
-import { IOFormat } from '../../../lib/io-util.js'
 import { CalculateOutputFormatFlags, calculateOutputFormat, calculateOutputFormatBuilder, jsonFormatter, yamlFormatter } from '../../../lib/command/output.js'
 import { BuildOutputFormatterFlags, buildOutputFormatter, buildOutputFormatterBuilder } from '../../../lib/command/output-builder.js'
 import { SimpleType } from '../../test-lib/simple-type.js'
@@ -44,7 +43,7 @@ describe('buildOutputFormatter', () => {
 	} as CLIConfig
 
 	it('uses commonOutputFormatter when it exists', () => {
-		calculateOutputFormatMock.mockReturnValue(IOFormat.COMMON)
+		calculateOutputFormatMock.mockReturnValue('common')
 		const commonFormatter = jest.fn()
 
 		expect(buildOutputFormatter<SimpleType>(flags, cliConfig, undefined, commonFormatter)).toBe(commonFormatter)
@@ -54,7 +53,7 @@ describe('buildOutputFormatter', () => {
 	})
 
 	it('uses yamlFormatter with default of 2 for YAML output', () => {
-		calculateOutputFormatMock.mockReturnValue(IOFormat.YAML)
+		calculateOutputFormatMock.mockReturnValue('yaml')
 
 		buildOutputFormatter<SimpleType>(flags, cliConfig)
 
@@ -65,7 +64,7 @@ describe('buildOutputFormatter', () => {
 	})
 
 	it('uses jsonFormatter with a default of 4 for JSON output', () => {
-		calculateOutputFormatMock.mockReturnValue(IOFormat.COMMON)
+		calculateOutputFormatMock.mockReturnValue('common')
 
 		expect(buildOutputFormatter<SimpleType>(flags, cliConfig)).toBe(jsonOutputFormatter)
 
@@ -76,7 +75,7 @@ describe('buildOutputFormatter', () => {
 	})
 
 	it('accepts indent from config file over default', () => {
-		calculateOutputFormatMock.mockReturnValue(IOFormat.JSON)
+		calculateOutputFormatMock.mockReturnValue('json')
 
 		const cliConfig = { profile: { indent: 7 } } as unknown as CLIConfig
 		buildOutputFormatter<SimpleType>(flags, cliConfig)
@@ -88,7 +87,7 @@ describe('buildOutputFormatter', () => {
 	})
 
 	it('accepts indent from command line over config file and default', () => {
-		calculateOutputFormatMock.mockReturnValue(IOFormat.YAML)
+		calculateOutputFormatMock.mockReturnValue('yaml')
 
 		const flags = { indent: 13 } as unknown as SmartThingsCommandFlags
 		const cliConfig = { profile: { indent: 13 } } as unknown as CLIConfig

--- a/src/__tests__/lib/command/output.test.ts
+++ b/src/__tests__/lib/command/output.test.ts
@@ -7,7 +7,7 @@ import {
 	writeOutput,
 	yamlFormatter,
 } from '../../../lib/command/output.js'
-import { IOFormat, formatFromFilename, stdoutIsTTY, writeFile } from '../../../lib/io-util.js'
+import { formatFromFilename, stdoutIsTTY, writeFile } from '../../../lib/io-util.js'
 import { DefaultTableGenerator, TableFieldDefinition, TableGenerator } from '../../../lib/table-generator.js'
 
 import { SimpleType } from '../../test-lib/simple-type.js'
@@ -35,40 +35,40 @@ describe('calculateOutputFormat', () => {
 	it('returns json when specified', () => {
 		const flags = { json: true }
 
-		expect(calculateOutputFormat(flags)).toBe(IOFormat.JSON)
+		expect(calculateOutputFormat(flags)).toBe('json')
 	})
 
 	it('uses yaml when specified', () => {
 		const flags = { yaml: true }
 
-		expect(calculateOutputFormat(flags)).toBe(IOFormat.YAML)
+		expect(calculateOutputFormat(flags)).toBe('yaml')
 	})
 
 	it('gets format using formatFromFilename with output file when not specified', () => {
 		const flags = { output: 'fn.json' }
-		const formatFromFilenameMock = jest.mocked(formatFromFilename).mockReturnValue(IOFormat.JSON)
+		const formatFromFilenameMock = jest.mocked(formatFromFilename).mockReturnValue('json')
 
-		expect(calculateOutputFormat(flags)).toBe(IOFormat.JSON)
+		expect(calculateOutputFormat(flags)).toBe('json')
 
 		expect(formatFromFilenameMock).toHaveBeenCalledTimes(1)
 		expect(formatFromFilenameMock).toHaveBeenCalledWith('fn.json')
 	})
 
 	it('defaults to specified default format', () => {
-		expect(calculateOutputFormat({}, IOFormat.YAML)).toBe(IOFormat.YAML)
+		expect(calculateOutputFormat({}, 'yaml')).toBe('yaml')
 	})
 
 	it('falls back to common in console with no other default specified', () => {
 		const ttySpy = jest.mocked(stdoutIsTTY).mockReturnValue(true)
 
-		expect(calculateOutputFormat({})).toBe(IOFormat.COMMON)
+		expect(calculateOutputFormat({})).toBe('common')
 		expect(ttySpy).toHaveBeenCalledTimes(1)
 	})
 
 	it('falls back to JSON with no other default specified and not outputting to the console', () => {
 		const ttySpy = jest.mocked(stdoutIsTTY).mockReturnValue(false)
 
-		expect(calculateOutputFormat({})).toBe(IOFormat.JSON)
+		expect(calculateOutputFormat({})).toBe('json')
 		expect(ttySpy).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/__tests__/lib/io-util.test.ts
+++ b/src/__tests__/lib/io-util.test.ts
@@ -15,24 +15,24 @@ jest.unstable_mockModule('fs', () => ({
 
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const { formatFromFilename, IOFormat, parseJSONOrYAML, readDataFromStdin, stdinIsTTY, yamlExists } =
+const { formatFromFilename, parseJSONOrYAML, readDataFromStdin, stdinIsTTY, yamlExists } =
 	await import('../../lib/io-util.js')
 
 
 describe('formatFromFilename', () => {
 	it('handles yaml extensions', function () {
-		expect(formatFromFilename('fn.yaml')).toBe(IOFormat.YAML)
-		expect(formatFromFilename('fn.yml')).toBe(IOFormat.YAML)
-		expect(formatFromFilename('fn.YAML')).toBe(IOFormat.YAML)
+		expect(formatFromFilename('fn.yaml')).toBe('yaml')
+		expect(formatFromFilename('fn.yml')).toBe('yaml')
+		expect(formatFromFilename('fn.YAML')).toBe('yaml')
 	})
 
 	it('handles json extensions', function () {
-		expect(formatFromFilename('fn.json')).toBe(IOFormat.JSON)
-		expect(formatFromFilename('fn.JSON')).toBe(IOFormat.JSON)
+		expect(formatFromFilename('fn.json')).toBe('json')
+		expect(formatFromFilename('fn.JSON')).toBe('json')
 	})
 
 	it('defaults to YAML', function () {
-		expect(formatFromFilename('fn')).toBe(IOFormat.YAML)
+		expect(formatFromFilename('fn')).toBe('yaml')
 	})
 })
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -2,7 +2,6 @@ import yaml from 'js-yaml'
 import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs'
 
 import { Profile } from '../lib/cli-config.js'
-import { IOFormat } from '../lib/io-util.js'
 import { TableFieldDefinition } from '../lib/table-generator.js'
 import { OutputListConfig, outputItem, outputList } from '../lib/command/basic-io.js'
 import { stringTranslateToId } from '../lib/command/command-util.js'
@@ -82,7 +81,7 @@ const handler = async (argv: ArgumentsCamelCase<CommandArgs>): Promise<void> => 
 		await outputItem(command, { tableFieldDefinitions }, () => getConfig(profileName))
 	} else {
 		const outputFormat = calculateOutputFormat(argv)
-		if (outputFormat === IOFormat.COMMON) {
+		if (outputFormat === 'common') {
 			await outputList(command, outputListConfig, listConfigs, true)
 		} else {
 			const outputFormatter = buildOutputFormatter(command.flags, command.cliConfig)

--- a/src/lib/command/input-processor.ts
+++ b/src/lib/command/input-processor.ts
@@ -35,7 +35,7 @@ export class FileInputProcessor<T> implements InputProcessor<T> {
 	readonly ioFormat: IOFormat
 
 	constructor(private readonly filename?: string) {
-		this.ioFormat = filename ? formatFromFilename(filename) : IOFormat.JSON
+		this.ioFormat = filename ? formatFromFilename(filename) : 'json'
 	}
 
 	hasInput(): boolean {
@@ -53,7 +53,7 @@ export class FileInputProcessor<T> implements InputProcessor<T> {
 
 export class StdinInputProcessor<T> implements InputProcessor<T> {
 	// Could be JSON or YAML but it's not really worth trying to figure out which.
-	readonly ioFormat = IOFormat.JSON
+	readonly ioFormat = 'json'
 	inputData?: string = undefined
 
 	async hasInput(): Promise<boolean> {
@@ -75,7 +75,7 @@ export class StdinInputProcessor<T> implements InputProcessor<T> {
  * Build an input processor given the necessary functions for doing so.
  */
 export function inputProcessor<T>(hasInput: () => boolean | Promise<boolean>, read: () => Promise<T>,
-		ioFormat: IOFormat = IOFormat.COMMON): InputProcessor<T> {
+		ioFormat: IOFormat = 'common'): InputProcessor<T> {
 	return { ioFormat, hasInput, read }
 }
 

--- a/src/lib/command/output-builder.ts
+++ b/src/lib/command/output-builder.ts
@@ -35,10 +35,10 @@ export function buildOutputFormatter<T extends object>(flags: BuildOutputFormatt
 	const outputFormat = calculateOutputFormat(flags, inputFormat)
 
 	const indent = flags.indent || (cliConfig.profile.indent as number | undefined)
-	if (outputFormat === IOFormat.COMMON && commonOutputFormatter) {
+	if (outputFormat === 'common' && commonOutputFormatter) {
 		return commonOutputFormatter
 	}
-	if (outputFormat == IOFormat.YAML) {
+	if (outputFormat == 'yaml') {
 		return yamlFormatter(indent ?? 2)
 	}
 	return jsonFormatter(indent ?? 4)

--- a/src/lib/command/output.ts
+++ b/src/lib/command/output.ts
@@ -30,10 +30,10 @@ export const calculateOutputFormatBuilder = <T extends object>(yargs: Argv<T>): 
 export function calculateOutputFormat(flags: CalculateOutputFormatFlags, defaultIOFormat?: IOFormat): IOFormat {
 	// flags get highest priority...check them first
 	if (flags.json) {
-		return IOFormat.JSON
+		return 'json'
 	}
 	if (flags.yaml) {
-		return IOFormat.YAML
+		return 'yaml'
 	}
 	// if we have an output filename, use that file's extension
 	if (flags.output) {
@@ -43,7 +43,7 @@ export function calculateOutputFormat(flags: CalculateOutputFormatFlags, default
 		return defaultIOFormat
 	}
 	// if we're writing to the console, use user-friendly output, otherwise default to JSON
-	return stdoutIsTTY() ? IOFormat.COMMON : IOFormat.JSON
+	return stdoutIsTTY() ? 'common' : 'json'
 }
 
 export type OutputFormatter<T extends object> = (data: T) => string

--- a/src/lib/io-util.ts
+++ b/src/lib/io-util.ts
@@ -4,24 +4,21 @@ import path from 'path'
 import yaml from 'js-yaml'
 
 
-export enum IOFormat {
-	YAML = 'yaml',
-	JSON = 'json',
-
-	// for input, this is Q & A or command line, for output, it's a human-readable table format
-	COMMON = 'common',
-}
+export type IOFormat =
+	| 'yaml'
+	| 'json'
+	| 'common' // Q&A or command line for input; table format for output
 
 export function formatFromFilename(filename: string): IOFormat {
 	const ext = path.extname(filename).toLowerCase()
 	if (ext === '.yaml' || ext === '.yml') {
-		return IOFormat.YAML
+		return 'yaml'
 	}
 	if (ext === '.json') {
-		return IOFormat.JSON
+		return 'json'
 	}
 	log4js.getLogger('cli').warn(`could not determine file type from filename "${filename}, assuming YAML`)
-	return IOFormat.YAML
+	return 'yaml'
 }
 
 


### PR DESCRIPTION
Converted `IOFormat` enum to a simple type.
