### PR TITLE
refactor: convert classes in input-processor.ts to simple functions

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,6 +8,7 @@ const config: JestConfigWithTsJest = {
 		// '**/__tests__/**/*.test.ts',
 		'**/__tests__/lib/*.test.ts',
 		'**/__tests__/lib/item-input/*.test.ts',
+		'**/__tests__/lib/command/(input-p*).test.ts',
 	],
 	setupFilesAfterEnv: ['jest-extended/all'],
 	collectCoverageFrom: ['src/**/*.ts'],

--- a/packages/cli/src/__tests__/lib/commands/virtualdevices-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/virtualdevices-util.test.ts
@@ -2,7 +2,7 @@ import inquirer from 'inquirer'
 import {
 	APICommand,
 	APIOrganizationCommand,
-	FileInputProcessor,
+	fileInputProcessor,
 	selectFromList,
 } from '@smartthings/cli-lib'
 import {
@@ -83,7 +83,7 @@ describe('virtualdevices-util', () => {
 				status: DeviceProfileStatus.PUBLISHED,
 			}
 
-			const fileSpy = jest.spyOn(FileInputProcessor.prototype, 'read').mockResolvedValueOnce(deviceProfile)
+			const fileSpy = jest.spyOn(fileInputProcessor.prototype, 'read').mockResolvedValueOnce(deviceProfile)
 
 			const value = await chooseDeviceProfileDefinition(command, undefined, 'device-profile-file')
 

--- a/packages/cli/src/lib/commands/virtualdevices-util.ts
+++ b/packages/cli/src/lib/commands/virtualdevices-util.ts
@@ -11,7 +11,7 @@ import {
 import {
 	APICommand,
 	APIOrganizationCommand,
-	FileInputProcessor,
+	fileInputProcessor,
 	selectFromList,
 	SelectFromListConfig,
 } from '@smartthings/cli-lib'
@@ -86,7 +86,7 @@ export async function chooseDeviceProfileDefinition(command: APIOrganizationComm
 	let deviceProfile
 
 	if (deviceProfileFile) {
-		const inputProcessor = new FileInputProcessor<DeviceProfile>(deviceProfileFile)
+		const inputProcessor = fileInputProcessor<DeviceProfile>(deviceProfileFile)
 		deviceProfile = await inputProcessor.read()
 	} else if (!deviceProfileId) {
 		deviceProfileId = await chooseDeviceProfile(command, deviceProfileId, { allowIndex: true })

--- a/src/__tests__/lib/command/input-builder.test.ts
+++ b/src/__tests__/lib/command/input-builder.test.ts
@@ -1,4 +1,4 @@
-import { CombinedInputProcessor, FileInputProcessor, InputProcessor, StdinInputProcessor }
+import { combinedInputProcessor, fileInputProcessor, InputProcessor, stdinInputProcessor }
 	from '../../../lib/command/input-processor.js'
 import { buildInputProcessor } from '../../../lib/command/input-builder.js'
 import { SimpleType } from '../../test-lib/simple-type.js'
@@ -9,8 +9,8 @@ jest.mock('../../../lib/command/input-processor.js')
 
 describe('buildInputProcessor', () => {
 	it('includes file and stdin input processors', () => {
-		const fileInputProcessorSpy = jest.mocked(FileInputProcessor)
-		const stdinInputProcessorSpy = jest.mocked(StdinInputProcessor)
+		const fileInputProcessorSpy = jest.mocked(fileInputProcessor)
+		const stdinInputProcessorSpy = jest.mocked(stdinInputProcessor)
 
 		const flags = {}
 
@@ -32,15 +32,15 @@ describe('buildInputProcessor', () => {
 			}
 		}
 
-		const fileInputProcessor = makeProcessor()
-		const fileMock = jest.mocked(FileInputProcessor)
-			.mockReturnValue(fileInputProcessor as FileInputProcessor<SimpleType>)
+		const inputProcessor = makeProcessor()
+		const fileMock = jest.mocked(fileInputProcessor)
+			.mockReturnValue(inputProcessor as InputProcessor<SimpleType>)
 		const stdinInputProcessor = makeProcessor()
-		const stdinMock = jest.mocked(StdinInputProcessor)
-			.mockReturnValue(stdinInputProcessor as StdinInputProcessor<SimpleType>)
+		const stdinMock = jest.mocked(stdinInputProcessor)
+			.mockReturnValue(stdinInputProcessor as InputProcessor<SimpleType>)
 		const userProcessor1 = makeProcessor()
 		const userProcessor2 = makeProcessor()
-		const mock = jest.mocked(CombinedInputProcessor)
+		const mock = jest.mocked(combinedInputProcessor)
 
 		buildInputProcessor<SimpleType>(flags, userProcessor1, userProcessor2)
 
@@ -48,6 +48,6 @@ describe('buildInputProcessor', () => {
 		expect(fileMock).toHaveBeenCalledWith('fn')
 		expect(stdinMock).toHaveBeenCalledTimes(1)
 		expect(mock).toHaveBeenCalledTimes(1)
-		expect(mock).toHaveBeenCalledWith(fileInputProcessor, stdinInputProcessor, userProcessor1, userProcessor2)
+		expect(mock).toHaveBeenCalledWith(inputProcessor, stdinInputProcessor, userProcessor1, userProcessor2)
 	})
 })

--- a/src/lib/command/input-builder.ts
+++ b/src/lib/command/input-builder.ts
@@ -1,10 +1,10 @@
 import { Argv } from 'yargs'
 
 import {
-	CombinedInputProcessor,
-	FileInputProcessor,
+	combinedInputProcessor,
+	fileInputProcessor,
 	InputProcessor,
-	StdinInputProcessor,
+	stdinInputProcessor,
 } from './input-processor.js'
 
 
@@ -27,9 +27,10 @@ export const inputProcessorBuilder = <T extends object>(yargs: Argv<T>): Argv<T 
  * Another less common use case (which might co-exist with a Q&A input processor) would be building
  * the data from command line options.
  */
-export function buildInputProcessor<T>(flags: InputProcessorFlags,
-		...alternateInputProcessors: InputProcessor<T>[]): InputProcessor<T> {
-	const fileInputProcessor = new FileInputProcessor<T>(flags.input)
-	const stdinInputProcessor = new StdinInputProcessor<T>()
-	return new CombinedInputProcessor(fileInputProcessor, stdinInputProcessor, ...alternateInputProcessors)
-}
+export const buildInputProcessor =
+	<T>(flags: InputProcessorFlags, ...alternateInputProcessors: InputProcessor<T>[]): InputProcessor<T> =>
+		combinedInputProcessor(
+			fileInputProcessor<T>(flags.input),
+			stdinInputProcessor<T>(),
+			...alternateInputProcessors,
+		)


### PR DESCRIPTION
* convert classes from `input-processor.ts` to simple functions
* updated unit tests for this code both for the new functions and for ESM
* 100% coverage of `input-processor.ts` now
* misc. minor test cleanup

Note that some tests that haven't yet been converted to ESM and thus are not running have been touched via search-and-replace. More will be done to these in future PRs when they are converted to ESM.