### PR TITLE
refactor: convert classes in table-generator.ts to functions

### DIFF
--- a/packages/cli/src/__tests__/commands/apps/create.test.ts
+++ b/packages/cli/src/__tests__/commands/apps/create.test.ts
@@ -1,4 +1,4 @@
-import { CustomCommonOutputProducer, DefaultTableGenerator, inputAndOutputItem, IOFormat } from '@smartthings/cli-lib'
+import { CustomCommonOutputProducer, defaultTableGenerator, inputAndOutputItem, IOFormat } from '@smartthings/cli-lib'
 import { AppCreationResponse, AppCreateRequest, AppsEndpoint, AppResponse } from '@smartthings/core-sdk'
 import AppCreateCommand from '../../../commands/apps/create.js'
 import { tableFieldDefinitions } from '../../../lib/commands/apps-util.js'
@@ -22,7 +22,7 @@ describe('AppCreateCommand', () => {
 		mockInputAndOutputItem.mockImplementationOnce(async (_command, config) => {
 			(config as CustomCommonOutputProducer<AppCreationResponse>).buildTableOutput(appCreate)
 		})
-		const buildTableSpy = jest.spyOn(DefaultTableGenerator.prototype, 'buildTableFromItem')
+		const buildTableSpy = jest.spyOn(defaultTableGenerator.prototype, 'buildTableFromItem')
 
 		await expect(AppCreateCommand.run([])).resolves.not.toThrow()
 

--- a/packages/cli/src/__tests__/commands/apps/settings.test.ts
+++ b/packages/cli/src/__tests__/commands/apps/settings.test.ts
@@ -1,4 +1,4 @@
-import { CustomCommonOutputProducer, DefaultTableGenerator, outputItem } from '@smartthings/cli-lib'
+import { CustomCommonOutputProducer, defaultTableGenerator, outputItem } from '@smartthings/cli-lib'
 import { AppsEndpoint, AppSettingsResponse } from '@smartthings/core-sdk'
 import AppSettingsCommand from '../../../commands/apps/settings.js'
 import { buildTableOutput, chooseApp } from '../../../lib/commands/apps-util.js'
@@ -47,7 +47,7 @@ describe('AppSettingsCommand', () => {
 		)
 
 		expect(buildTableOutput).toBeCalledWith(
-			expect.any(DefaultTableGenerator),
+			expect.any(defaultTableGenerator),
 			appSettings,
 		)
 	})

--- a/packages/cli/src/__tests__/commands/devices.test.ts
+++ b/packages/cli/src/__tests__/commands/devices.test.ts
@@ -1,7 +1,7 @@
 import { Device, DevicesEndpoint, DeviceStatus, SmartThingsClient } from '@smartthings/core-sdk'
 
 import {
-	CustomCommonOutputProducer, DefaultTableGenerator, outputItemOrList,
+	CustomCommonOutputProducer, defaultTableGenerator, outputItemOrList,
 	withLocationAndRoom,
 	withLocationsAndRooms, WithNamedRoom,
 } from '@smartthings/cli-lib'
@@ -85,7 +85,7 @@ describe('DevicesCommand', () => {
 		expect(config.buildTableOutput(device)).toBe('table output')
 
 		expect(buildTableOutputMock).toHaveBeenCalledTimes(1)
-		expect(buildTableOutputMock).toHaveBeenCalledWith(expect.any(DefaultTableGenerator), device)
+		expect(buildTableOutputMock).toHaveBeenCalledWith(expect.any(defaultTableGenerator), device)
 	})
 
 	describe('list function', () => {

--- a/packages/cli/src/__tests__/commands/devices/update.test.ts
+++ b/packages/cli/src/__tests__/commands/devices/update.test.ts
@@ -1,4 +1,4 @@
-import { ActionFunction, chooseDevice, CustomCommonOutputProducer, DefaultTableGenerator, inputAndOutputItem } from '@smartthings/cli-lib'
+import { ActionFunction, chooseDevice, CustomCommonOutputProducer, defaultTableGenerator, inputAndOutputItem } from '@smartthings/cli-lib'
 import { Device, DevicesEndpoint, DeviceUpdate } from '@smartthings/core-sdk'
 import DeviceUpdateCommand from '../../../commands/devices/update.js'
 import { buildTableOutput } from '../../../lib/commands/devices-util.js'
@@ -37,7 +37,7 @@ describe('DeviceUpdateCommand', () => {
 		const device = { deviceId: 'deviceId' } as Device
 		await outputProducerFunction(device)
 
-		expect(buildTableOutput).toBeCalledWith(expect.any(DefaultTableGenerator), device)
+		expect(buildTableOutput).toBeCalledWith(expect.any(defaultTableGenerator), device)
 
 		const actionFunction = inputAndOutputItemMock.mock.calls[0][2] as ActionFunction<void, DeviceUpdate, Device>
 		const deviceUpdate = { label: 'device' } as DeviceUpdate

--- a/packages/cli/src/__tests__/commands/rules/execute.test.ts
+++ b/packages/cli/src/__tests__/commands/rules/execute.test.ts
@@ -1,6 +1,6 @@
 import { RulesEndpoint, RuleExecutionResponse, SmartThingsClient, Rule } from '@smartthings/core-sdk'
 
-import { CustomCommonOutputProducer, DefaultTableGenerator, formatAndWriteItem, WithNamedLocation } from '@smartthings/cli-lib'
+import { CustomCommonOutputProducer, defaultTableGenerator, formatAndWriteItem, WithNamedLocation } from '@smartthings/cli-lib'
 
 import RulesExecuteCommand from '../../../commands/rules/execute.js'
 import { buildExecuteResponseTableOutput, chooseRule, getRuleWithLocation }
@@ -47,7 +47,7 @@ describe('RulesExecuteCommand', () => {
 
 		expect(buildExecuteResponseTableOutputMock).toHaveBeenCalledTimes(1)
 		expect(buildExecuteResponseTableOutputMock)
-			.toHaveBeenCalledWith(expect.any(DefaultTableGenerator), executeResponse)
+			.toHaveBeenCalledWith(expect.any(defaultTableGenerator), executeResponse)
 	})
 
 	it('use rule id from command line', async () => {

--- a/packages/cli/src/__tests__/commands/virtualdevices/update.test.ts
+++ b/packages/cli/src/__tests__/commands/virtualdevices/update.test.ts
@@ -1,4 +1,4 @@
-import { ActionFunction, chooseDevice, CustomCommonOutputProducer, DefaultTableGenerator, inputAndOutputItem } from '@smartthings/cli-lib'
+import { ActionFunction, chooseDevice, CustomCommonOutputProducer, defaultTableGenerator, inputAndOutputItem } from '@smartthings/cli-lib'
 import { Device, DeviceIntegrationType, DevicesEndpoint, DeviceUpdate } from '@smartthings/core-sdk'
 import VirtualDeviceUpdateCommand from '../../../commands/virtualdevices/update.js'
 import { buildTableOutput } from '../../../lib/commands/devices-util.js'
@@ -41,7 +41,7 @@ describe('VirtualDeviceUpdateCommand', () => {
 		const device = { deviceId: 'deviceId' } as Device
 		await outputProducerFunction(device)
 
-		expect(buildTableOutput).toBeCalledWith(expect.any(DefaultTableGenerator), device)
+		expect(buildTableOutput).toBeCalledWith(expect.any(defaultTableGenerator), device)
 
 		const actionFunction = inputAndOutputItemMock.mock.calls[0][2] as ActionFunction<void, DeviceUpdate, Device>
 		const deviceUpdate = { label: 'device' } as DeviceUpdate

--- a/packages/edge/src/__tests__/commands/edge/channels/metainfo.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/channels/metainfo.test.ts
@@ -1,6 +1,6 @@
 import { ChannelsEndpoint, DriverChannelDetails, EdgeDriver } from '@smartthings/core-sdk'
 
-import { CustomCommonOutputProducer, DefaultTableGenerator, outputItemOrList } from '@smartthings/cli-lib'
+import { CustomCommonOutputProducer, defaultTableGenerator, outputItemOrList } from '@smartthings/cli-lib'
 
 import ChannelsMetaInfoCommand from '../../../../commands/edge/channels/metainfo.js'
 import { buildTableOutput } from '../../../../lib/commands/drivers-util.js'
@@ -123,6 +123,6 @@ describe('ChannelsMetaInfoCommand', () => {
 		expect(config.buildTableOutput(driver)).toBe('table output')
 
 		expect(buildTableOutputMock).toHaveBeenCalledTimes(1)
-		expect(buildTableOutputMock).toHaveBeenCalledWith(expect.any(DefaultTableGenerator), driver)
+		expect(buildTableOutputMock).toHaveBeenCalledWith(expect.any(defaultTableGenerator), driver)
 	})
 })

--- a/packages/edge/src/__tests__/commands/edge/drivers.test.ts
+++ b/packages/edge/src/__tests__/commands/edge/drivers.test.ts
@@ -1,6 +1,6 @@
 import { DriversEndpoint, EdgeDriver, SmartThingsClient } from '@smartthings/core-sdk'
 
-import { CustomCommonOutputProducer, DefaultTableGenerator, outputItemOrList } from '@smartthings/cli-lib'
+import { CustomCommonOutputProducer, defaultTableGenerator, outputItemOrList } from '@smartthings/cli-lib'
 
 import DriversCommand from '../../../commands/edge/drivers.js'
 import { buildTableOutput, listDrivers } from '../../../lib/commands/drivers-util.js'
@@ -143,6 +143,6 @@ describe('DriversCommand', () => {
 		expect(config.buildTableOutput(driver)).toBe('table output')
 
 		expect(buildTableOutputMock).toHaveBeenCalledTimes(1)
-		expect(buildTableOutputMock).toHaveBeenCalledWith(expect.any(DefaultTableGenerator), driver)
+		expect(buildTableOutputMock).toHaveBeenCalledWith(expect.any(defaultTableGenerator), driver)
 	})
 })

--- a/src/__tests__/lib/command/output.test.ts
+++ b/src/__tests__/lib/command/output.test.ts
@@ -8,7 +8,7 @@ import {
 	yamlFormatter,
 } from '../../../lib/command/output.js'
 import { formatFromFilename, stdoutIsTTY, writeFile } from '../../../lib/io-util.js'
-import { DefaultTableGenerator, TableFieldDefinition, TableGenerator } from '../../../lib/table-generator.js'
+import { defaultTableGenerator, TableFieldDefinition, TableGenerator } from '../../../lib/table-generator.js'
 
 import { SimpleType } from '../../test-lib/simple-type.js'
 
@@ -136,7 +136,7 @@ describe('listTableFormatter', () => {
 	})
 
 	it('handles includeIndex', () => {
-		const tableGenerator = new DefaultTableGenerator(true)
+		const tableGenerator = defaultTableGenerator({ groupRows: true })
 		const formatter = listTableFormatter(tableGenerator, fieldDefinitions, /* includeIndex */ true)
 
 		const buildTableSpy = jest.spyOn(tableGenerator, 'buildTableFromList')

--- a/src/lib/command/smartthings-command.ts
+++ b/src/lib/command/smartthings-command.ts
@@ -4,7 +4,7 @@ import { Argv } from 'yargs'
 import { CLIConfig, loadConfig, Profile } from '../cli-config.js'
 import { buildDefaultLog4jsConfig, loadLog4jsConfig } from '../log-utils.js'
 import { BuildOutputFormatterFlags } from './output-builder.js'
-import { DefaultTableGenerator, TableGenerator } from '../table-generator.js'
+import { defaultTableGenerator, TableGenerator } from '../table-generator.js'
 
 
 export type SmartThingsCommandFlags = {
@@ -106,7 +106,7 @@ export const smartThingsCommand = async <T extends SmartThingsCommandFlags>(flag
 	const groupRowsFlag = (flags as Pick<BuildOutputFormatterFlags, 'groupRows'>).groupRows
 	const groupRows = groupRowsFlag ?? booleanConfigValue('groupTableOutputRows', true)
 
-	const tableGenerator = new DefaultTableGenerator(groupRows)
+	const tableGenerator = defaultTableGenerator({ groupRows })
 
 	function stringConfigValue(keyName: string): string
 	function stringConfigValue(keyName: string, defaultValue: string): string


### PR DESCRIPTION
* converted `DefaultTableGenerator` and `Table` classes to functions
  * `defaultTableGenerator` now takes an `options` object (with only `groupRows` as an option) instead of the `groupRows` boolean
* updated unit tests, including adding a little more coverage
