### PR TITLE
test: convert api-organization-command.test to ESM

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,7 +8,7 @@ const config: JestConfigWithTsJest = {
 		// '**/__tests__/**/*.test.ts',
 		'**/__tests__/lib/*.test.ts',
 		'**/__tests__/lib/item-input/*.test.ts',
-		'**/__tests__/lib/command/(api-command|input-*|output|smart*).test.ts',
+		'**/__tests__/lib/command/(api-*|input-*|output|smart*).test.ts',
 	],
 	setupFilesAfterEnv: ['jest-extended/all'],
 	collectCoverageFrom: ['src/**/*.ts'],

--- a/src/lib/command/api-command.ts
+++ b/src/lib/command/api-command.ts
@@ -35,7 +35,7 @@ export const apiCommandBuilder = <T extends object>(yargs: Argv<T>): Argv<T & AP
 			type: 'string',
 		})
 
-export type APICommand<T extends APICommandFlags> = SmartThingsCommand<T> & {
+export type APICommand<T extends APICommandFlags = APICommandFlags> = SmartThingsCommand<T> & {
 	token?: string
 	clientIdProvider: ClientIdProvider
 	authenticator: Authenticator


### PR DESCRIPTION
* update `api-organization-command.test.ts` to ESM
* some minor updates to `api-command.test.ts` so it matches this one and they are both more complete