### PR TITLE
test: convert listing-io, output-builder, and select tests to ESM

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,7 +8,7 @@ const config: JestConfigWithTsJest = {
 		// '**/__tests__/**/*.test.ts',
 		'**/__tests__/lib/*.test.ts',
 		'**/__tests__/lib/item-input/*.test.ts',
-		'**/__tests__/lib/command/(api-*|input-*|basic*|command*|format*|output|smart*).test.ts',
+		'**/__tests__/lib/command/*.test.ts',
 	],
 	setupFilesAfterEnv: ['jest-extended/all'],
 	collectCoverageFrom: ['src/**/*.ts'],

--- a/src/__tests__/lib/command/listing-io.test.ts
+++ b/src/__tests__/lib/command/listing-io.test.ts
@@ -1,16 +1,32 @@
-import { OutputItemOrListConfig, outputItemOrListGeneric, outputItemOrList } from '../../../lib/command/listing-io.js'
+import { jest } from '@jest/globals'
+
+import { OutputItemOrListConfig } from '../../../lib/command/listing-io.js'
 import { SimpleType } from '../../test-lib/simple-type.js'
-import { outputItem, outputList } from '../../../lib/command/basic-io.js'
+import { IdTranslationFunction, ListDataFunction, LookupDataFunction, outputItem, outputList, outputListBuilder } from '../../../lib/command/basic-io.js'
 import { stringTranslateToId } from '../../../lib/command/command-util.js'
 import { SmartThingsCommand } from '../../../lib/command/smartthings-command.js'
 import { BuildOutputFormatterFlags } from '../../../lib/command/output-builder.js'
 
 
-jest.mock('../../../lib/command/basic-io.js')
-jest.mock('../../../lib/command/command-util.js')
+const outputItemMock: jest.Mock<typeof outputItem<SimpleType>> = jest.fn()
+const outputListMock: jest.Mock<typeof outputList<SimpleType>> = jest.fn()
+jest.unstable_mockModule('../../../lib/command/basic-io.js', () => ({
+	outputItem: outputItemMock,
+	outputList: outputListMock,
+	outputListBuilder,
+}))
+
+const stringTranslateToIdMock: jest.Mock<typeof stringTranslateToId> = jest.fn()
+stringTranslateToIdMock.mockResolvedValue('string translated id')
+jest.unstable_mockModule('../../../lib/command/command-util.js', () => ({
+	stringTranslateToId: stringTranslateToIdMock,
+}))
 
 
-const item = { str: 'string-id', num: 5 }
+const { outputItemOrListGeneric, outputItemOrList } = await import('../../../lib/command/listing-io.js')
+
+
+const item: SimpleType = { str: 'string-id', num: 5 }
 const list = [item]
 const command = {
 	flags: {
@@ -23,11 +39,11 @@ const config: OutputItemOrListConfig<SimpleType, SimpleType> = {
 	sortKeyName: 'num',
 }
 
-const getFunction = jest.fn().mockResolvedValue(item)
-const listFunction = jest.fn()
-const outputItemMock = jest.mocked(outputItem)
-const outputListMock = jest.mocked(outputList)
-const translateToId = jest.fn().mockResolvedValue('translated id')
+const getFunction: jest.Mock<LookupDataFunction<string, SimpleType>> = jest.fn()
+getFunction.mockResolvedValue(item)
+const listFunction: jest.Mock<ListDataFunction<SimpleType>> = jest.fn()
+const translateToId: jest.Mock<IdTranslationFunction<string, SimpleType>> = jest.fn()
+translateToId.mockResolvedValue('translated id')
 
 describe('outputItemOrListGeneric', () => {
 	it('calls outputItem when given idOrIndex', async () => {
@@ -70,27 +86,25 @@ describe('outputItemOrListGeneric', () => {
 })
 
 describe('outputItemOrList', () => {
-	const translateToIdMock = jest.mocked(stringTranslateToId).mockResolvedValue('id or index')
-
 	it('calls outputItem when given an id', async () => {
 		outputItemMock.mockResolvedValue(item)
 
 		await outputItemOrList(command, config, 'id or index', listFunction, getFunction)
 
-		expect(translateToIdMock).toHaveBeenCalledTimes(1)
-		expect(translateToIdMock).toHaveBeenCalledWith(config, 'id or index', listFunction)
+		expect(stringTranslateToIdMock).toHaveBeenCalledTimes(1)
+		expect(stringTranslateToIdMock).toHaveBeenCalledWith(config, 'id or index', listFunction)
 		expect(outputItemMock).toHaveBeenCalledTimes(1)
 		expect(outputItemMock).toHaveBeenCalledWith(command, config, expect.anything())
 
 		expect(getFunction).toHaveBeenCalledTimes(0)
 		expect(outputListMock).toHaveBeenCalledTimes(0)
 
-		const getCaller: () => Promise<SimpleType> = outputItemMock.mock.calls[0][2] as never
+		const getCaller = outputItemMock.mock.calls[0][2]
 		const getCallerResult = await getCaller()
 
 		expect(getCallerResult).toBe(item)
 		expect(getFunction).toHaveBeenCalledTimes(1)
-		expect(getFunction).toHaveBeenCalledWith('id or index')
+		expect(getFunction).toHaveBeenCalledWith('string translated id')
 	})
 
 	it('calls outputList when not given idOrIndex', async () => {
@@ -101,7 +115,7 @@ describe('outputItemOrList', () => {
 		expect(outputListMock).toHaveBeenCalledTimes(1)
 		expect(outputListMock).toHaveBeenCalledWith(command, config, listFunction, true)
 
-		expect(translateToIdMock).toHaveBeenCalledTimes(0)
+		expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
 		expect(getFunction).toHaveBeenCalledTimes(0)
 		expect(listFunction).toHaveBeenCalledTimes(0)
 		expect(outputItemMock).toHaveBeenCalledTimes(0)

--- a/src/lib/command/select.ts
+++ b/src/lib/command/select.ts
@@ -7,7 +7,8 @@ import {
 	Naming,
 	outputList,
 	OutputListConfig,
-	Sorting } from './basic-io.js'
+	Sorting,
+} from './basic-io.js'
 import { resetManagedConfigKey, setConfigKey } from '../cli-config.js'
 import { stringGetIdFromUser } from './command-util.js'
 import { SmartThingsCommand } from './smartthings-command.js'


### PR DESCRIPTION
converted listing-io, output-builder, and select tests to ESM