### PR TITLE
refactor: clean up builder tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,6 +15,7 @@ const config: JestConfigWithTsJest = {
 		'/src/index.ts',
 		'/src/commands/index.ts',
 		'/src/lib/command/util/st-client-wrapper.ts',
+		'/src/lib/colors.ts',
 	],
 	modulePathIgnorePatterns: [
 		'<rootDir>/dist',

--- a/src/__tests__/commands/locations/delete.test.ts
+++ b/src/__tests__/commands/locations/delete.test.ts
@@ -1,5 +1,4 @@
 import { jest } from '@jest/globals'
-import { FunctionLike } from 'jest-mock'
 
 import { ArgumentsCamelCase, Argv } from 'yargs'
 
@@ -8,6 +7,7 @@ import { LocationsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
 import { CommandArgs } from '../../../commands/locations/delete.js'
 import { APICommand, APICommandFlags, apiCommand, apiCommandBuilder, apiDocsURL } from '../../../lib/command/api-command.js'
 import { chooseLocation } from '../../../lib/command/util/locations-util.js'
+import { buildArgvMock } from '../../test-lib/builder-mock.js'
 
 
 const apiCommandMock = jest.fn<typeof apiCommand>()
@@ -30,28 +30,22 @@ const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => { /*no
 const { default: cmd } = await import('../../../commands/locations/delete.js')
 
 
-type BuilderFunctionMock<T extends FunctionLike> = jest.Mock<T> & T
-
 test('builder', () => {
-	const apiCommandArgvMock = jest.fn() as BuilderFunctionMock<Argv<APICommandFlags>>
-	apiCommandBuilderMock.mockReturnValue(apiCommandArgvMock)
+	const {
+		yargsMock,
+		positionalMock,
+		exampleMock,
+		epilogMock,
+		argvMock,
+	} = buildArgvMock<object, CommandArgs>()
 
-	const positionalMock = jest.fn() as BuilderFunctionMock<Argv<APICommandFlags>['positional']>
-	positionalMock.mockReturnValue(apiCommandArgvMock)
-	apiCommandArgvMock.positional = positionalMock
-
-	const exampleMock = jest.fn() as BuilderFunctionMock<Argv<APICommandFlags>['example']>
-	exampleMock.mockReturnValue(apiCommandArgvMock)
-	apiCommandArgvMock.example = exampleMock
-
-	const epilogMock = jest.fn() as BuilderFunctionMock<Argv<APICommandFlags>['epilog']>
-	epilogMock.mockReturnValue(apiCommandArgvMock)
-	apiCommandArgvMock.epilog = epilogMock
-
-	const yargsMock = jest.fn() as BuilderFunctionMock<Argv<CommandArgs>>
+	apiCommandBuilderMock.mockReturnValue(argvMock)
 
 	const builder = cmd.builder as (yargs: Argv<object>) => Argv<CommandArgs>
-	expect(builder(yargsMock)).toBe(apiCommandArgvMock)
+	expect(builder(yargsMock)).toBe(argvMock)
+
+	expect(apiCommandBuilderMock).toHaveBeenCalledTimes(1)
+	expect(apiCommandBuilderMock).toHaveBeenCalledWith(yargsMock)
 
 	expect(positionalMock).toHaveBeenCalledTimes(1)
 	expect(exampleMock).toHaveBeenCalledTimes(1)

--- a/src/__tests__/commands/locations/update.test.ts
+++ b/src/__tests__/commands/locations/update.test.ts
@@ -1,5 +1,4 @@
 import { jest } from '@jest/globals'
-import { FunctionLike } from 'jest-mock'
 
 import { ArgumentsCamelCase, Argv } from 'yargs'
 
@@ -9,25 +8,26 @@ import { chooseLocation, tableFieldDefinitions } from '../../../lib/command/util
 import { APICommand, APICommandFlags, apiCommand, apiCommandBuilder, apiDocsURL } from '../../../lib/command/api-command.js'
 import { inputAndOutputItem, inputAndOutputItemBuilder } from '../../../lib/command/basic-io.js'
 import { CommandArgs } from '../../../commands/locations/update.js'
+import { buildArgvMock, buildArgvMockStub } from '../../test-lib/builder-mock.js'
 
 
-const chooseLocationMock: jest.Mock<typeof chooseLocation> = jest.fn()
+const chooseLocationMock = jest.fn<typeof chooseLocation>()
 jest.unstable_mockModule('../../../lib/command/util/locations-util.js', () => ({
 	chooseLocation: chooseLocationMock,
 	tableFieldDefinitions,
 }))
 
-const apiCommandMock: jest.Mock<typeof apiCommand> = jest.fn()
-const apiCommandBuilderMock: jest.Mock<typeof apiCommandBuilder> = jest.fn()
-const apiDocsURLMock: jest.Mock<typeof apiDocsURL> = jest.fn()
+const apiCommandMock = jest.fn<typeof apiCommand>()
+const apiCommandBuilderMock = jest.fn<typeof apiCommandBuilder>()
+const apiDocsURLMock = jest.fn<typeof apiDocsURL>()
 jest.unstable_mockModule('../../../lib/command/api-command.js', () => ({
 	apiCommand: apiCommandMock,
 	apiCommandBuilder: apiCommandBuilderMock,
 	apiDocsURL: apiDocsURLMock,
 }))
 
-const inputAndOutputItemMock: jest.Mock<typeof inputAndOutputItem> = jest.fn()
-const inputAndOutputItemBuilderMock: jest.Mock<typeof inputAndOutputItemBuilder> = jest.fn()
+const inputAndOutputItemMock = jest.fn<typeof inputAndOutputItem>()
+const inputAndOutputItemBuilderMock = jest.fn<typeof inputAndOutputItemBuilder>()
 jest.unstable_mockModule('../../../lib/command/basic-io.js', () => ({
 	inputAndOutputItem: inputAndOutputItemMock,
 	inputAndOutputItemBuilder: inputAndOutputItemBuilderMock,
@@ -37,32 +37,26 @@ jest.unstable_mockModule('../../../lib/command/basic-io.js', () => ({
 const { default: cmd } = await import('../../../commands/locations/update.js')
 
 
-type BuilderFunctionMock<T extends FunctionLike> = jest.Mock<T> & T
-
 test('builder', () => {
-	const apiCommandArgvMock = jest.fn() as BuilderFunctionMock<Argv<object & APICommandFlags>>
-	apiCommandBuilderMock.mockReturnValue(apiCommandArgvMock)
+	const yargsMock = buildArgvMockStub<object>()
+	const {
+		yargsMock: apiCommandBuilderArgvMock,
+		positionalMock,
+		exampleMock,
+		epilogMock,
+		argvMock,
+	} = buildArgvMock<APICommandFlags, CommandArgs>()
 
-	const inputAndOutputItemArgvMock = jest.fn() as BuilderFunctionMock<Argv<CommandArgs>>
-
-	const positionalMock = jest.fn() as BuilderFunctionMock<Argv<APICommandFlags>['positional']>
-	positionalMock.mockReturnValue(inputAndOutputItemArgvMock)
-	inputAndOutputItemArgvMock.positional = positionalMock
-
-	const exampleMock = jest.fn() as BuilderFunctionMock<Argv<CommandArgs>['example']>
-	exampleMock.mockReturnValue(inputAndOutputItemArgvMock)
-	inputAndOutputItemArgvMock.example = exampleMock
-
-	const epilogMock = jest.fn() as BuilderFunctionMock<Argv<CommandArgs>['epilog']>
-	epilogMock.mockReturnValue(inputAndOutputItemArgvMock)
-	inputAndOutputItemArgvMock.epilog = epilogMock
-
-	inputAndOutputItemBuilderMock.mockReturnValueOnce(inputAndOutputItemArgvMock)
-
-	const yargsMock = jest.fn() as BuilderFunctionMock<Argv<CommandArgs>>
+	apiCommandBuilderMock.mockReturnValueOnce(apiCommandBuilderArgvMock)
+	inputAndOutputItemBuilderMock.mockReturnValueOnce(argvMock)
 
 	const builder = cmd.builder as (yargs: Argv<object>) => Argv<CommandArgs>
-	expect(builder(yargsMock)).toBe(inputAndOutputItemArgvMock)
+	expect(builder(yargsMock)).toBe(argvMock)
+
+	expect(apiCommandBuilderMock).toHaveBeenCalledTimes(1)
+	expect(apiCommandBuilderMock).toHaveBeenCalledWith(yargsMock)
+	expect(inputAndOutputItemBuilderMock).toHaveBeenCalledTimes(1)
+	expect(inputAndOutputItemBuilderMock).toHaveBeenCalledWith(apiCommandBuilderArgvMock)
 
 	expect(positionalMock).toHaveBeenCalledTimes(1)
 	expect(exampleMock).toHaveBeenCalledTimes(1)

--- a/src/__tests__/lib/cli-config.test.ts
+++ b/src/__tests__/lib/cli-config.test.ts
@@ -12,15 +12,15 @@ import {
 import { yamlExists } from '../../lib/io-util.js'
 
 
-const readFileMock: jest.Mock<typeof readFile> = jest.fn()
-const writeFileMock: jest.Mock<typeof writeFile> = jest.fn()
+const readFileMock = jest.fn<typeof readFile>()
+const writeFileMock = jest.fn<typeof writeFile>()
 jest.unstable_mockModule('fs/promises', () => ({
 	readFile: readFileMock,
 	writeFile: writeFileMock,
 }))
 
-const yamlLoadMock: jest.Mock<typeof yaml.load> = jest.fn()
-const yamlDumpMock: jest.Mock<typeof yaml.dump> = jest.fn()
+const yamlLoadMock = jest.fn<typeof yaml.load>()
+const yamlDumpMock = jest.fn<typeof yaml.dump>()
 jest.unstable_mockModule('js-yaml', () => ({
 	default: {
 		load: yamlLoadMock,
@@ -28,7 +28,7 @@ jest.unstable_mockModule('js-yaml', () => ({
 	},
 }))
 
-const yamlExistsMock: jest.Mock<typeof yamlExists> = jest.fn()
+const yamlExistsMock = jest.fn<typeof yamlExists>()
 yamlExistsMock.mockReturnValue(true)
 jest.unstable_mockModule('../../lib/io-util.js', () => ({
 	yamlExists: yamlExistsMock,
@@ -330,7 +330,7 @@ describe('cli-config', () => {
 			profile2: {},
 		}
 
-		const predicateMock: jest.Mock<(value: unknown) => boolean> = jest.fn()
+		const predicateMock = jest.fn<(value: unknown) => boolean>()
 
 		it('does nothing when key not present', async () => {
 			const cliConfig = makeConfig(profiles, managedProfiles)

--- a/src/__tests__/lib/command/api-organization-command.test.ts
+++ b/src/__tests__/lib/command/api-organization-command.test.ts
@@ -1,24 +1,46 @@
 import { jest } from '@jest/globals'
 
 import { APICommand, apiCommand, apiCommandBuilder } from '../../../lib/command/api-command.js'
-import { SmartThingsCommand } from '../../../lib/command/smartthings-command.js'
+import { SmartThingsCommand, SmartThingsCommandFlags } from '../../../lib/command/smartthings-command.js'
+import { buildArgvMock } from '../../test-lib/builder-mock.js'
+import { APIOrganizationCommandFlags } from '../../../lib/command/api-organization-command.js'
 
 
-const stringConfigValueMock: jest.Mock<SmartThingsCommand['stringConfigValue']> = jest.fn()
+const stringConfigValueMock = jest.fn<SmartThingsCommand['stringConfigValue']>()
 const apiCommandResultMock = {
 	configDir: 'test-config-dir',
 	profileName: 'profile-from-parent',
 	stringConfigValue: stringConfigValueMock,
 } as unknown as APICommand
-const apiCommandMock: jest.Mock<typeof apiCommand> = jest.fn()
+const apiCommandBuilderMock = jest.fn<typeof apiCommandBuilder>()
+const apiCommandMock = jest.fn<typeof apiCommand>()
 apiCommandMock.mockResolvedValue(apiCommandResultMock)
 jest.unstable_mockModule('../../../lib/command/api-command.js', () => ({
-	apiCommandBuilder,
+	apiCommandBuilder: apiCommandBuilderMock,
 	apiCommand: apiCommandMock,
 }))
 
-const { apiOrganizationCommand } = await import('../../../lib/command/api-organization-command.js')
+const {
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+} = await import('../../../lib/command/api-organization-command.js')
 
+
+test('apiOrganizationCommandBuilder', () => {
+	const {
+		yargsMock,
+		optionMock,
+		argvMock,
+	} = buildArgvMock<SmartThingsCommandFlags, APIOrganizationCommandFlags>()
+	apiCommandBuilderMock.mockReturnValueOnce(argvMock)
+
+	expect(apiOrganizationCommandBuilder(yargsMock)).toBe(argvMock)
+
+	expect(apiCommandBuilderMock).toHaveBeenCalledTimes(1)
+	expect(apiCommandBuilderMock).toHaveBeenCalledWith(yargsMock)
+
+	expect(optionMock).toHaveBeenCalledTimes(1)
+})
 
 describe('apiOrganizationCommand', () => {
 	const flags = { profile: 'cmd-line-profile' }

--- a/src/__tests__/lib/command/command-util.test.ts
+++ b/src/__tests__/lib/command/command-util.test.ts
@@ -8,14 +8,14 @@ import { ListDataFunction, Sorting } from '../../../lib/command/basic-io.js'
 import { SimpleType } from '../../test-lib/simple-type.js'
 
 
-const promptMock: jest.Mock<typeof inquirer.prompt> = jest.fn()
+const promptMock = jest.fn<typeof inquirer.prompt>()
 jest.unstable_mockModule('inquirer', () => ({
 	default: {
 		prompt: promptMock,
 	},
 }))
 
-const sortMock: jest.Mock<typeof sort> = jest.fn()
+const sortMock = jest.fn<typeof sort>()
 jest.unstable_mockModule('../../../lib/command/output.js', () => ({
 	sort: sortMock,
 }))
@@ -78,7 +78,7 @@ const config: Sorting<SimpleType> = {
 }
 
 describe('stringTranslateToId', () => {
-	const listFunction: jest.Mock<ListDataFunction<SimpleType>> = jest.fn()
+	const listFunction = jest.fn<ListDataFunction<SimpleType>>()
 
 	it('simply returns undefined given undefined idOrIndex', async () => {
 		const computedId = await stringTranslateToId(config, undefined, listFunction)

--- a/src/__tests__/lib/command/common-flags.test.ts
+++ b/src/__tests__/lib/command/common-flags.test.ts
@@ -1,0 +1,20 @@
+import { buildArgvMock } from '../../test-lib/builder-mock.js'
+
+
+const { allOrganizationsBuilder, lambdaAuthBuilder } = await import('../../../lib/command/common-flags.js')
+
+test('lambdaAuthBuilder', () => {
+	const { optionMock, argvMock } = buildArgvMock<object>()
+
+	expect(lambdaAuthBuilder(argvMock)).toBe(argvMock)
+
+	expect(optionMock).toHaveBeenCalledTimes(2)
+})
+
+test('allOrganizationsBuilder', () => {
+	const { optionMock, argvMock } = buildArgvMock<object>()
+
+	expect(allOrganizationsBuilder(argvMock)).toBe(argvMock)
+
+	expect(optionMock).toHaveBeenCalledTimes(1)
+})

--- a/src/__tests__/lib/command/format.test.ts
+++ b/src/__tests__/lib/command/format.test.ts
@@ -16,9 +16,9 @@ import { SmartThingsCommand } from '../../../lib/command/smartthings-command.js'
 import { SimpleType } from '../../test-lib/simple-type.js'
 
 
-const itemTableFormatterMock: jest.Mock<typeof itemTableFormatter<SimpleType>> = jest.fn()
-const listTableFormatterMock: jest.Mock<typeof listTableFormatter<SimpleType>> = jest.fn()
-const writeOutputMock: jest.Mock<typeof writeOutput> = jest.fn()
+const itemTableFormatterMock = jest.fn<typeof itemTableFormatter<SimpleType>>()
+const listTableFormatterMock = jest.fn<typeof listTableFormatter<SimpleType>>()
+const writeOutputMock = jest.fn<typeof writeOutput>()
 writeOutputMock.mockResolvedValue()
 jest.unstable_mockModule('../../../lib/command/output.js', () => ({
 	itemTableFormatter: itemTableFormatterMock,
@@ -26,8 +26,8 @@ jest.unstable_mockModule('../../../lib/command/output.js', () => ({
 	writeOutput: writeOutputMock,
 }))
 
-const buildOutputFormatterMock: jest.Mock<typeof buildOutputFormatter<SimpleType>> = jest.fn()
-const outputFormatterMock: jest.Mock<OutputFormatter<SimpleType>> = jest.fn()
+const buildOutputFormatterMock = jest.fn<typeof buildOutputFormatter<SimpleType>>()
+const outputFormatterMock = jest.fn<OutputFormatter<SimpleType>>()
 outputFormatterMock.mockReturnValue('output')
 buildOutputFormatterMock.mockReturnValue(outputFormatterMock)
 jest.unstable_mockModule('../../../lib/command/output-builder.js', () => ({
@@ -53,14 +53,14 @@ const command = {
 } as unknown as SmartThingsCommand<BuildOutputFormatterFlags>
 
 describe('formatAndWriteItem', () => {
-	const buildTableOutputMock: jest.Mock<CustomCommonOutputProducer<SimpleType>['buildTableOutput']> = jest.fn()
+	const buildTableOutputMock = jest.fn<CustomCommonOutputProducer<SimpleType>['buildTableOutput']>()
 
 	it('uses tableFieldDefinitions when specified', async () => {
 		const config: FormatAndWriteItemConfig<SimpleType> = {
 			tableFieldDefinitions: [],
 		}
 
-		const commonFormatter: jest.Mock<OutputFormatter<SimpleType>> = jest.fn()
+		const commonFormatter = jest.fn<OutputFormatter<SimpleType>>()
 		itemTableFormatterMock.mockReturnValue(commonFormatter)
 
 		await formatAndWriteItem(command, config, item, 'common')
@@ -126,7 +126,7 @@ describe('formatAndWriteList', () => {
 	// `SimpleType` for `buildOutputFormatter`'s generic.
 	const listBuildOutputFormatterMock =
 		buildOutputFormatterMock as unknown as jest.Mock<typeof buildOutputFormatter<SimpleType[]>>
-	const buildListTableOutputMock: jest.Mock<CustomCommonListOutputProducer<SimpleType>['buildListTableOutput']> = jest.fn()
+	const buildListTableOutputMock = jest.fn<CustomCommonListOutputProducer<SimpleType>['buildListTableOutput']>()
 
 	it('returns no items found when none found', async () => {
 		const config: FormatAndWriteListConfig<SimpleType> = {
@@ -199,7 +199,7 @@ describe('formatAndWriteList', () => {
 			primaryKeyName: 'num',
 		}
 
-		const commonFormatter: jest.Mock<OutputFormatter<SimpleType[]>> = jest.fn()
+		const commonFormatter = jest.fn<OutputFormatter<SimpleType[]>>()
 		listTableFormatterMock.mockReturnValue(commonFormatter)
 
 		await formatAndWriteList(command, config, list)
@@ -267,7 +267,7 @@ describe('formatAndWriteList', () => {
 			sortKeyName: 'str',
 		}
 
-		const commonFormatter: jest.Mock<OutputFormatter<SimpleType[]>> = jest.fn()
+		const commonFormatter = jest.fn<OutputFormatter<SimpleType[]>>()
 		listTableFormatterMock.mockReturnValue(commonFormatter)
 
 		await formatAndWriteList(command, config, list)
@@ -288,8 +288,7 @@ describe('formatAndWriteList', () => {
 			primaryKeyName: 'num',
 		}
 
-		const commonFormatter: jest.Mock<OutputFormatter<SimpleType[]>> = jest.fn()
-		commonFormatter.mockReturnValue('common output')
+		const commonFormatter = jest.fn<OutputFormatter<SimpleType[]>>().mockReturnValue('common output')
 		listTableFormatterMock.mockReturnValue(commonFormatter)
 
 		await formatAndWriteList(command, config, list, false, true)

--- a/src/__tests__/lib/command/input-builder.test.ts
+++ b/src/__tests__/lib/command/input-builder.test.ts
@@ -1,13 +1,15 @@
 import { jest } from '@jest/globals'
 
+import { InputProcessorFlags } from '../../../lib/command/input-builder.js'
 import { combinedInputProcessor, fileInputProcessor, InputProcessor, stdinInputProcessor }
 	from '../../../lib/command/input-processor.js'
 import { SimpleType } from '../../test-lib/simple-type.js'
+import { buildArgvMock } from '../../test-lib/builder-mock.js'
 
 
-const combinedInputProcessorMock: jest.Mock<typeof combinedInputProcessor> = jest.fn()
-const fileInputProcessorMock: jest.Mock<typeof fileInputProcessor> = jest.fn()
-const stdinInputProcessorMock: jest.Mock<typeof stdinInputProcessor> = jest.fn()
+const combinedInputProcessorMock = jest.fn<typeof combinedInputProcessor>()
+const fileInputProcessorMock = jest.fn<typeof fileInputProcessor>()
+const stdinInputProcessorMock = jest.fn<typeof stdinInputProcessor>()
 jest.unstable_mockModule('../../../lib/command/input-processor.js', () => ({
 	combinedInputProcessor: combinedInputProcessorMock,
 	fileInputProcessor: fileInputProcessorMock,
@@ -15,8 +17,16 @@ jest.unstable_mockModule('../../../lib/command/input-processor.js', () => ({
 }))
 
 
-const { buildInputProcessor } = await import('../../../lib/command/input-builder.js')
+const { buildInputProcessor, inputProcessorBuilder } = await import('../../../lib/command/input-builder.js')
 
+
+test('inputProcessorBuilder', () => {
+	const { optionMock, argvMock } = buildArgvMock<InputProcessorFlags>()
+
+	expect(inputProcessorBuilder(argvMock)).toBe(argvMock)
+
+	expect(optionMock).toHaveBeenCalledTimes(1)
+})
 
 describe('buildInputProcessor', () => {
 	it('includes file and stdin input processors', () => {

--- a/src/__tests__/lib/command/input-processor.test.ts
+++ b/src/__tests__/lib/command/input-processor.test.ts
@@ -16,15 +16,15 @@ import {
 import { SimpleType, validData } from '../../test-lib/simple-type.js'
 
 
-const readFileMock: jest.Mock<typeof readFile> = jest.fn()
+const readFileMock = jest.fn<typeof readFile>()
 jest.unstable_mockModule('fs/promises', () => ({
 	readFile: readFileMock,
 }))
 
-const formatFromFilenameMock: jest.Mock<typeof formatFromFilename> = jest.fn()
-const parseJSONOrYAMLMock: jest.Mock<typeof parseJSONOrYAML> = jest.fn()
-const readDataFromStdinMock: jest.Mock<typeof readDataFromStdin> = jest.fn()
-const stdinIsTTYMock: jest.Mock<typeof stdinIsTTY> = jest.fn()
+const formatFromFilenameMock = jest.fn<typeof formatFromFilename>()
+const parseJSONOrYAMLMock = jest.fn<typeof parseJSONOrYAML>()
+const readDataFromStdinMock = jest.fn<typeof readDataFromStdin>()
+const stdinIsTTYMock = jest.fn<typeof stdinIsTTY>()
 jest.unstable_mockModule('../../../lib/io-util.js', () => ({
 	formatFromFilename: formatFromFilenameMock,
 	parseJSONOrYAML: parseJSONOrYAMLMock,
@@ -130,8 +130,8 @@ describe('stdinInputProcessor', () => {
 })
 
 describe('simple input processor builder functions', () => {
-	const hasInputMock: jest.Mock<() => boolean> = jest.fn()
-	const readMock: jest.Mock<() => Promise<string>> = jest.fn()
+	const hasInputMock = jest.fn<() => boolean>()
+	const readMock = jest.fn<() => Promise<string>>()
 
 	it('inputBuilder defaults to common input', () => {
 		const result = inputProcessor(hasInputMock, readMock)
@@ -197,13 +197,13 @@ describe('simple input processor builder functions', () => {
 })
 
 describe('combinedInputProcessor', () => {
-	const hasInputMock1: jest.Mock<() => boolean> = jest.fn()
-	const hasInputMock2: jest.Mock<() => Promise<boolean>> = jest.fn()
-	const hasInputMock3: jest.Mock<() => Promise<boolean>> = jest.fn()
+	const hasInputMock1 = jest.fn<() => boolean>()
+	const hasInputMock2 = jest.fn<() => Promise<boolean>>()
+	const hasInputMock3 = jest.fn<() => Promise<boolean>>()
 
-	const readMock1: jest.Mock<() => Promise<SimpleType>> = jest.fn()
-	const readMock2: jest.Mock<() => Promise<SimpleType>> = jest.fn()
-	const readMock3: jest.Mock<() => Promise<SimpleType>> = jest.fn()
+	const readMock1 = jest.fn<() => Promise<SimpleType>>()
+	const readMock2 = jest.fn<() => Promise<SimpleType>>()
+	const readMock3 = jest.fn<() => Promise<SimpleType>>()
 
 	const makeProcessor = (hasInputMock: () => boolean | Promise<boolean>, readMock?: () => Promise<SimpleType>): InputProcessor<SimpleType> => ({
 		ioFormat: 'common',

--- a/src/__tests__/lib/command/listing-io.test.ts
+++ b/src/__tests__/lib/command/listing-io.test.ts
@@ -8,15 +8,15 @@ import { SmartThingsCommand } from '../../../lib/command/smartthings-command.js'
 import { BuildOutputFormatterFlags } from '../../../lib/command/output-builder.js'
 
 
-const outputItemMock: jest.Mock<typeof outputItem<SimpleType>> = jest.fn()
-const outputListMock: jest.Mock<typeof outputList<SimpleType>> = jest.fn()
+const outputItemMock = jest.fn<typeof outputItem<SimpleType>>()
+const outputListMock = jest.fn<typeof outputList<SimpleType>>()
 jest.unstable_mockModule('../../../lib/command/basic-io.js', () => ({
 	outputItem: outputItemMock,
 	outputList: outputListMock,
 	outputListBuilder,
 }))
 
-const stringTranslateToIdMock: jest.Mock<typeof stringTranslateToId> = jest.fn()
+const stringTranslateToIdMock = jest.fn<typeof stringTranslateToId>()
 stringTranslateToIdMock.mockResolvedValue('string translated id')
 jest.unstable_mockModule('../../../lib/command/command-util.js', () => ({
 	stringTranslateToId: stringTranslateToIdMock,
@@ -39,10 +39,9 @@ const config: OutputItemOrListConfig<SimpleType, SimpleType> = {
 	sortKeyName: 'num',
 }
 
-const getFunction: jest.Mock<LookupDataFunction<string, SimpleType>> = jest.fn()
-getFunction.mockResolvedValue(item)
-const listFunction: jest.Mock<ListDataFunction<SimpleType>> = jest.fn()
-const translateToId: jest.Mock<IdTranslationFunction<string, SimpleType>> = jest.fn()
+const getFunction = jest.fn<LookupDataFunction<string, SimpleType>>().mockResolvedValue(item)
+const listFunction = jest.fn<ListDataFunction<SimpleType>>()
+const translateToId = jest.fn<IdTranslationFunction<string, SimpleType>>()
 translateToId.mockResolvedValue('translated id')
 
 describe('outputItemOrListGeneric', () => {

--- a/src/__tests__/lib/command/output.test.ts
+++ b/src/__tests__/lib/command/output.test.ts
@@ -3,26 +3,34 @@ import { jest } from '@jest/globals'
 import { writeFile } from 'fs/promises'
 
 import { formatFromFilename, stdoutIsTTY } from '../../../lib/io-util.js'
-import { Table, TableFieldDefinition, TableGenerator, TableOptions, ValueTableFieldDefinition } from '../../../lib/table-generator.js'
+import {
+	Table,
+	TableFieldDefinition,
+	TableGenerator,
+	TableOptions,
+	ValueTableFieldDefinition,
+} from '../../../lib/table-generator.js'
 
 import { SimpleType } from '../../test-lib/simple-type.js'
+import { buildArgvMock } from '../../test-lib/builder-mock.js'
+import { CalculateOutputFormatFlags } from '../../../lib/command/output.js'
 
 
-const writeFileMock: jest.Mock<typeof writeFile> = jest.fn()
+const writeFileMock = jest.fn<typeof writeFile>()
 jest.unstable_mockModule('fs/promises', () => ({
 	writeFile: writeFileMock,
 }))
 
-const formatFromFilenameMock: jest.Mock<typeof formatFromFilename> = jest.fn()
-const stdoutIsTTYMock: jest.Mock<typeof stdoutIsTTY> = jest.fn()
+const formatFromFilenameMock = jest.fn<typeof formatFromFilename>()
+const stdoutIsTTYMock = jest.fn<typeof stdoutIsTTY>()
 jest.unstable_mockModule('../../../lib/io-util.js', () => ({
 	formatFromFilename: formatFromFilenameMock,
 	stdoutIsTTY: stdoutIsTTYMock,
 }))
 
-const newOutputTableMock: jest.Mock<(options?: Partial<TableOptions>) => Table> = jest.fn()
-const buildTableFromItemMock: jest.Mock<(item: object, tableFieldDefinitions: TableFieldDefinition<object>[]) => string> = jest.fn()
-const buildTableFromListMock: jest.Mock<(items: object[], tableFieldDefinitions: TableFieldDefinition<object>[]) => string> = jest.fn()
+const newOutputTableMock = jest.fn<(options?: Partial<TableOptions>) => Table>()
+const buildTableFromItemMock = jest.fn<(item: object, tableFieldDefinitions: TableFieldDefinition<object>[]) => string>()
+const buildTableFromListMock = jest.fn<(items: object[], tableFieldDefinitions: TableFieldDefinition<object>[]) => string>()
 const tableGeneratorMock: TableGenerator = {
 	newOutputTable: newOutputTableMock,
 	buildTableFromItem: buildTableFromItemMock,
@@ -32,6 +40,7 @@ const tableGeneratorMock: TableGenerator = {
 
 const {
 	calculateOutputFormat,
+	calculateOutputFormatBuilder,
 	itemTableFormatter,
 	jsonFormatter,
 	listTableFormatter,
@@ -60,6 +69,14 @@ describe('sort', () => {
 		const result = sort(input, 'str')
 		expect(result).toEqual([st('abc'), st('ABC'), st('that'), st('this'), st('xyz')])
 	})
+})
+
+test('calculateOutputFormatBuilder', () => {
+	const { optionMock, argvMock } = buildArgvMock<object, CalculateOutputFormatFlags>()
+
+	expect(calculateOutputFormatBuilder(argvMock)).toBe(argvMock)
+
+	expect(optionMock).toHaveBeenCalledTimes(3)
 })
 
 describe('calculateOutputFormat', () => {

--- a/src/__tests__/lib/command/select.test.ts
+++ b/src/__tests__/lib/command/select.test.ts
@@ -11,26 +11,26 @@ import { SmartThingsCommand, SmartThingsCommandFlags } from '../../../lib/comman
 import { SimpleType } from '../../test-lib/simple-type.js'
 
 
-const promptMock: jest.Mock<typeof inquirer.prompt> = jest.fn()
+const promptMock = jest.fn<typeof inquirer.prompt>()
 jest.unstable_mockModule('inquirer', () => ({
 	default: {
 		prompt: promptMock,
 	},
 }))
 
-const resetManagedConfigKeyMock: jest.Mock<typeof resetManagedConfigKey> = jest.fn()
-const setConfigKeyMock: jest.Mock<typeof setConfigKey> = jest.fn()
+const resetManagedConfigKeyMock = jest.fn<typeof resetManagedConfigKey>()
+const setConfigKeyMock = jest.fn<typeof setConfigKey>()
 jest.unstable_mockModule('../../../lib/cli-config.js', () => ({
 	resetManagedConfigKey: resetManagedConfigKeyMock,
 	setConfigKey: setConfigKeyMock,
 }))
 
-const outputListMock: jest.Mock<typeof outputList> = jest.fn()
+const outputListMock = jest.fn<typeof outputList>()
 jest.unstable_mockModule('../../../lib/command/basic-io.js', () => ({
 	outputList: outputListMock,
 }))
 
-const stringGetIdFromUserMock: jest.Mock<typeof stringGetIdFromUser> = jest.fn()
+const stringGetIdFromUserMock = jest.fn<typeof stringGetIdFromUser>()
 jest.unstable_mockModule('../../../lib/command/command-util.js', () => ({
 	stringGetIdFromUser: stringGetIdFromUserMock,
 }))
@@ -61,8 +61,7 @@ describe('select', () => {
 		sortKeyName: 'num',
 	}
 
-	const listItemsMock: jest.Mock<ListDataFunction<SimpleType>> = jest.fn()
-	listItemsMock.mockResolvedValue(list)
+	const listItemsMock = jest.fn<ListDataFunction<SimpleType>>().mockResolvedValue(list)
 
 	const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => { /*no-op*/ })
 
@@ -139,8 +138,7 @@ describe('select', () => {
 		it('calls custom getIdFromUser when specified', async () => {
 			outputListMock.mockResolvedValueOnce(list)
 
-			const getIdFromUser: jest.Mock<IdRetrievalFunction<string, SimpleType>> = jest.fn()
-			getIdFromUser.mockResolvedValueOnce('special-id')
+			const getIdFromUser = jest.fn<IdRetrievalFunction<string, SimpleType>>().mockResolvedValueOnce('special-id')
 
 			expect(await promptUser(command, config, { listItems: listItemsMock, getIdFromUser })).toBe('special-id')
 
@@ -181,8 +179,8 @@ describe('select', () => {
 	})
 
 	describe('selectFromList', () => {
-		const getItemMock: jest.Mock<LookupDataFunction<string, SimpleType>> = jest.fn()
-		const userMessageMock: jest.Mock<(item: SimpleType) => string> = jest.fn()
+		const getItemMock = jest.fn<LookupDataFunction<string, SimpleType>>()
+		const userMessageMock = jest.fn<(item: SimpleType) => string>()
 		const defaultValue: SelectOptions<SimpleType>['defaultValue'] = {
 			configKey: 'defaultItem',
 			getItem: getItemMock,

--- a/src/__tests__/lib/command/smartthings-command.test.ts
+++ b/src/__tests__/lib/command/smartthings-command.test.ts
@@ -5,30 +5,41 @@ import log4js from 'log4js'
 import { CLIConfig, loadConfig } from '../../../lib/cli-config.js'
 import { buildDefaultLog4jsConfig, loadLog4jsConfig } from '../../../lib/log-utils.js'
 import { defaultTableGenerator } from '../../../lib/table-generator.js'
+import { buildArgvMock } from '../../test-lib/builder-mock.js'
+import { SmartThingsCommandFlags } from '../../../lib/command/smartthings-command.js'
 
 
 const { configureMock, getLoggerMock } = await import('../../test-lib/logger-mock.js')
 
-const loadConfigMock: jest.Mock<typeof loadConfig> = jest.fn()
+const loadConfigMock = jest.fn<typeof loadConfig>()
 jest.unstable_mockModule('../../../lib/cli-config.js', () => ({
 	loadConfig: loadConfigMock,
 }))
 
-const buildDefaultLog4jsConfigMock: jest.Mock<typeof buildDefaultLog4jsConfig> = jest.fn()
-const loadLog4jsConfigMock: jest.Mock<typeof loadLog4jsConfig> = jest.fn()
+const buildDefaultLog4jsConfigMock = jest.fn<typeof buildDefaultLog4jsConfig>()
+const loadLog4jsConfigMock = jest.fn<typeof loadLog4jsConfig>()
 jest.unstable_mockModule('../../../lib/log-utils.js', () => ({
 	buildDefaultLog4jsConfig: buildDefaultLog4jsConfigMock,
 	loadLog4jsConfig: loadLog4jsConfigMock,
 }))
 
-const defaultTableGeneratorMock: jest.Mock<typeof defaultTableGenerator> = jest.fn()
+const defaultTableGeneratorMock = jest.fn<typeof defaultTableGenerator>()
 jest.unstable_mockModule('../../../lib//table-generator', () => ({
 	defaultTableGenerator: defaultTableGeneratorMock,
 }))
 
 
-const { smartThingsCommand } = await import('../../../lib/command/smartthings-command.js')
+const { smartThingsCommandBuilder, smartThingsCommand } = await import('../../../lib/command/smartthings-command.js')
 
+
+test('smartThingsCommandBuilder', () => {
+	const { envMock, optionMock, argvMock } = buildArgvMock<object, SmartThingsCommandFlags>()
+
+	expect(smartThingsCommandBuilder(argvMock)).toBe(argvMock)
+
+	expect(envMock).toHaveBeenCalledTimes(1)
+	expect(optionMock).toHaveBeenCalledTimes(1)
+})
 
 describe('smartThingsCommand', () => {
 	const defaultLogConfig = { config: 'default' } as unknown as log4js.Configuration

--- a/src/__tests__/lib/command/util/apps-util.test.ts
+++ b/src/__tests__/lib/command/util/apps-util.test.ts
@@ -12,15 +12,15 @@ import {
 import { selectFromList, SelectFromListFlags } from '../../../../lib/command/select.js'
 
 
-const chooseOptionsWithDefaultsMock: jest.Mock<typeof chooseOptionsWithDefaults> = jest.fn()
-const stringTranslateToIdMock: jest.Mock<typeof stringTranslateToId> = jest.fn()
+const chooseOptionsWithDefaultsMock = jest.fn<typeof chooseOptionsWithDefaults>()
+const stringTranslateToIdMock = jest.fn<typeof stringTranslateToId>()
 jest.unstable_mockModule('../../../../lib/command/command-util.js', () => ({
 	chooseOptionsDefaults,
 	chooseOptionsWithDefaults: chooseOptionsWithDefaultsMock,
 	stringTranslateToId: stringTranslateToIdMock,
 }))
 
-const selectFromListMock: jest.Mock<typeof selectFromList> = jest.fn()
+const selectFromListMock = jest.fn<typeof selectFromList>()
 jest.unstable_mockModule('../../../../lib/command/select.js', () => ({
 	selectFromList: selectFromListMock,
 }))
@@ -165,7 +165,7 @@ test('chooseApp uses correct endpoint to list apps', async () => {
 })
 
 describe('buildTableOutput', () => {
-	const newOutputTableMock: jest.Mock<TableGenerator['newOutputTable']> = jest.fn()
+	const newOutputTableMock = jest.fn<TableGenerator['newOutputTable']>()
 	const mockTableGenerator = {
 		newOutputTable: newOutputTableMock,
 	} as unknown as TableGenerator
@@ -191,8 +191,8 @@ describe('buildTableOutput', () => {
 })
 
 describe('verboseApps', () => {
-	const listMock: jest.Mock<typeof AppsEndpoint.prototype.list> = jest.fn()
-	const getMock: jest.Mock<typeof AppsEndpoint.prototype.get> = jest.fn()
+	const listMock = jest.fn<typeof AppsEndpoint.prototype.list>()
+	const getMock = jest.fn<typeof AppsEndpoint.prototype.get>()
 	const apps = { list: listMock, get: getMock } as unknown as AppsEndpoint
 	const client = { apps } as SmartThingsClient
 

--- a/src/__tests__/lib/command/util/devicepreferences-util.test.ts
+++ b/src/__tests__/lib/command/util/devicepreferences-util.test.ts
@@ -7,7 +7,7 @@ import { SelectFromListFlags, selectFromList } from '../../../../lib/command/sel
 import { ValueTableFieldDefinition } from '../../../../lib/table-generator.js'
 
 
-const selectFromListMock: jest.Mock<typeof selectFromList> = jest.fn()
+const selectFromListMock = jest.fn<typeof selectFromList>()
 jest.unstable_mockModule('../../../../lib/command/select', () => ({
 	selectFromList: selectFromListMock,
 }))
@@ -40,7 +40,7 @@ describe('tableFieldDefinitions options definition', () => {
 
 test('chooseDevicePreference', async () => {
 	selectFromListMock.mockResolvedValueOnce('chosen-id')
-	const listMock: jest.Mock<typeof DevicePreferencesEndpoint.prototype.list> = jest.fn()
+	const listMock = jest.fn<typeof DevicePreferencesEndpoint.prototype.list>()
 	const client = { devicePreferences: { list: listMock } } as unknown as SmartThingsClient
 	const command = { client } as APICommand<SelectFromListFlags>
 

--- a/src/__tests__/lib/command/util/locations-util.test.ts
+++ b/src/__tests__/lib/command/util/locations-util.test.ts
@@ -10,15 +10,15 @@ import {
 } from '../../../../lib/command/command-util.js'
 
 
-const chooseOptionsWithDefaultsMock: jest.Mock<typeof chooseOptionsWithDefaults> = jest.fn()
-const stringTranslateToIdMock: jest.Mock<typeof stringTranslateToId> = jest.fn()
+const chooseOptionsWithDefaultsMock = jest.fn<typeof chooseOptionsWithDefaults>()
+const stringTranslateToIdMock = jest.fn<typeof stringTranslateToId>()
 jest.unstable_mockModule('../../../../lib/command/command-util.js', () => ({
 	chooseOptionsDefaults,
 	chooseOptionsWithDefaults: chooseOptionsWithDefaultsMock,
 	stringTranslateToId: stringTranslateToIdMock,
 }))
 
-const selectFromListMock: jest.Mock<typeof selectFromList> = jest.fn()
+const selectFromListMock = jest.fn<typeof selectFromList>()
 jest.unstable_mockModule('../../../../lib/command/select.js', () => ({
 	selectFromList: selectFromListMock,
 }))

--- a/src/__tests__/lib/command/util/util-util.test.ts
+++ b/src/__tests__/lib/command/util/util-util.test.ts
@@ -13,15 +13,15 @@ import {
 import { SimpleType } from '../../../test-lib/simple-type.js'
 
 
-const chooseOptionsWithDefaultsMock: jest.Mock<typeof chooseOptionsWithDefaults> = jest.fn()
-const stringTranslateToIdMock: jest.Mock<typeof stringTranslateToId> = jest.fn()
+const chooseOptionsWithDefaultsMock = jest.fn<typeof chooseOptionsWithDefaults>()
+const stringTranslateToIdMock = jest.fn<typeof stringTranslateToId>()
 jest.unstable_mockModule('../../../../lib/command/command-util.js', () => ({
 	chooseOptionsDefaults,
 	chooseOptionsWithDefaults: chooseOptionsWithDefaultsMock,
 	stringTranslateToId: stringTranslateToIdMock,
 }))
 
-const selectFromListMock: jest.Mock<typeof selectFromList> = jest.fn()
+const selectFromListMock = jest.fn<typeof selectFromList>()
 jest.unstable_mockModule('../../../../lib/command/select.js', () => ({
 	selectFromList: selectFromListMock,
 }))

--- a/src/__tests__/lib/file-util.test.ts
+++ b/src/__tests__/lib/file-util.test.ts
@@ -7,8 +7,8 @@ import yaml from 'js-yaml'
 import { YAMLFileData } from '../../lib/file-util.js'
 
 
-const readFileSyncMock: jest.Mock<typeof fs.readFileSync> = jest.fn()
-const statMock: jest.Mock<typeof fs.promises.stat> = jest.fn()
+const readFileSyncMock = jest.fn<typeof fs.readFileSync>()
+const statMock = jest.fn<typeof fs.promises.stat>()
 jest.unstable_mockModule('fs', () => ({
 	default: {
 		readFileSync: readFileSyncMock,
@@ -17,8 +17,8 @@ jest.unstable_mockModule('fs', () => ({
 		},
 	},
 }))
-const yamlLoadMock: jest.Mock<typeof yaml.load> = jest.fn()
-const yamlDumpMock: jest.Mock<typeof yaml.dump> = jest.fn()
+const yamlLoadMock = jest.fn<typeof yaml.load>()
+const yamlDumpMock = jest.fn<typeof yaml.dump>()
 jest.unstable_mockModule('js-yaml', () => ({
 	default: {
 		load: yamlLoadMock,

--- a/src/__tests__/lib/io-util.test.ts
+++ b/src/__tests__/lib/io-util.test.ts
@@ -6,7 +6,7 @@ import { stdin as mockStdin } from 'mock-stdin'
 import { validData, validYAML, SimpleType } from '../test-lib/simple-type.js'
 
 
-const existsSyncMock: jest.Mock<typeof existsSync> = jest.fn()
+const existsSyncMock = jest.fn<typeof existsSync>()
 jest.unstable_mockModule('fs', () => ({
 	default: {
 		existsSync: existsSyncMock,

--- a/src/__tests__/lib/item-input/array.test.ts
+++ b/src/__tests__/lib/item-input/array.test.ts
@@ -19,16 +19,16 @@ import { clipToMaximum, stringFromUnknown } from '../../../lib/util.js'
 import { ArrayDefOptions, CheckboxDefOptions } from '../../../lib/item-input/array.js'
 
 
-const promptMock: jest.Mock<typeof inquirer.prompt> = jest.fn()
+const promptMock = jest.fn<typeof inquirer.prompt>()
 jest.unstable_mockModule('inquirer', () => ({
 	default: {
 		prompt: promptMock,
 		Separator: inquirer.Separator,
 	},
 }))
-const clipToMaximumMock: jest.Mock<typeof clipToMaximum> = jest.fn()
+const clipToMaximumMock = jest.fn<typeof clipToMaximum>()
 clipToMaximumMock.mockReturnValue('clipped')
-const stringFromUnknownMock: jest.Mock<typeof stringFromUnknown> = jest.fn()
+const stringFromUnknownMock = jest.fn<typeof stringFromUnknown>()
 jest.unstable_mockModule('../../../lib/util.js', () => ({
 	clipToMaximum: clipToMaximumMock,
 	stringFromUnknown: stringFromUnknownMock,

--- a/src/__tests__/lib/item-input/misc.test.ts
+++ b/src/__tests__/lib/item-input/misc.test.ts
@@ -21,18 +21,18 @@ import { stringFromUnknown } from '../../../lib/util.js'
 import { ListSelectionDefOptions, OptionalDefPredicateFn } from '../../../lib/item-input/misc.js'
 
 
-const promptMock: jest.Mock<typeof inquirer.prompt> = jest.fn()
+const promptMock = jest.fn<typeof inquirer.prompt>()
 jest.unstable_mockModule('inquirer', () => ({
 	default: {
 		prompt: promptMock,
 		Separator: inquirer.Separator,
 	},
 }))
-const askForBooleanMock: jest.Mock<typeof askForBoolean> = jest.fn()
-const askForIntegerMock: jest.Mock<typeof askForInteger> = jest.fn()
-const askForOptionalIntegerMock: jest.Mock<typeof askForOptionalInteger> = jest.fn()
-const askForStringMock: jest.Mock<typeof askForString> = jest.fn()
-const askForOptionalStringMock: jest.Mock<typeof askForOptionalString> = jest.fn()
+const askForBooleanMock = jest.fn<typeof askForBoolean>()
+const askForIntegerMock = jest.fn<typeof askForInteger>()
+const askForOptionalIntegerMock = jest.fn<typeof askForOptionalInteger>()
+const askForStringMock = jest.fn<typeof askForString>()
+const askForOptionalStringMock = jest.fn<typeof askForOptionalString>()
 jest.unstable_mockModule('../../../lib/user-query.js', () => ({
 	askForBoolean: askForBooleanMock,
 	askForInteger: askForIntegerMock,

--- a/src/__tests__/lib/item-input/object.test.ts
+++ b/src/__tests__/lib/item-input/object.test.ts
@@ -6,7 +6,7 @@ import { cancelAction, finishAction, helpAction, InputDefinition, inquirerPageSi
 import { ObjectDefOptions, ObjectItemTypeData } from '../../../lib/item-input/object.js'
 
 
-const promptMock: jest.Mock<typeof inquirer.prompt> = jest.fn()
+const promptMock = jest.fn<typeof inquirer.prompt>()
 jest.unstable_mockModule('inquirer', () => ({
 	default: {
 		prompt: promptMock,

--- a/src/__tests__/lib/log-utils.test.ts
+++ b/src/__tests__/lib/log-utils.test.ts
@@ -8,21 +8,21 @@ import yaml from 'js-yaml'
 import { yamlExists } from '../../lib/io-util.js'
 
 
-const readFileSyncMock: jest.Mock<typeof readFileSync> = jest.fn()
+const readFileSyncMock = jest.fn<typeof readFileSync>()
 jest.unstable_mockModule('fs', () => ({
 	default: {
 		readFileSync: readFileSyncMock,
 	},
 }))
 
-const yamlLoadMock: jest.Mock<typeof yaml.load> = jest.fn()
+const yamlLoadMock = jest.fn<typeof yaml.load>()
 jest.unstable_mockModule('js-yaml', () => ({
 	default: {
 		load: yamlLoadMock,
 	},
 }))
 
-const yamlExistsMock: jest.Mock<typeof yamlExists> = jest.fn()
+const yamlExistsMock = jest.fn<typeof yamlExists>()
 jest.unstable_mockModule('../../lib/io-util.js', () => ({
 	yamlExists: yamlExistsMock,
 }))

--- a/src/__tests__/lib/login-authenticator.test.ts
+++ b/src/__tests__/lib/login-authenticator.test.ts
@@ -14,10 +14,10 @@ import { delay } from '../../lib/util.js'
 import { Server } from 'http'
 
 
-const chmodMock: jest.Mock<typeof chmod> = jest.fn()
-const mkdirSyncMock: jest.Mock<typeof mkdirSync> = jest.fn()
-const readFileSyncMock: jest.Mock<typeof readFileSync> = jest.fn()
-const writeFileSyncMock: jest.Mock<typeof writeFileSync> = jest.fn()
+const chmodMock = jest.fn<typeof chmod>()
+const mkdirSyncMock = jest.fn<typeof mkdirSync>()
+const readFileSyncMock = jest.fn<typeof readFileSync>()
+const writeFileSyncMock = jest.fn<typeof writeFileSync>()
 jest.unstable_mockModule('fs', () => ({
 	chmod: chmodMock,
 	mkdirSync: mkdirSyncMock,
@@ -25,30 +25,30 @@ jest.unstable_mockModule('fs', () => ({
 	writeFileSync: writeFileSyncMock,
 }))
 
-const expressMock: jest.Mock<typeof express> = jest.fn()
+const expressMock = jest.fn<typeof express>()
 jest.unstable_mockModule('express', () => ({ default: expressMock }))
 
-const getPortMock: jest.Mock<typeof getPort> = jest.fn()
+const getPortMock = jest.fn<typeof getPort>()
 jest.unstable_mockModule('get-port-please', () => ({
 	getPort: getPortMock,
 }))
 
 const { debugMock, errorMock, traceMock } = await import('../test-lib/logger-mock.js')
 
-const openMock: jest.Mock<typeof open> = jest.fn()
+const openMock = jest.fn<typeof open>()
 jest.unstable_mockModule('open', () => ({ default: openMock }))
 
-const oraMock: jest.Mock<typeof ora> = jest.fn()
+const oraMock = jest.fn<typeof ora>()
 jest.unstable_mockModule('ora', () => ({ default: oraMock }))
 
-const postMock: jest.Mock<typeof axios.post> = jest.fn()
+const postMock = jest.fn<typeof axios.post>()
 jest.unstable_mockModule('axios', () => ({
 	default: {
 		post: postMock,
 	},
 }))
 
-const delayMock: jest.Mock<typeof delay> = jest.fn()
+const delayMock = jest.fn<typeof delay>()
 delayMock.mockImplementation(() => new Promise(resolve => setTimeout(resolve, 5)))
 jest.unstable_mockModule('../../lib/util.js', () => ({
 	delay: delayMock,

--- a/src/__tests__/test-lib/builder-mock.ts
+++ b/src/__tests__/test-lib/builder-mock.ts
@@ -1,0 +1,121 @@
+import { jest } from '@jest/globals'
+import { FunctionLike } from 'jest-mock'
+
+import { Argv } from 'yargs'
+
+
+/**
+ * yargs builder functions work using the `Argv` interface which represents a function
+ * with data. The data is mostly other functions that update the instance and return it
+ * to allow chaining. This type allows us to represent a mock of the `Argv` function and
+ * its property functions.
+ */
+export type BuilderFunctionMock<T extends FunctionLike> = jest.Mock<T> & T
+
+/**
+ * A shortcut for creating a jest mock and casting it to `BuilderFunctionMock`.
+ * Using the `buildArgvMock` function will provide you with two of these. Use this
+ * to create more if your `builder` function calls 2 or more other builder functions.
+ */
+export const buildArgvMockStub = <T extends object>(): BuilderFunctionMock<Argv<T>> =>
+	jest.fn() as BuilderFunctionMock<Argv<T>>
+
+export type ArgvMock<I extends object, O extends I> = {
+	/**
+	 * A simple mock of `Argv` meant to be used as the input to the last builder function
+	 * in the chain.
+	 *
+	 * If the builder function under test does not chain any builder functions,
+	 * this can be ignored.
+	 *
+	 * If the builder chains a single function, use this as the input to that function.
+	 *
+	 * If more than one builder function is chained, you can create more of these using
+	 * `buildArgvMockStub`. In this case, use this for the input type to the last builder
+	 * in the chain and rename it appropriately.
+	 */
+	yargsMock: BuilderFunctionMock<Argv<I>>
+
+	envMock: BuilderFunctionMock<Argv<I>['env']>
+	positionalMock: BuilderFunctionMock<Argv<I>['positional']>
+	optionMock: BuilderFunctionMock<Argv<I>['option']>
+	exampleMock: BuilderFunctionMock<Argv<I>['example']>
+	epilogMock: BuilderFunctionMock<Argv<I>['epilog']>
+
+	/**
+	 * This mock is meant to be used as output of the last builder in the chain or as the
+	 * input to the builder being tested if there are no chained builders.
+	 *
+	 * This mock includes mocks for the various builder functions we use which are returned
+	 * alongside it via the above `envMock`, `positionalMock`, etc.
+	 *
+	 * It is also returned from all the mocked functions (e.g. `envMock`, etc.) and can be used
+	 * as the expected result of the builder itself.
+	 */
+	argvMock: BuilderFunctionMock<Argv<O>>
+}
+
+/**
+ * Most builder functions will not only call `.option` or `.positional` on the instance of `Argv`
+ * passed in but also will chain one or more other builder functions. This method helps mock the
+ * return values of each which are passed into the next in the chain. It also makes a final mock
+ * of `Argv` (`argvMock`) which mocks several properties of `Argv` (e.g. `option`) so they can
+ * be tested as well.
+ *
+ * For the generics to this function, `I` and `O`, specify the expected input and output types
+ * for the last builder in the chain (or the expected input and output types for this builder if
+ * there are no chained builders).
+ *
+ * For more details of this functions return value, see its return type `ArgvMock` above.
+ */
+export function buildArgvMock<I extends object, O = I>(): ArgvMock<I, I & O> {
+	// (Note, for clarity, I'm using `{}` below rather than TypeScript's preferred `object` to
+	// represent an object type with no fields defined. I feel this reads more easily.)
+	//
+	// The exact type of the `Argv` passed on from each call varies over the course of the builder.
+	// For example, consider the following bit of builder code:
+	//
+	// yargs
+	//     .option('output', { alias: 'o', describe: '...', type: 'string' })
+	//     .option('json', { alias: 'j', describe: '...' }, type: 'boolean' )
+	//
+	// Using type of `{}` for `I`, the type of `O` should be `{ output?: string, json?: boolean }`.
+	//
+	// The type of `Argv` returned from the first call to `option` will be `Argv<{ output?: string }>`.
+	// The type of `Argv` returned from the second and final call will be
+	// `Argv<{ output?: string, json?: boolean }`, or `Argv<O>`. Since along the way, it varies
+	// in between `Argv<I>` and `Argv<O>`, we declare `argvMock` here to be `Argv<I & Partial<O>`
+	// so it can be used on these in-between mocks. Then, finally, we cast it to `Argv<O>` when we
+	// return it.
+	const argvMock = buildArgvMockStub<I & Partial<O>>()
+
+	const envMock = jest.fn() as BuilderFunctionMock<Argv<I>['env']>
+	envMock.mockReturnValue(argvMock)
+	argvMock.env = envMock
+
+	const positionalMock = jest.fn() as BuilderFunctionMock<Argv<I>['positional']>
+	positionalMock.mockReturnValue(argvMock)
+	argvMock.positional = positionalMock
+
+	const optionMock = jest.fn() as BuilderFunctionMock<Argv<I>['option']>
+	optionMock.mockReturnValue(argvMock)
+	argvMock.option = optionMock
+
+	const exampleMock = jest.fn() as BuilderFunctionMock<Argv<I>['example']>
+	exampleMock.mockReturnValue(argvMock)
+	argvMock.example = exampleMock
+
+	const epilogMock = jest.fn() as BuilderFunctionMock<Argv<I>['epilog']>
+	epilogMock.mockReturnValue(argvMock)
+	argvMock.epilog = epilogMock
+
+	return {
+		envMock,
+		positionalMock,
+		optionMock,
+		exampleMock,
+		epilogMock,
+		yargsMock: buildArgvMockStub<I>(),
+		argvMock: argvMock as BuilderFunctionMock<Argv<I & O>>,
+	}
+}

--- a/src/lib/command/basic-io.ts
+++ b/src/lib/command/basic-io.ts
@@ -6,7 +6,7 @@ import { buildInputProcessor, inputProcessorBuilder, InputProcessorFlags } from 
 import { IOFormat } from '../io-util.js'
 import { sort, writeOutput } from './output.js'
 import { buildOutputFormatter, buildOutputFormatterBuilder, BuildOutputFormatterFlags } from './output-builder.js'
-import { SmartThingsCommand } from './smartthings-command.js'
+import { SmartThingsCommand, SmartThingsCommandFlags } from './smartthings-command.js'
 
 
 export type GetDataFunction<O extends object> = () => Promise<O>
@@ -98,7 +98,7 @@ export type InputAndOutputItemFlags = InputProcessorFlags & BuildOutputFormatter
 	dryRun?: boolean
 }
 export type InputAndOutputItemConfig<O extends object> = FormatAndWriteItemConfig<O>
-export const inputAndOutputItemBuilder = <T extends InputAndOutputItemFlags>(yargs: Argv<T>): Argv<T & InputAndOutputItemFlags> =>
+export const inputAndOutputItemBuilder = <T extends SmartThingsCommandFlags>(yargs: Argv<T>): Argv<T & InputAndOutputItemFlags> =>
 	inputItemBuilder(buildOutputFormatterBuilder(yargs))
 		.option('dry-run', { alias: 'd', describe: "produce JSON but don't actually submit", type: 'boolean' })
 /**

--- a/src/lib/command/smartthings-command.ts
+++ b/src/lib/command/smartthings-command.ts
@@ -11,8 +11,8 @@ export type SmartThingsCommandFlags = {
 	profile: string
 }
 
-export const smartThingsCommandBuilder = <T extends object = object>(argv: Argv<T>): Argv<T & SmartThingsCommandFlags> =>
-	argv.env('SMARTTHINGS')
+export const smartThingsCommandBuilder = <T extends object = object>(yargs: Argv<T>): Argv<T & SmartThingsCommandFlags> =>
+	yargs.env('SMARTTHINGS')
 		.option('profile', {
 			alias: 'p',
 			describe: 'configuration profile',


### PR DESCRIPTION
* added helper functions for testing `yargs` `builder`-type functions in `builder-mock.ts`
* updated builder tests to use new functions from `builder-mock.ts`
* added unit test for untested builder functions
* updated `const someMock: jest.Mock<SomeType> = jest.fn()` to `const someMock = jest.fn<SomeType>()` using regex search and replace `const (\w+): jest\.Mock(<.*>) = jest\.fn\(\)` to `const $1 = jest.fn$2()`
* fixed input type for `inputAndOutputItemBuilder`
* ignore `colors.ts` for coverage purposes since it doesn't have any logic in it