### PR TITLE
refactor: remove extra top-level describe in some tests

### DIFF
--- a/packages/cli/src/__tests__/lib/commands/devices-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/devices-util.test.ts
@@ -10,654 +10,652 @@ import {
 } from '../../../lib/commands/devices-util.js'
 
 
-describe('devices-util', () => {
-	const tablePushMock: jest.Mock<number, [(string | undefined)[]]> = jest.fn()
-	const tableToStringMock = jest.fn()
-	const tableMock = {
-		push: tablePushMock,
-		toString: tableToStringMock,
-	} as unknown as Table
-	const newOutputTableMock = jest.fn().mockReturnValue(tableMock)
-	const buildTableFromItemMock = jest.fn()
-	const buildTableFromListMock = jest.fn()
+const tablePushMock: jest.Mock<number, [(string | undefined)[]]> = jest.fn()
+const tableToStringMock = jest.fn()
+const tableMock = {
+	push: tablePushMock,
+	toString: tableToStringMock,
+} as unknown as Table
+const newOutputTableMock = jest.fn().mockReturnValue(tableMock)
+const buildTableFromItemMock = jest.fn()
+const buildTableFromListMock = jest.fn()
 
-	const tableGeneratorMock: TableGenerator = {
-		newOutputTable: newOutputTableMock,
-		buildTableFromItem: buildTableFromItemMock,
-		buildTableFromList: buildTableFromListMock,
-	}
+const tableGeneratorMock: TableGenerator = {
+	newOutputTable: newOutputTableMock,
+	buildTableFromItem: buildTableFromItemMock,
+	buildTableFromList: buildTableFromListMock,
+}
 
-	describe('prettyPrintAttribute', () => {
-		it ('handles integer value', () => {
-			expect(prettyPrintAttribute(100)).toEqual('100')
-		})
-
-		it ('handles decimal value', () => {
-			expect(prettyPrintAttribute(21.5)).toEqual('21.5')
-		})
-
-		it ('handles string value', () => {
-			expect(prettyPrintAttribute('active')).toEqual('"active"')
-		})
-
-		it ('handles object value', () => {
-			expect(prettyPrintAttribute({ x: 1, y: 2 })).toEqual('{"x":1,"y":2}')
-		})
-
-		it ('handles large object value', () => {
-			const value = {
-				name: 'Entity name',
-				id: 'entity-id',
-				description: 'This is a test entity. It serves no other purpose other than to be used in this test.',
-				version: 1,
-				precision: 120.375,
-			}
-			const expectedResult = JSON.stringify(value, null, 2)
-			expect(prettyPrintAttribute(value)).toEqual(expectedResult)
-		})
+describe('prettyPrintAttribute', () => {
+	it ('handles integer value', () => {
+		expect(prettyPrintAttribute(100)).toEqual('100')
 	})
 
-	describe('buildStatusTableOutput', () => {
+	it ('handles decimal value', () => {
+		expect(prettyPrintAttribute(21.5)).toEqual('21.5')
+	})
 
-		it('handles a single component', () => {
-			const deviceStatus: DeviceStatus = {
-				components: {
-					main: {
+	it ('handles string value', () => {
+		expect(prettyPrintAttribute('active')).toEqual('"active"')
+	})
+
+	it ('handles object value', () => {
+		expect(prettyPrintAttribute({ x: 1, y: 2 })).toEqual('{"x":1,"y":2}')
+	})
+
+	it ('handles large object value', () => {
+		const value = {
+			name: 'Entity name',
+			id: 'entity-id',
+			description: 'This is a test entity. It serves no other purpose other than to be used in this test.',
+			version: 1,
+			precision: 120.375,
+		}
+		const expectedResult = JSON.stringify(value, null, 2)
+		expect(prettyPrintAttribute(value)).toEqual(expectedResult)
+	})
+})
+
+describe('buildStatusTableOutput', () => {
+
+	it('handles a single component', () => {
+		const deviceStatus: DeviceStatus = {
+			components: {
+				main: {
+					switch: {
 						switch: {
-							switch: {
-								value: 'off',
-							},
+							value: 'off',
 						},
 					},
 				},
-			}
+			},
+		}
 
-			tableToStringMock.mockReturnValueOnce('main component status')
+		tableToStringMock.mockReturnValueOnce('main component status')
 
-			expect(buildStatusTableOutput(tableGeneratorMock, deviceStatus))
-				.toEqual('main component status\n')
+		expect(buildStatusTableOutput(tableGeneratorMock, deviceStatus))
+			.toEqual('main component status\n')
 
-			expect(tablePushMock).toHaveBeenCalledTimes(1)
-			expect(tablePushMock).toHaveBeenCalledWith(['switch', 'switch', '"off"'])
-		})
+		expect(tablePushMock).toHaveBeenCalledTimes(1)
+		expect(tablePushMock).toHaveBeenCalledWith(['switch', 'switch', '"off"'])
+	})
 
-		it('handles a multiple components', () => {
-			const deviceStatus: DeviceStatus = {
-				components: {
-					main: {
+	it('handles a multiple components', () => {
+		const deviceStatus: DeviceStatus = {
+			components: {
+				main: {
+					switch: {
 						switch: {
-							switch: {
-								value: 'off',
-							},
-						},
-					},
-					light: {
-						switchLevel: {
-							level: {
-								value: 80,
-							},
+							value: 'off',
 						},
 					},
 				},
-			}
-
-			tableToStringMock.mockReturnValueOnce('main component status')
-			tableToStringMock.mockReturnValueOnce('light component status')
-
-			expect(buildStatusTableOutput(tableGeneratorMock, deviceStatus))
-				.toEqual('\nmain component\nmain component status\n\nlight component\nlight component status\n')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(2)
-			expect(tablePushMock).toHaveBeenNthCalledWith(1, ['switch', 'switch', '"off"'])
-			expect(tablePushMock).toHaveBeenNthCalledWith(2, ['switchLevel', 'level', '80'])
-		})
-	})
-
-	describe('buildEmbeddedStatusTableOutput', () => {
-
-		it('handles a single component', () => {
-			const device = {
-				components: [
-					{
-						id: 'main',
-						capabilities: [
-							{
-								id: 'switch',
-								status: {
-									switch: {
-										value: 'off',
-									},
-								},
-							},
-						],
+				light: {
+					switchLevel: {
+						level: {
+							value: 80,
+						},
 					},
-				],
-			} as unknown as Device
-
-			tableToStringMock.mockReturnValueOnce('main component status')
-
-			expect(buildEmbeddedStatusTableOutput(tableGeneratorMock, device))
-				.toEqual('main component status')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(1)
-			expect(tablePushMock).toHaveBeenCalledWith(['switch', 'switch', '"off"'])
-		})
-
-		it('handles a multiple components', () => {
-			const device = {
-				components: [
-					{
-						id: 'main',
-						capabilities: [
-							{
-								id: 'switch',
-								status: {
-									switch: {
-										value: 'off',
-									},
-								},
-							},
-						],
-					},
-					{
-						id: 'light',
-						capabilities: [
-							{
-								id: 'switchLevel',
-								status: {
-									level: {
-										value: 80,
-									},
-								},
-							},
-						],
-					},
-				],
-			} as unknown as Device
-
-			tableToStringMock.mockReturnValueOnce('main component status')
-			tableToStringMock.mockReturnValueOnce('light component status')
-
-			expect(buildEmbeddedStatusTableOutput(tableGeneratorMock, device))
-				.toEqual('main component\nmain component status\nlight component\nlight component status')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(2)
-			expect(tablePushMock).toHaveBeenNthCalledWith(1, ['switch', 'switch', '"off"'])
-			expect(tablePushMock).toHaveBeenNthCalledWith(2, ['switchLevel', 'level', '80'])
-		})
-	})
-
-	describe('buildTableOutput', () => {
-
-		it('includes all main fields', () => {
-			const device = {
-				name: 'device name',
-				type: 'device type',
-				deviceId: 'device-id',
-				label: 'device label',
-				deviceManufacturerCode: 'device-manufacturer-code',
-				manufacturerName: 'manufacturer-name',
-				locationId: 'location-id',
-				roomId: 'room-id',
-				components: [{ id: 'main', capabilities: [{ id: 'capability-id' }] }],
-				childDevices: [{ id: 'child-id' }],
-				profile: { id: 'device-profile-id' },
-			} as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(10)
-			expect(tablePushMock).toHaveBeenCalledWith(['Label', 'device label'])
-			expect(tablePushMock).toHaveBeenCalledWith(['Name', 'device name'])
-			expect(tablePushMock).toHaveBeenCalledWith(['Id', 'device-id'])
-			expect(tablePushMock).toHaveBeenCalledWith(['Type', 'device type'])
-			expect(tablePushMock).toHaveBeenCalledWith(['Manufacturer Code', 'device-manufacturer-code'])
-			expect(tablePushMock).toHaveBeenCalledWith(['Location Id', 'location-id'])
-			expect(tablePushMock).toHaveBeenCalledWith(['Room Id', 'room-id'])
-			expect(tablePushMock).toHaveBeenCalledWith(['Profile Id', 'device-profile-id'])
-			expect(tablePushMock).toHaveBeenCalledWith(['Capabilities', 'capability-id'])
-			expect(tablePushMock).toHaveBeenCalledWith(['Child Devices', 'child-id'])
-			expect(tableToStringMock).toHaveBeenCalledTimes(2)
-		})
-
-		it('handles old style profile id', () => {
-			const device = {
-				profileId: 'device-profile-id',
-			} as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(tablePushMock).toHaveBeenCalledWith(['Profile Id', 'device-profile-id'])
-		})
-
-		it('defaults optional fields to empty strings', () => {
-			const device = {} as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(tablePushMock).toHaveBeenCalledWith(['Manufacturer Code', ''])
-			expect(tablePushMock).toHaveBeenCalledWith(['Location Id', ''])
-			expect(tablePushMock).toHaveBeenCalledWith(['Room Id', ''])
-			expect(tablePushMock).toHaveBeenCalledWith(['Profile Id', ''])
-		})
-
-		it('displays health state', () => {
-			const device = {
-				healthState: {
-					state: 'ONLINE',
-					lastUpdatedDate: '2022-07-28T14:50:42.899Z',
 				},
-			} as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
+			},
+		}
 
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table')
+		tableToStringMock.mockReturnValueOnce('main component status')
+		tableToStringMock.mockReturnValueOnce('light component status')
 
-			expect(tablePushMock).toHaveBeenCalledTimes(10)
-			expect(tablePushMock).toHaveBeenCalledWith(['Device Health', 'ONLINE'])
-			expect(tablePushMock).toHaveBeenCalledWith(['Last Updated', '2022-07-28T14:50:42.899Z'])
-		})
+		expect(buildStatusTableOutput(tableGeneratorMock, deviceStatus))
+			.toEqual('\nmain component\nmain component status\n\nlight component\nlight component status\n')
 
-		it('displays location and room names', () => {
-			const verboseDevice = {
-				room: 'room-name',
-				location: 'location-name',
-			} as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
+		expect(tablePushMock).toHaveBeenCalledTimes(2)
+		expect(tablePushMock).toHaveBeenNthCalledWith(1, ['switch', 'switch', '"off"'])
+		expect(tablePushMock).toHaveBeenNthCalledWith(2, ['switchLevel', 'level', '80'])
+	})
+})
 
-			expect(buildTableOutput(tableGeneratorMock, verboseDevice))
-				.toEqual('Main Info\nmain table')
+describe('buildEmbeddedStatusTableOutput', () => {
 
-			expect(tablePushMock).toHaveBeenCalledTimes(10)
-			expect(tablePushMock).toHaveBeenCalledWith(['Room', 'room-name'])
-			expect(tablePushMock).toHaveBeenCalledWith(['Location', 'location-name'])
-		})
-
-		it('displays device status', () => {
-			const device = {
-				components: [
-					{
-						id: 'main',
-						capabilities: [
-							{
-								id: 'capability-id',
-								status: {
-									switch: {
-										value: 'off',
-									},
+	it('handles a single component', () => {
+		const device = {
+			components: [
+				{
+					id: 'main',
+					capabilities: [
+						{
+							id: 'switch',
+							status: {
+								switch: {
+									value: 'off',
 								},
 							},
-						],
-					},
-				],
-			} as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-			tableToStringMock.mockReturnValueOnce('device status')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table\n\nDevice Status\ndevice status')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(10)
-			expect(tableToStringMock).toHaveBeenCalledTimes(2)
-		})
-
-		it('includes app info', () => {
-			const app = { installedAppId: 'installed-app-id' }
-			const device = { app } as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-			buildTableFromItemMock.mockReturnValue('app info')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from app)\napp info')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromItemMock).toHaveBeenCalledWith(app,
-				['installedAppId', 'externalId', { path: 'profile.id', label: 'Profile Id' }])
-		})
-
-		it('includes ble info', () => {
-			const ble = { thisIs: 'a ble device' }
-			const device = { ble } as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from ble)\nNo Device Integration Info for BLE devices')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(0)
-		})
-
-		it('includes bleD2D info', () => {
-			const bleD2D = { identifier: 'bleD2D-device' }
-			const device = { bleD2D } as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-			buildTableFromItemMock.mockReturnValue('bleD2D info')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from bleD2D)\nbleD2D info')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromItemMock).toHaveBeenCalledWith(bleD2D,
-				['advertisingId', 'identifier', 'configurationVersion', 'configurationUrl'])
-		})
-
-		it('includes dth info', () => {
-			const dth = { deviceTypeName: 'dth-device' }
-			const device = { dth } as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-			buildTableFromItemMock.mockReturnValue('dth info')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from dth)\ndth info')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromItemMock).toHaveBeenCalledWith(dth,
-				['deviceTypeId', 'deviceTypeName', 'completedSetup', 'deviceNetworkType',
-					'executingLocally', 'hubId', 'installedGroovyAppId', 'networkSecurityLevel'])
-		})
-
-		it('includes lan info', () => {
-			const lan = { networkId: 'lan-device' }
-			const device = { lan } as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-			buildTableFromItemMock.mockReturnValue('lan info')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from lan)\nlan info')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromItemMock).toHaveBeenCalledWith(lan,
-				['networkId', 'driverId', 'executingLocally', 'hubId', 'provisioningState'])
-		})
-
-		it('includes zigbee info', () => {
-			const zigbee = { networkId: 'zigbee-device' }
-			const device = { zigbee } as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-			buildTableFromItemMock.mockReturnValue('zigbee info')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from zigbee)\nzigbee info')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromItemMock).toHaveBeenCalledWith(zigbee,
-				['eui', 'networkId', 'driverId', 'executingLocally', 'hubId', 'provisioningState'])
-		})
-
-		it('includes zwave info', () => {
-			const zwave = { networkId: 'zwave-device' }
-			const device = { zwave } as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-			buildTableFromItemMock.mockReturnValue('zwave info')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from zwave)\nzwave info')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromItemMock).toHaveBeenCalledWith(zwave,
-				['networkId', 'driverId', 'executingLocally', 'hubId', 'networkSecurityLevel', 'provisioningState'])
-		})
-
-		describe('matter info', () => {
-			const matter = { driverId: 'matter-driver-id' }
-			const device = { matter } as unknown as Device
-
-			it('includes basic info', () => {
-				tableToStringMock.mockReturnValueOnce('main table')
-				buildTableFromItemMock.mockReturnValue('matter info')
-
-				expect(buildTableOutput(tableGeneratorMock, device))
-					.toEqual('Main Info\nmain table\n\nDevice Integration Info (from matter)\nmatter info')
-
-				expect(tablePushMock).toHaveBeenCalledTimes(8)
-				expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-				expect(buildTableFromItemMock).toHaveBeenCalledWith(matter, expect.arrayContaining([
-					'driverId', 'hubId', 'provisioningState', 'networkId', 'executingLocally', 'uniqueId',
-					'vendorId', 'supportedNetworkInterfaces',
-					{ label: 'Hardware Version', value: expect.any(Function) },
-					{ label: 'Software Version', value: expect.any(Function) },
-					{ label: 'Endpoints', value: expect.any(Function) },
-				]))
-			})
-
-			test.each`
-				hardwareLabel | hardware     | expected
-				${undefined}  | ${undefined} | ${'n/a (n/a)'}
-				${'1.0.0'}    | ${undefined} | ${'1.0.0 (n/a)'}
-				${undefined}  | ${72}        | ${'n/a (72)'}
-				${'1.0.0'}    | ${72}        | ${'1.0.0 (72)'}
-			`('hardware version function maps label "$hardwareLabel" and version "$hardware" to "$expected"', ({ hardwareLabel, hardware, expected }) => {
-				tableToStringMock.mockReturnValueOnce('main table')
-				buildTableFromItemMock.mockReturnValue('matter info')
-
-				expect(buildTableOutput(tableGeneratorMock, device))
-					.toEqual('Main Info\nmain table\n\nDevice Integration Info (from matter)\nmatter info')
-
-				const tableDefinitions = buildTableFromItemMock.mock.calls[0][1] as TableFieldDefinition<MatterDeviceDetails>[]
-				const hardwareVersionFunc = (tableDefinitions[8] as ValueTableFieldDefinition<MatterDeviceDetails>).value
-
-				const matterDeviceDetails = { version: { hardwareLabel, hardware } } as MatterDeviceDetails
-				expect(hardwareVersionFunc(matterDeviceDetails)).toBe(expected)
-			})
-
-			test('hardware version function maps undefined version to "n/a"', () => {
-				tableToStringMock.mockReturnValueOnce('main table')
-				buildTableFromItemMock.mockReturnValue('matter info')
-
-				expect(buildTableOutput(tableGeneratorMock, device))
-					.toEqual('Main Info\nmain table\n\nDevice Integration Info (from matter)\nmatter info')
-
-				const tableDefinitions = buildTableFromItemMock.mock.calls[0][1] as TableFieldDefinition<MatterDeviceDetails>[]
-				const hardwareVersionFunc = (tableDefinitions[8] as ValueTableFieldDefinition<MatterDeviceDetails>).value
-
-				const matterDeviceDetails = {} as MatterDeviceDetails
-				expect(hardwareVersionFunc(matterDeviceDetails)).toBe('n/a')
-			})
-
-			test.each`
-				softwareLabel | software     | expected
-				${undefined}  | ${undefined} | ${'n/a (n/a)'}
-				${'1.0.0'}    | ${undefined} | ${'1.0.0 (n/a)'}
-				${undefined}  | ${72}        | ${'n/a (72)'}
-				${'1.0.0'}    | ${72}        | ${'1.0.0 (72)'}
-			`('software version function maps label "$softwareLabel" and version "$software" to "$expected"', ({ softwareLabel, software, expected }) => {
-				tableToStringMock.mockReturnValueOnce('main table')
-				buildTableFromItemMock.mockReturnValue('matter info')
-
-				expect(buildTableOutput(tableGeneratorMock, device))
-					.toEqual('Main Info\nmain table\n\nDevice Integration Info (from matter)\nmatter info')
-
-				const tableDefinitions = buildTableFromItemMock.mock.calls[0][1] as TableFieldDefinition<MatterDeviceDetails>[]
-				const softwareVersionFunc = (tableDefinitions[9] as ValueTableFieldDefinition<MatterDeviceDetails>).value
-
-				const matterDeviceDetails = { version: { softwareLabel, software } } as MatterDeviceDetails
-				expect(softwareVersionFunc(matterDeviceDetails)).toBe(expected)
-			})
-
-			test('software version function maps undefined version to "n/a"', () => {
-				tableToStringMock.mockReturnValueOnce('main table')
-				buildTableFromItemMock.mockReturnValue('matter info')
-
-				expect(buildTableOutput(tableGeneratorMock, device))
-					.toEqual('Main Info\nmain table\n\nDevice Integration Info (from matter)\nmatter info')
-
-				const tableDefinitions = buildTableFromItemMock.mock.calls[0][1] as TableFieldDefinition<MatterDeviceDetails>[]
-				const softwareVersionFunc = (tableDefinitions[9] as ValueTableFieldDefinition<MatterDeviceDetails>).value
-
-				const matterDeviceDetails = {} as MatterDeviceDetails
-				expect(softwareVersionFunc(matterDeviceDetails)).toBe('n/a')
-			})
-
-			test.each`
-				desc | endpoints | expected
-				${'undefined'}   | ${undefined}                                                                       | ${''}
-				${'empty array'} | ${[]}                                                                              | ${''}
-				${'no types'}    | ${[{ endpointId: 'id' }]}                                                          | ${'id: '}
-				${'empty types'} | ${[{ endpointId: 'id', deviceTypes: [] }]}                                         | ${'id: '}
-				${'one type'}    | ${[{ endpointId: 'id', deviceTypes: [{ deviceTypeId: 1 }] }]}                      | ${'id: 1'}
-				${'2 types'}     | ${[{ endpointId: 'id', deviceTypes: [{ deviceTypeId: 1 }, { deviceTypeId: 2 }] }]} | ${'id: 1, 2'}
-			`('endpoints function maps $desc map to "$expected"', ({ endpoints, expected }) => {
-				tableToStringMock.mockReturnValueOnce('main table')
-				buildTableFromItemMock.mockReturnValue('matter info')
-
-				expect(buildTableOutput(tableGeneratorMock, device))
-					.toEqual('Main Info\nmain table\n\nDevice Integration Info (from matter)\nmatter info')
-
-				const tableDefinitions = buildTableFromItemMock.mock.calls[0][1] as TableFieldDefinition<MatterDeviceDetails>[]
-				const endpointsFunc = (tableDefinitions[10] as ValueTableFieldDefinition<MatterDeviceDetails>).value
-
-				const matterDeviceDetails = { endpoints } as MatterDeviceDetails
-				expect(endpointsFunc(matterDeviceDetails)).toBe(expected)
-			})
-		})
-
-		describe('hub info', () => {
-			it('includes basic info', () => {
-				const hub = { hubEui: 'hub-eui' }
-				const device = { hub } as unknown as Device
-				tableToStringMock.mockReturnValueOnce('main table')
-				buildTableFromItemMock.mockReturnValue('hub info')
-
-				expect(buildTableOutput(tableGeneratorMock, device))
-					.toEqual('Main Info\nmain table\n\nDevice Integration Info (from hub)\nhub info')
-
-				expect(tablePushMock).toHaveBeenCalledTimes(8)
-				expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-				expect(buildTableFromItemMock).toHaveBeenCalledWith(hub, expect.arrayContaining([
-					'hubEui', 'firmwareVersion', { path: 'hubData.zwaveS2' },
-				]))
-			})
-
-			test.each`
-				desc             | hubDrivers                                              | expected
-				${'empty array'} | ${[]}                                                   | ${''}
-				${'one driver'}  | ${[{ driverId: 'driver-1' }]}                           | ${'driver-1'}
-				${'two drivers'} | ${[{ driverId: 'driver-1' }, { driverId: 'driver-2' }]} | ${'driver-1\ndriver-2'}
-			`('hubDrivers function maps $desc to $expected', ({ hubDrivers, expected }) => {
-				const hub = { hubEui: 'hub-eui' }
-				const device = { hub } as unknown as Device
-				tableToStringMock.mockReturnValueOnce('main table')
-				buildTableFromItemMock.mockReturnValue('hub info')
-
-				expect(buildTableOutput(tableGeneratorMock, device))
-					.toEqual('Main Info\nmain table\n\nDevice Integration Info (from hub)\nhub info')
-
-				const tableDefinitions = buildTableFromItemMock.mock.calls[0][1] as TableFieldDefinition<HubDeviceDetails>[]
-				const hubDriversFunc = (tableDefinitions[33] as ValueTableFieldDefinition<HubDeviceDetails>).value
-
-				const hubDeviceDetails = { hubDrivers } as HubDeviceDetails
-				expect(hubDriversFunc(hubDeviceDetails)).toBe(expected)
-			})
-
-		})
-		it('includes edgeChild info', () => {
-			const edgeChild = { driverId: 'edge-child-driver-id' }
-			const device = { edgeChild } as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-			buildTableFromItemMock.mockReturnValue('edgeChild info')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from edgeChild)\nedgeChild info')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromItemMock).toHaveBeenCalledWith(edgeChild,
-				['driverId', 'hubId', 'provisioningState', 'networkId', 'executingLocally', 'parentAssignedChildKey'])
-		})
-
-		it('includes ir info', () => {
-			const ir = { irCode: 'ir-device-code' }
-			const device = { ir } as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-			buildTableFromItemMock.mockReturnValue('ir info')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from ir)\nir info')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromItemMock).toHaveBeenCalledWith(ir,
-				['parentDeviceId', 'profileId', 'ocfDeviceType', 'irCode'])
-		})
-
-		it('includes irOcf info', () => {
-			const irOcf = { irCode: 'ocf-ir-device-code' }
-			const device = { irOcf } as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-			buildTableFromItemMock.mockReturnValue('ir ocf info')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from irOcf)\nir ocf info')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromItemMock).toHaveBeenCalledWith(irOcf,
-				['parentDeviceId', 'profileId', 'ocfDeviceType', 'irCode'])
-		})
-
-		it('includes ocf info', () => {
-			const ocf = { name: 'OCF Device' }
-			const device = { ocf } as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-			buildTableFromItemMock.mockReturnValue('ocf info')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from ocf)\nocf info')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromItemMock).toHaveBeenCalledWith(ocf,
-				['deviceId', 'ocfDeviceType', 'name', 'specVersion', 'verticalDomainSpecVersion',
-					'manufacturerName', 'modelNumber', 'platformVersion', 'platformOS', 'hwVersion',
-					'firmwareVersion', 'vendorId', 'vendorResourceClientServerVersion', 'locale'])
-		})
-
-		it('includes viper info', () => {
-			const viper = { uniqueIdentifier: 'unique-upon-it' }
-			const device = { viper } as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-			buildTableFromItemMock.mockReturnValue('viper info')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from viper)\nviper info')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromItemMock).toHaveBeenCalledWith(viper,
-				['uniqueIdentifier', 'manufacturerName', 'modelName', 'swVersion', 'hwVersion'])
-		})
-
-		it('includes virtual device info', () => {
-			const virtual = { name: 'Virtual Device' }
-			const device = { virtual } as unknown as Device
-			tableToStringMock.mockReturnValueOnce('main table')
-			buildTableFromItemMock.mockReturnValue('virtual device info')
-
-			expect(buildTableOutput(tableGeneratorMock, device))
-				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from virtual)\nvirtual device info')
-
-			expect(tablePushMock).toHaveBeenCalledTimes(8)
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromItemMock).toHaveBeenCalledWith(virtual,
-				['name', { prop: 'hubId', skipEmpty: true }, { prop: 'driverId', skipEmpty: true }])
-		})
-
-		it.todo('adds multiple components')
-		it.todo('joins multiple component capabilities with newlines')
-		it.todo('joins multiple children with newlines')
+						},
+					],
+				},
+			],
+		} as unknown as Device
+
+		tableToStringMock.mockReturnValueOnce('main component status')
+
+		expect(buildEmbeddedStatusTableOutput(tableGeneratorMock, device))
+			.toEqual('main component status')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(1)
+		expect(tablePushMock).toHaveBeenCalledWith(['switch', 'switch', '"off"'])
 	})
+
+	it('handles a multiple components', () => {
+		const device = {
+			components: [
+				{
+					id: 'main',
+					capabilities: [
+						{
+							id: 'switch',
+							status: {
+								switch: {
+									value: 'off',
+								},
+							},
+						},
+					],
+				},
+				{
+					id: 'light',
+					capabilities: [
+						{
+							id: 'switchLevel',
+							status: {
+								level: {
+									value: 80,
+								},
+							},
+						},
+					],
+				},
+			],
+		} as unknown as Device
+
+		tableToStringMock.mockReturnValueOnce('main component status')
+		tableToStringMock.mockReturnValueOnce('light component status')
+
+		expect(buildEmbeddedStatusTableOutput(tableGeneratorMock, device))
+			.toEqual('main component\nmain component status\nlight component\nlight component status')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(2)
+		expect(tablePushMock).toHaveBeenNthCalledWith(1, ['switch', 'switch', '"off"'])
+		expect(tablePushMock).toHaveBeenNthCalledWith(2, ['switchLevel', 'level', '80'])
+	})
+})
+
+describe('buildTableOutput', () => {
+
+	it('includes all main fields', () => {
+		const device = {
+			name: 'device name',
+			type: 'device type',
+			deviceId: 'device-id',
+			label: 'device label',
+			deviceManufacturerCode: 'device-manufacturer-code',
+			manufacturerName: 'manufacturer-name',
+			locationId: 'location-id',
+			roomId: 'room-id',
+			components: [{ id: 'main', capabilities: [{ id: 'capability-id' }] }],
+			childDevices: [{ id: 'child-id' }],
+			profile: { id: 'device-profile-id' },
+		} as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(10)
+		expect(tablePushMock).toHaveBeenCalledWith(['Label', 'device label'])
+		expect(tablePushMock).toHaveBeenCalledWith(['Name', 'device name'])
+		expect(tablePushMock).toHaveBeenCalledWith(['Id', 'device-id'])
+		expect(tablePushMock).toHaveBeenCalledWith(['Type', 'device type'])
+		expect(tablePushMock).toHaveBeenCalledWith(['Manufacturer Code', 'device-manufacturer-code'])
+		expect(tablePushMock).toHaveBeenCalledWith(['Location Id', 'location-id'])
+		expect(tablePushMock).toHaveBeenCalledWith(['Room Id', 'room-id'])
+		expect(tablePushMock).toHaveBeenCalledWith(['Profile Id', 'device-profile-id'])
+		expect(tablePushMock).toHaveBeenCalledWith(['Capabilities', 'capability-id'])
+		expect(tablePushMock).toHaveBeenCalledWith(['Child Devices', 'child-id'])
+		expect(tableToStringMock).toHaveBeenCalledTimes(2)
+	})
+
+	it('handles old style profile id', () => {
+		const device = {
+			profileId: 'device-profile-id',
+		} as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(tablePushMock).toHaveBeenCalledWith(['Profile Id', 'device-profile-id'])
+	})
+
+	it('defaults optional fields to empty strings', () => {
+		const device = {} as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(tablePushMock).toHaveBeenCalledWith(['Manufacturer Code', ''])
+		expect(tablePushMock).toHaveBeenCalledWith(['Location Id', ''])
+		expect(tablePushMock).toHaveBeenCalledWith(['Room Id', ''])
+		expect(tablePushMock).toHaveBeenCalledWith(['Profile Id', ''])
+	})
+
+	it('displays health state', () => {
+		const device = {
+			healthState: {
+				state: 'ONLINE',
+				lastUpdatedDate: '2022-07-28T14:50:42.899Z',
+			},
+		} as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(10)
+		expect(tablePushMock).toHaveBeenCalledWith(['Device Health', 'ONLINE'])
+		expect(tablePushMock).toHaveBeenCalledWith(['Last Updated', '2022-07-28T14:50:42.899Z'])
+	})
+
+	it('displays location and room names', () => {
+		const verboseDevice = {
+			room: 'room-name',
+			location: 'location-name',
+		} as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+
+		expect(buildTableOutput(tableGeneratorMock, verboseDevice))
+			.toEqual('Main Info\nmain table')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(10)
+		expect(tablePushMock).toHaveBeenCalledWith(['Room', 'room-name'])
+		expect(tablePushMock).toHaveBeenCalledWith(['Location', 'location-name'])
+	})
+
+	it('displays device status', () => {
+		const device = {
+			components: [
+				{
+					id: 'main',
+					capabilities: [
+						{
+							id: 'capability-id',
+							status: {
+								switch: {
+									value: 'off',
+								},
+							},
+						},
+					],
+				},
+			],
+		} as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+		tableToStringMock.mockReturnValueOnce('device status')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table\n\nDevice Status\ndevice status')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(10)
+		expect(tableToStringMock).toHaveBeenCalledTimes(2)
+	})
+
+	it('includes app info', () => {
+		const app = { installedAppId: 'installed-app-id' }
+		const device = { app } as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+		buildTableFromItemMock.mockReturnValue('app info')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table\n\nDevice Integration Info (from app)\napp info')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromItemMock).toHaveBeenCalledWith(app,
+			['installedAppId', 'externalId', { path: 'profile.id', label: 'Profile Id' }])
+	})
+
+	it('includes ble info', () => {
+		const ble = { thisIs: 'a ble device' }
+		const device = { ble } as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table\n\nDevice Integration Info (from ble)\nNo Device Integration Info for BLE devices')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('includes bleD2D info', () => {
+		const bleD2D = { identifier: 'bleD2D-device' }
+		const device = { bleD2D } as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+		buildTableFromItemMock.mockReturnValue('bleD2D info')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table\n\nDevice Integration Info (from bleD2D)\nbleD2D info')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromItemMock).toHaveBeenCalledWith(bleD2D,
+			['advertisingId', 'identifier', 'configurationVersion', 'configurationUrl'])
+	})
+
+	it('includes dth info', () => {
+		const dth = { deviceTypeName: 'dth-device' }
+		const device = { dth } as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+		buildTableFromItemMock.mockReturnValue('dth info')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table\n\nDevice Integration Info (from dth)\ndth info')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromItemMock).toHaveBeenCalledWith(dth,
+			['deviceTypeId', 'deviceTypeName', 'completedSetup', 'deviceNetworkType',
+				'executingLocally', 'hubId', 'installedGroovyAppId', 'networkSecurityLevel'])
+	})
+
+	it('includes lan info', () => {
+		const lan = { networkId: 'lan-device' }
+		const device = { lan } as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+		buildTableFromItemMock.mockReturnValue('lan info')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table\n\nDevice Integration Info (from lan)\nlan info')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromItemMock).toHaveBeenCalledWith(lan,
+			['networkId', 'driverId', 'executingLocally', 'hubId', 'provisioningState'])
+	})
+
+	it('includes zigbee info', () => {
+		const zigbee = { networkId: 'zigbee-device' }
+		const device = { zigbee } as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+		buildTableFromItemMock.mockReturnValue('zigbee info')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table\n\nDevice Integration Info (from zigbee)\nzigbee info')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromItemMock).toHaveBeenCalledWith(zigbee,
+			['eui', 'networkId', 'driverId', 'executingLocally', 'hubId', 'provisioningState'])
+	})
+
+	it('includes zwave info', () => {
+		const zwave = { networkId: 'zwave-device' }
+		const device = { zwave } as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+		buildTableFromItemMock.mockReturnValue('zwave info')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table\n\nDevice Integration Info (from zwave)\nzwave info')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromItemMock).toHaveBeenCalledWith(zwave,
+			['networkId', 'driverId', 'executingLocally', 'hubId', 'networkSecurityLevel', 'provisioningState'])
+	})
+
+	describe('matter info', () => {
+		const matter = { driverId: 'matter-driver-id' }
+		const device = { matter } as unknown as Device
+
+		it('includes basic info', () => {
+			tableToStringMock.mockReturnValueOnce('main table')
+			buildTableFromItemMock.mockReturnValue('matter info')
+
+			expect(buildTableOutput(tableGeneratorMock, device))
+				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from matter)\nmatter info')
+
+			expect(tablePushMock).toHaveBeenCalledTimes(8)
+			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+			expect(buildTableFromItemMock).toHaveBeenCalledWith(matter, expect.arrayContaining([
+				'driverId', 'hubId', 'provisioningState', 'networkId', 'executingLocally', 'uniqueId',
+				'vendorId', 'supportedNetworkInterfaces',
+				{ label: 'Hardware Version', value: expect.any(Function) },
+				{ label: 'Software Version', value: expect.any(Function) },
+				{ label: 'Endpoints', value: expect.any(Function) },
+			]))
+		})
+
+		test.each`
+			hardwareLabel | hardware     | expected
+			${undefined}  | ${undefined} | ${'n/a (n/a)'}
+			${'1.0.0'}    | ${undefined} | ${'1.0.0 (n/a)'}
+			${undefined}  | ${72}        | ${'n/a (72)'}
+			${'1.0.0'}    | ${72}        | ${'1.0.0 (72)'}
+		`('hardware version function maps label "$hardwareLabel" and version "$hardware" to "$expected"', ({ hardwareLabel, hardware, expected }) => {
+			tableToStringMock.mockReturnValueOnce('main table')
+			buildTableFromItemMock.mockReturnValue('matter info')
+
+			expect(buildTableOutput(tableGeneratorMock, device))
+				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from matter)\nmatter info')
+
+			const tableDefinitions = buildTableFromItemMock.mock.calls[0][1] as TableFieldDefinition<MatterDeviceDetails>[]
+			const hardwareVersionFunc = (tableDefinitions[8] as ValueTableFieldDefinition<MatterDeviceDetails>).value
+
+			const matterDeviceDetails = { version: { hardwareLabel, hardware } } as MatterDeviceDetails
+			expect(hardwareVersionFunc(matterDeviceDetails)).toBe(expected)
+		})
+
+		test('hardware version function maps undefined version to "n/a"', () => {
+			tableToStringMock.mockReturnValueOnce('main table')
+			buildTableFromItemMock.mockReturnValue('matter info')
+
+			expect(buildTableOutput(tableGeneratorMock, device))
+				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from matter)\nmatter info')
+
+			const tableDefinitions = buildTableFromItemMock.mock.calls[0][1] as TableFieldDefinition<MatterDeviceDetails>[]
+			const hardwareVersionFunc = (tableDefinitions[8] as ValueTableFieldDefinition<MatterDeviceDetails>).value
+
+			const matterDeviceDetails = {} as MatterDeviceDetails
+			expect(hardwareVersionFunc(matterDeviceDetails)).toBe('n/a')
+		})
+
+		test.each`
+			softwareLabel | software     | expected
+			${undefined}  | ${undefined} | ${'n/a (n/a)'}
+			${'1.0.0'}    | ${undefined} | ${'1.0.0 (n/a)'}
+			${undefined}  | ${72}        | ${'n/a (72)'}
+			${'1.0.0'}    | ${72}        | ${'1.0.0 (72)'}
+		`('software version function maps label "$softwareLabel" and version "$software" to "$expected"', ({ softwareLabel, software, expected }) => {
+			tableToStringMock.mockReturnValueOnce('main table')
+			buildTableFromItemMock.mockReturnValue('matter info')
+
+			expect(buildTableOutput(tableGeneratorMock, device))
+				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from matter)\nmatter info')
+
+			const tableDefinitions = buildTableFromItemMock.mock.calls[0][1] as TableFieldDefinition<MatterDeviceDetails>[]
+			const softwareVersionFunc = (tableDefinitions[9] as ValueTableFieldDefinition<MatterDeviceDetails>).value
+
+			const matterDeviceDetails = { version: { softwareLabel, software } } as MatterDeviceDetails
+			expect(softwareVersionFunc(matterDeviceDetails)).toBe(expected)
+		})
+
+		test('software version function maps undefined version to "n/a"', () => {
+			tableToStringMock.mockReturnValueOnce('main table')
+			buildTableFromItemMock.mockReturnValue('matter info')
+
+			expect(buildTableOutput(tableGeneratorMock, device))
+				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from matter)\nmatter info')
+
+			const tableDefinitions = buildTableFromItemMock.mock.calls[0][1] as TableFieldDefinition<MatterDeviceDetails>[]
+			const softwareVersionFunc = (tableDefinitions[9] as ValueTableFieldDefinition<MatterDeviceDetails>).value
+
+			const matterDeviceDetails = {} as MatterDeviceDetails
+			expect(softwareVersionFunc(matterDeviceDetails)).toBe('n/a')
+		})
+
+		test.each`
+			desc | endpoints | expected
+			${'undefined'}   | ${undefined}                                                                       | ${''}
+			${'empty array'} | ${[]}                                                                              | ${''}
+			${'no types'}    | ${[{ endpointId: 'id' }]}                                                          | ${'id: '}
+			${'empty types'} | ${[{ endpointId: 'id', deviceTypes: [] }]}                                         | ${'id: '}
+			${'one type'}    | ${[{ endpointId: 'id', deviceTypes: [{ deviceTypeId: 1 }] }]}                      | ${'id: 1'}
+			${'2 types'}     | ${[{ endpointId: 'id', deviceTypes: [{ deviceTypeId: 1 }, { deviceTypeId: 2 }] }]} | ${'id: 1, 2'}
+		`('endpoints function maps $desc map to "$expected"', ({ endpoints, expected }) => {
+			tableToStringMock.mockReturnValueOnce('main table')
+			buildTableFromItemMock.mockReturnValue('matter info')
+
+			expect(buildTableOutput(tableGeneratorMock, device))
+				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from matter)\nmatter info')
+
+			const tableDefinitions = buildTableFromItemMock.mock.calls[0][1] as TableFieldDefinition<MatterDeviceDetails>[]
+			const endpointsFunc = (tableDefinitions[10] as ValueTableFieldDefinition<MatterDeviceDetails>).value
+
+			const matterDeviceDetails = { endpoints } as MatterDeviceDetails
+			expect(endpointsFunc(matterDeviceDetails)).toBe(expected)
+		})
+	})
+
+	describe('hub info', () => {
+		it('includes basic info', () => {
+			const hub = { hubEui: 'hub-eui' }
+			const device = { hub } as unknown as Device
+			tableToStringMock.mockReturnValueOnce('main table')
+			buildTableFromItemMock.mockReturnValue('hub info')
+
+			expect(buildTableOutput(tableGeneratorMock, device))
+				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from hub)\nhub info')
+
+			expect(tablePushMock).toHaveBeenCalledTimes(8)
+			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+			expect(buildTableFromItemMock).toHaveBeenCalledWith(hub, expect.arrayContaining([
+				'hubEui', 'firmwareVersion', { path: 'hubData.zwaveS2' },
+			]))
+		})
+
+		test.each`
+			desc             | hubDrivers                                              | expected
+			${'empty array'} | ${[]}                                                   | ${''}
+			${'one driver'}  | ${[{ driverId: 'driver-1' }]}                           | ${'driver-1'}
+			${'two drivers'} | ${[{ driverId: 'driver-1' }, { driverId: 'driver-2' }]} | ${'driver-1\ndriver-2'}
+		`('hubDrivers function maps $desc to $expected', ({ hubDrivers, expected }) => {
+			const hub = { hubEui: 'hub-eui' }
+			const device = { hub } as unknown as Device
+			tableToStringMock.mockReturnValueOnce('main table')
+			buildTableFromItemMock.mockReturnValue('hub info')
+
+			expect(buildTableOutput(tableGeneratorMock, device))
+				.toEqual('Main Info\nmain table\n\nDevice Integration Info (from hub)\nhub info')
+
+			const tableDefinitions = buildTableFromItemMock.mock.calls[0][1] as TableFieldDefinition<HubDeviceDetails>[]
+			const hubDriversFunc = (tableDefinitions[33] as ValueTableFieldDefinition<HubDeviceDetails>).value
+
+			const hubDeviceDetails = { hubDrivers } as HubDeviceDetails
+			expect(hubDriversFunc(hubDeviceDetails)).toBe(expected)
+		})
+
+	})
+	it('includes edgeChild info', () => {
+		const edgeChild = { driverId: 'edge-child-driver-id' }
+		const device = { edgeChild } as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+		buildTableFromItemMock.mockReturnValue('edgeChild info')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table\n\nDevice Integration Info (from edgeChild)\nedgeChild info')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromItemMock).toHaveBeenCalledWith(edgeChild,
+			['driverId', 'hubId', 'provisioningState', 'networkId', 'executingLocally', 'parentAssignedChildKey'])
+	})
+
+	it('includes ir info', () => {
+		const ir = { irCode: 'ir-device-code' }
+		const device = { ir } as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+		buildTableFromItemMock.mockReturnValue('ir info')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table\n\nDevice Integration Info (from ir)\nir info')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromItemMock).toHaveBeenCalledWith(ir,
+			['parentDeviceId', 'profileId', 'ocfDeviceType', 'irCode'])
+	})
+
+	it('includes irOcf info', () => {
+		const irOcf = { irCode: 'ocf-ir-device-code' }
+		const device = { irOcf } as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+		buildTableFromItemMock.mockReturnValue('ir ocf info')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table\n\nDevice Integration Info (from irOcf)\nir ocf info')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromItemMock).toHaveBeenCalledWith(irOcf,
+			['parentDeviceId', 'profileId', 'ocfDeviceType', 'irCode'])
+	})
+
+	it('includes ocf info', () => {
+		const ocf = { name: 'OCF Device' }
+		const device = { ocf } as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+		buildTableFromItemMock.mockReturnValue('ocf info')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table\n\nDevice Integration Info (from ocf)\nocf info')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromItemMock).toHaveBeenCalledWith(ocf,
+			['deviceId', 'ocfDeviceType', 'name', 'specVersion', 'verticalDomainSpecVersion',
+				'manufacturerName', 'modelNumber', 'platformVersion', 'platformOS', 'hwVersion',
+				'firmwareVersion', 'vendorId', 'vendorResourceClientServerVersion', 'locale'])
+	})
+
+	it('includes viper info', () => {
+		const viper = { uniqueIdentifier: 'unique-upon-it' }
+		const device = { viper } as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+		buildTableFromItemMock.mockReturnValue('viper info')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table\n\nDevice Integration Info (from viper)\nviper info')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromItemMock).toHaveBeenCalledWith(viper,
+			['uniqueIdentifier', 'manufacturerName', 'modelName', 'swVersion', 'hwVersion'])
+	})
+
+	it('includes virtual device info', () => {
+		const virtual = { name: 'Virtual Device' }
+		const device = { virtual } as unknown as Device
+		tableToStringMock.mockReturnValueOnce('main table')
+		buildTableFromItemMock.mockReturnValue('virtual device info')
+
+		expect(buildTableOutput(tableGeneratorMock, device))
+			.toEqual('Main Info\nmain table\n\nDevice Integration Info (from virtual)\nvirtual device info')
+
+		expect(tablePushMock).toHaveBeenCalledTimes(8)
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromItemMock).toHaveBeenCalledWith(virtual,
+			['name', { prop: 'hubId', skipEmpty: true }, { prop: 'driverId', skipEmpty: true }])
+	})
+
+	it.todo('adds multiple components')
+	it.todo('joins multiple component capabilities with newlines')
+	it.todo('joins multiple children with newlines')
 })

--- a/packages/cli/src/__tests__/lib/commands/history-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/history-util.test.ts
@@ -18,381 +18,379 @@ import {
 
 jest.mock('inquirer')
 
-describe('history-util', () => {
-	describe('toEpochTime', () => {
-		it ('handles ISO input', () => {
-			expect(toEpochTime('2022-08-01T22:41:42.559Z')).toBe(1659393702559)
-		})
-
-		it ('handles locale time input', () => {
-			const expected = new Date('8/1/2022, 6:41:42 PM').getTime()
-			expect(toEpochTime('8/1/2022, 6:41:42 PM')).toBe(expected)
-		})
-
-		it ('handles input in millis since epoch', () => {
-			expect(toEpochTime('1700596752000')).toBe(1700596752000)
-		})
-
-		it('handles undefined input', () => {
-			expect(toEpochTime(undefined)).toBeUndefined()
-		})
+describe('toEpochTime', () => {
+	it ('handles ISO input', () => {
+		expect(toEpochTime('2022-08-01T22:41:42.559Z')).toBe(1659393702559)
 	})
 
-	describe('sortEvents', () => {
-		it('sorts in reverse order', () => {
-			const events = [
-				{ epoch: 1659394186591 },
-				{ epoch: 1659394186591 },
-				{ epoch: 1659394186592 },
-				{ epoch: 1659394186593 },
-				{ epoch: 1659394186590 },
-			] as DeviceActivity[]
-
-			const result = sortEvents([...events])
-
-			expect(result).toBeDefined()
-			expect(result.length).toBe(5)
-			expect(result[0]).toBe(events[3])
-			expect(result[1]).toBe(events[2])
-			expect(result[2]).toBe(events[0])
-			expect(result[3]).toBe(events[1])
-			expect(result[4]).toBe(events[4])
-		})
+	it ('handles locale time input', () => {
+		const expected = new Date('8/1/2022, 6:41:42 PM').getTime()
+		expect(toEpochTime('8/1/2022, 6:41:42 PM')).toBe(expected)
 	})
 
-	describe('getNextDeviceEvents', () => {
-		const tablePushMock: jest.Mock<number, [(string | undefined)[]]> = jest.fn()
-		const tableToStringMock = jest.fn()
-		const tableMock = {
-			push: tablePushMock,
-			toString: tableToStringMock,
-		} as unknown as Table
-
-		it('outputs local time and string values', () => {
-			const time = new Date()
-			const items = [
-				{ time, component: 'main', capability: 'switch', attribute: 'switch', value: 'on' },
-			] as unknown as DeviceActivity[]
-
-			getNextDeviceEvents(tableMock, items, {})
-
-			expect(tablePushMock).toHaveBeenCalledTimes(1)
-			expect(tablePushMock).toHaveBeenCalledWith([
-				time.toLocaleString(),
-				'main',
-				'switch',
-				'switch',
-				'"on"',
-			])
-			expect(tableToStringMock).toHaveBeenCalledTimes(0)
-		})
-
-		it('outputs UTC time and number value', () => {
-			const time = new Date()
-			const items = [
-				{ time, component: 'main', capability: 'switchLevel', attribute: 'level', value: 80 },
-			] as unknown as DeviceActivity[]
-
-			getNextDeviceEvents(tableMock, items, { utcTimeFormat: true })
-
-			expect(tablePushMock).toHaveBeenCalledTimes(1)
-			expect(tablePushMock).toHaveBeenCalledWith([
-				time.toISOString(),
-				'main',
-				'switchLevel',
-				'level',
-				'80',
-			])
-			expect(tableToStringMock).toHaveBeenCalledTimes(0)
-		})
-
-		it('outputs device name and number with units value', () => {
-			const time = new Date()
-			const items = [
-				{ time, deviceName: 'Thermometer', component: 'main', capability: 'temperature', attribute: 'temp', value: 72, unit: 'F' },
-			] as unknown as DeviceActivity[]
-
-			getNextDeviceEvents(tableMock, items, { includeName: true })
-
-			expect(tablePushMock).toHaveBeenCalledTimes(1)
-			expect(tablePushMock).toHaveBeenCalledWith([
-				time.toLocaleString(),
-				'Thermometer',
-				'main',
-				'temperature',
-				'temp',
-				'72 F',
-			])
-			expect(tableToStringMock).toHaveBeenCalledTimes(0)
-		})
+	it ('handles input in millis since epoch', () => {
+		expect(toEpochTime('1700596752000')).toBe(1700596752000)
 	})
 
-	describe('writeDeviceEventsTable', () => {
-		const promptSpy = jest.spyOn(inquirer, 'prompt')
-		const stdOutSpy = jest.spyOn(process.stdout, 'write')
-		const tablePushMock: jest.Mock<number, [(string | undefined)[]]> = jest.fn()
-		const tableToStringMock = jest.fn().mockReturnValue('table')
-		const tableMock = {
-			push: tablePushMock,
-			toString: tableToStringMock,
-		} as unknown as Table
+	it('handles undefined input', () => {
+		expect(toEpochTime(undefined)).toBeUndefined()
+	})
+})
 
-		const newOutputTableMock = jest.fn().mockReturnValue(tableMock)
+describe('sortEvents', () => {
+	it('sorts in reverse order', () => {
+		const events = [
+			{ epoch: 1659394186591 },
+			{ epoch: 1659394186591 },
+			{ epoch: 1659394186592 },
+			{ epoch: 1659394186593 },
+			{ epoch: 1659394186590 },
+		] as DeviceActivity[]
 
-		const tableGeneratorMock: TableGenerator = {
-			newOutputTable: newOutputTableMock,
-			buildTableFromItem: jest.fn(),
-			buildTableFromList: jest.fn(),
-		} as TableGenerator
+		const result = sortEvents([...events])
 
-		const commandMock = {
-			tableGenerator: tableGeneratorMock,
-		} as SmartThingsCommandInterface
+		expect(result).toBeDefined()
+		expect(result.length).toBe(5)
+		expect(result[0]).toBe(events[3])
+		expect(result[1]).toBe(events[2])
+		expect(result[2]).toBe(events[0])
+		expect(result[3]).toBe(events[1])
+		expect(result[4]).toBe(events[4])
+	})
+})
 
+describe('getNextDeviceEvents', () => {
+	const tablePushMock: jest.Mock<number, [(string | undefined)[]]> = jest.fn()
+	const tableToStringMock = jest.fn()
+	const tableMock = {
+		push: tablePushMock,
+		toString: tableToStringMock,
+	} as unknown as Table
+
+	it('outputs local time and string values', () => {
+		const time = new Date()
 		const items = [
-			{ time: new Date(), deviceName: 'Thermometer', component: 'main', capability: 'temperature', attribute: 'temp', value: 72, unit: 'F' },
+			{ time, component: 'main', capability: 'switch', attribute: 'switch', value: 'on' },
 		] as unknown as DeviceActivity[]
 
-		const hasNext = jest.fn()
-		const next = jest.fn()
-		const dataMock = {
-			items,
-			hasNext,
-			next,
-		} as unknown as PaginatedList<DeviceActivity>
+		getNextDeviceEvents(tableMock, items, {})
 
-		it('omits the device name by default', async () => {
-			hasNext.mockReturnValue(false)
-
-			await writeDeviceEventsTable(commandMock, dataMock)
-
-			expect(newOutputTableMock).toHaveBeenCalledTimes(1)
-			expect(newOutputTableMock).toHaveBeenCalledWith({
-				isList: true,
-				head: ['Time', 'Component', 'Capability', 'Attribute', 'Value'],
-			})
-			expect(tablePushMock).toHaveBeenCalledTimes(1)
-			expect(stdOutSpy).toHaveBeenCalledTimes(1)
-		})
-
-		it('includes the device name when specified', async () => {
-			hasNext.mockReturnValue(false)
-
-			await writeDeviceEventsTable(commandMock, dataMock, { includeName: true })
-
-			expect(newOutputTableMock).toHaveBeenCalledTimes(1)
-			expect(newOutputTableMock).toHaveBeenCalledWith({
-				isList: true,
-				head: ['Time', 'Device Name', 'Component', 'Capability', 'Attribute', 'Value'],
-			})
-			expect(tablePushMock).toHaveBeenCalledTimes(1)
-			expect(stdOutSpy).toHaveBeenCalledTimes(1)
-		})
-
-		it('returns next page when prompted until no more', async () => {
-			hasNext.mockReturnValueOnce(true)
-			hasNext.mockReturnValueOnce(true)
-			hasNext.mockReturnValueOnce(false)
-			promptSpy.mockResolvedValueOnce({ more: true })
-			promptSpy.mockResolvedValueOnce({ more: true })
-
-			await writeDeviceEventsTable(commandMock, dataMock)
-
-			expect(newOutputTableMock).toHaveBeenCalledTimes(3)
-			expect(tablePushMock).toHaveBeenCalledTimes(3)
-			expect(stdOutSpy).toHaveBeenCalledTimes(3)
-		})
-
-		it('returns next page until canceled', async () => {
-			hasNext.mockReturnValue(true)
-			promptSpy.mockResolvedValueOnce({ more: true })
-			promptSpy.mockResolvedValueOnce({ more: false })
-
-			await writeDeviceEventsTable(commandMock, dataMock)
-
-			expect(newOutputTableMock).toHaveBeenCalledTimes(2)
-			expect(tablePushMock).toHaveBeenCalledTimes(2)
-			expect(stdOutSpy).toHaveBeenCalledTimes(2)
-		})
+		expect(tablePushMock).toHaveBeenCalledTimes(1)
+		expect(tablePushMock).toHaveBeenCalledWith([
+			time.toLocaleString(),
+			'main',
+			'switch',
+			'switch',
+			'"on"',
+		])
+		expect(tableToStringMock).toHaveBeenCalledTimes(0)
 	})
 
-	describe('calculateHistoryRequestLimit', () => {
-		it('returns limit if less than or equal to maxItemsPerRequest', () => {
-			expect(calculateRequestLimit(20)).toBe(20)
-			expect(calculateRequestLimit(300)).toBe(300)
-			expect(calculateRequestLimit(301)).toBe(300)
-			expect(calculateRequestLimit(500)).toBe(300)
-		})
+	it('outputs UTC time and number value', () => {
+		const time = new Date()
+		const items = [
+			{ time, component: 'main', capability: 'switchLevel', attribute: 'level', value: 80 },
+		] as unknown as DeviceActivity[]
+
+		getNextDeviceEvents(tableMock, items, { utcTimeFormat: true })
+
+		expect(tablePushMock).toHaveBeenCalledTimes(1)
+		expect(tablePushMock).toHaveBeenCalledWith([
+			time.toISOString(),
+			'main',
+			'switchLevel',
+			'level',
+			'80',
+		])
+		expect(tableToStringMock).toHaveBeenCalledTimes(0)
 	})
 
-	describe('getHistory', () => {
-		const historyDevicesMock = jest.fn()
-		const history = { devices: historyDevicesMock } as unknown as HistoryEndpoint
-		const client = { history } as SmartThingsClient
+	it('outputs device name and number with units value', () => {
+		const time = new Date()
+		const items = [
+			{ time, deviceName: 'Thermometer', component: 'main', capability: 'temperature', attribute: 'temp', value: 72, unit: 'F' },
+		] as unknown as DeviceActivity[]
 
-		const hasNextMock = jest.fn().mockReturnValue(false)
-		const nextMock = jest.fn().mockImplementation()
+		getNextDeviceEvents(tableMock, items, { includeName: true })
 
-		const params = { locationId: 'location-id', deviceId: 'device-id' }
-		const items: DeviceActivity[] = []
-		const totalNumItems = maxItemsPerRequest * maxRequestsBeforeWarning + 10
-		for (let index = 0; index < totalNumItems; index++) {
-			items.push({
-				deviceId: 'history-device-id',
-				text: `item${index}`,
-			} as DeviceActivity)
-		}
+		expect(tablePushMock).toHaveBeenCalledTimes(1)
+		expect(tablePushMock).toHaveBeenCalledWith([
+			time.toLocaleString(),
+			'Thermometer',
+			'main',
+			'temperature',
+			'temp',
+			'72 F',
+		])
+		expect(tableToStringMock).toHaveBeenCalledTimes(0)
+	})
+})
 
-		const promptMock = jest.mocked(inquirer.prompt)
+describe('writeDeviceEventsTable', () => {
+	const promptSpy = jest.spyOn(inquirer, 'prompt')
+	const stdOutSpy = jest.spyOn(process.stdout, 'write')
+	const tablePushMock: jest.Mock<number, [(string | undefined)[]]> = jest.fn()
+	const tableToStringMock = jest.fn().mockReturnValue('table')
+	const tableMock = {
+		push: tablePushMock,
+		toString: tableToStringMock,
+	} as unknown as Table
 
-		// Since the core SDK mutates this object via the `.next` call, each test needs its own instance.
-		const makeHistoryResponse = (items: DeviceActivity[]): PaginatedList<DeviceActivity> => ({
-			items,
-			hasNext: hasNextMock,
-			next: nextMock,
-		} as unknown as PaginatedList<DeviceActivity>)
+	const newOutputTableMock = jest.fn().mockReturnValue(tableMock)
 
-		it('uses single request when one is enough', async () => {
-			const returnedItems = items.slice(0, 2)
-			historyDevicesMock.mockResolvedValueOnce(makeHistoryResponse(returnedItems))
+	const tableGeneratorMock: TableGenerator = {
+		newOutputTable: newOutputTableMock,
+		buildTableFromItem: jest.fn(),
+		buildTableFromList: jest.fn(),
+	} as TableGenerator
 
-			expect(await getHistory(client, 20, 20, params)).toStrictEqual(returnedItems)
+	const commandMock = {
+		tableGenerator: tableGeneratorMock,
+	} as SmartThingsCommandInterface
 
-			expect(historyDevicesMock).toHaveBeenCalledTimes(1)
-			expect(historyDevicesMock).toHaveBeenCalledWith(params)
-			expect(hasNextMock).toHaveBeenCalledTimes(1)
-			expect(nextMock).toHaveBeenCalledTimes(0)
-			expect(promptMock).toHaveBeenCalledTimes(0)
+	const items = [
+		{ time: new Date(), deviceName: 'Thermometer', component: 'main', capability: 'temperature', attribute: 'temp', value: 72, unit: 'F' },
+	] as unknown as DeviceActivity[]
+
+	const hasNext = jest.fn()
+	const next = jest.fn()
+	const dataMock = {
+		items,
+		hasNext,
+		next,
+	} as unknown as PaginatedList<DeviceActivity>
+
+	it('omits the device name by default', async () => {
+		hasNext.mockReturnValue(false)
+
+		await writeDeviceEventsTable(commandMock, dataMock)
+
+		expect(newOutputTableMock).toHaveBeenCalledTimes(1)
+		expect(newOutputTableMock).toHaveBeenCalledWith({
+			isList: true,
+			head: ['Time', 'Component', 'Capability', 'Attribute', 'Value'],
+		})
+		expect(tablePushMock).toHaveBeenCalledTimes(1)
+		expect(stdOutSpy).toHaveBeenCalledTimes(1)
+	})
+
+	it('includes the device name when specified', async () => {
+		hasNext.mockReturnValue(false)
+
+		await writeDeviceEventsTable(commandMock, dataMock, { includeName: true })
+
+		expect(newOutputTableMock).toHaveBeenCalledTimes(1)
+		expect(newOutputTableMock).toHaveBeenCalledWith({
+			isList: true,
+			head: ['Time', 'Device Name', 'Component', 'Capability', 'Attribute', 'Value'],
+		})
+		expect(tablePushMock).toHaveBeenCalledTimes(1)
+		expect(stdOutSpy).toHaveBeenCalledTimes(1)
+	})
+
+	it('returns next page when prompted until no more', async () => {
+		hasNext.mockReturnValueOnce(true)
+		hasNext.mockReturnValueOnce(true)
+		hasNext.mockReturnValueOnce(false)
+		promptSpy.mockResolvedValueOnce({ more: true })
+		promptSpy.mockResolvedValueOnce({ more: true })
+
+		await writeDeviceEventsTable(commandMock, dataMock)
+
+		expect(newOutputTableMock).toHaveBeenCalledTimes(3)
+		expect(tablePushMock).toHaveBeenCalledTimes(3)
+		expect(stdOutSpy).toHaveBeenCalledTimes(3)
+	})
+
+	it('returns next page until canceled', async () => {
+		hasNext.mockReturnValue(true)
+		promptSpy.mockResolvedValueOnce({ more: true })
+		promptSpy.mockResolvedValueOnce({ more: false })
+
+		await writeDeviceEventsTable(commandMock, dataMock)
+
+		expect(newOutputTableMock).toHaveBeenCalledTimes(2)
+		expect(tablePushMock).toHaveBeenCalledTimes(2)
+		expect(stdOutSpy).toHaveBeenCalledTimes(2)
+	})
+})
+
+describe('calculateHistoryRequestLimit', () => {
+	it('returns limit if less than or equal to maxItemsPerRequest', () => {
+		expect(calculateRequestLimit(20)).toBe(20)
+		expect(calculateRequestLimit(300)).toBe(300)
+		expect(calculateRequestLimit(301)).toBe(300)
+		expect(calculateRequestLimit(500)).toBe(300)
+	})
+})
+
+describe('getHistory', () => {
+	const historyDevicesMock = jest.fn()
+	const history = { devices: historyDevicesMock } as unknown as HistoryEndpoint
+	const client = { history } as SmartThingsClient
+
+	const hasNextMock = jest.fn().mockReturnValue(false)
+	const nextMock = jest.fn().mockImplementation()
+
+	const params = { locationId: 'location-id', deviceId: 'device-id' }
+	const items: DeviceActivity[] = []
+	const totalNumItems = maxItemsPerRequest * maxRequestsBeforeWarning + 10
+	for (let index = 0; index < totalNumItems; index++) {
+		items.push({
+			deviceId: 'history-device-id',
+			text: `item${index}`,
+		} as DeviceActivity)
+	}
+
+	const promptMock = jest.mocked(inquirer.prompt)
+
+	// Since the core SDK mutates this object via the `.next` call, each test needs its own instance.
+	const makeHistoryResponse = (items: DeviceActivity[]): PaginatedList<DeviceActivity> => ({
+		items,
+		hasNext: hasNextMock,
+		next: nextMock,
+	} as unknown as PaginatedList<DeviceActivity>)
+
+	it('uses single request when one is enough', async () => {
+		const returnedItems = items.slice(0, 2)
+		historyDevicesMock.mockResolvedValueOnce(makeHistoryResponse(returnedItems))
+
+		expect(await getHistory(client, 20, 20, params)).toStrictEqual(returnedItems)
+
+		expect(historyDevicesMock).toHaveBeenCalledTimes(1)
+		expect(historyDevicesMock).toHaveBeenCalledWith(params)
+		expect(hasNextMock).toHaveBeenCalledTimes(1)
+		expect(nextMock).toHaveBeenCalledTimes(0)
+		expect(promptMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('makes multiple calls when needed', async () => {
+		const firstItemSet = items.slice(0, 2)
+		const secondItemSet = items.slice(2, 4)
+		const allItems = items.slice(0, 4)
+		const historyResponse = makeHistoryResponse(firstItemSet)
+		historyDevicesMock.mockResolvedValueOnce(historyResponse)
+		hasNextMock.mockReturnValueOnce(true)
+		nextMock.mockImplementationOnce(async () => historyResponse.items = secondItemSet)
+
+		expect(await getHistory(client, 20, 20, params)).toStrictEqual(allItems)
+
+		expect(historyDevicesMock).toHaveBeenCalledTimes(1)
+		expect(historyDevicesMock).toHaveBeenCalledWith(params)
+		expect(hasNextMock).toHaveBeenCalledTimes(2)
+		expect(nextMock).toHaveBeenCalledTimes(1)
+		expect(promptMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('abandons large query when requested to do so', async () => {
+		promptMock.mockResolvedValueOnce({ answer: 'cancel' })
+
+		await expect(getHistory(client, maxItemsPerRequest * maxRequestsBeforeWarning + 1, maxItemsPerRequest,
+			params)).rejects.toThrow()
+
+		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(historyDevicesMock).toHaveBeenCalledTimes(0)
+		expect(hasNextMock).toHaveBeenCalledTimes(0)
+		expect(nextMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('limits large query when requested to do so', async () => {
+		promptMock.mockResolvedValueOnce({ answer: 'reduce' })
+		const firstItemSet = items.slice(0, maxItemsPerRequest)
+		const historyResponse = makeHistoryResponse(firstItemSet)
+		historyDevicesMock.mockResolvedValueOnce(historyResponse)
+		hasNextMock.mockReturnValue(true)
+		let nextStart = 300
+		nextMock.mockImplementation(async () => {
+			historyResponse.items = items.slice(nextStart, nextStart + maxItemsPerRequest)
+			nextStart += maxItemsPerRequest
 		})
 
-		it('makes multiple calls when needed', async () => {
-			const firstItemSet = items.slice(0, 2)
-			const secondItemSet = items.slice(2, 4)
-			const allItems = items.slice(0, 4)
-			const historyResponse = makeHistoryResponse(firstItemSet)
-			historyDevicesMock.mockResolvedValueOnce(historyResponse)
-			hasNextMock.mockReturnValueOnce(true)
-			nextMock.mockImplementationOnce(async () => historyResponse.items = secondItemSet)
+		const result = await getHistory(client, maxItemsPerRequest * maxRequestsBeforeWarning + 1,
+			maxItemsPerRequest, params)
+		expect(result).toStrictEqual(items.slice(0, maxRequestsBeforeWarning * maxItemsPerRequest))
 
-			expect(await getHistory(client, 20, 20, params)).toStrictEqual(allItems)
+		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(historyDevicesMock).toHaveBeenCalledTimes(1)
+		expect(historyDevicesMock).toHaveBeenCalledWith(params)
+		expect(hasNextMock).toHaveBeenCalledTimes(5)
+		expect(nextMock).toHaveBeenCalledTimes(5)
+	})
 
-			expect(historyDevicesMock).toHaveBeenCalledTimes(1)
-			expect(historyDevicesMock).toHaveBeenCalledWith(params)
-			expect(hasNextMock).toHaveBeenCalledTimes(2)
-			expect(nextMock).toHaveBeenCalledTimes(1)
-			expect(promptMock).toHaveBeenCalledTimes(0)
+	it('makes all requests when asked to', async () => {
+		promptMock.mockResolvedValueOnce({ answer: 'yes' })
+		const firstItemSet = items.slice(0, maxItemsPerRequest)
+		const historyResponse = makeHistoryResponse(firstItemSet)
+		historyDevicesMock.mockResolvedValueOnce(historyResponse)
+		hasNextMock.mockReturnValue(true)
+		let nextStart = 300
+		nextMock.mockImplementation(async () => {
+			historyResponse.items = items.slice(nextStart, nextStart + maxItemsPerRequest)
+			nextStart += maxItemsPerRequest
 		})
 
-		it('abandons large query when requested to do so', async () => {
-			promptMock.mockResolvedValueOnce({ answer: 'cancel' })
+		const result = await getHistory(client, items.length, maxItemsPerRequest, params)
+		expect(result).toStrictEqual(items)
 
-			await expect(getHistory(client, maxItemsPerRequest * maxRequestsBeforeWarning + 1, maxItemsPerRequest,
-				params)).rejects.toThrow()
+		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(historyDevicesMock).toHaveBeenCalledTimes(1)
+		expect(historyDevicesMock).toHaveBeenCalledWith(params)
+		expect(hasNextMock).toHaveBeenCalledTimes(6)
+		expect(nextMock).toHaveBeenCalledTimes(6)
+	})
 
-			expect(promptMock).toHaveBeenCalledTimes(1)
-			expect(historyDevicesMock).toHaveBeenCalledTimes(0)
-			expect(hasNextMock).toHaveBeenCalledTimes(0)
-			expect(nextMock).toHaveBeenCalledTimes(0)
+	it('ignores some result from last request to return no more than requested limit', async () => {
+		promptMock.mockResolvedValueOnce({ answer: 'yes' })
+		const firstItemSet = items.slice(0, maxItemsPerRequest)
+		const historyResponse = makeHistoryResponse(firstItemSet)
+		historyDevicesMock.mockResolvedValueOnce(historyResponse)
+		hasNextMock.mockReturnValue(true)
+		let nextStart = 300
+		nextMock.mockImplementation(async () => {
+			historyResponse.items = items.slice(nextStart, nextStart + maxItemsPerRequest)
+			nextStart += maxItemsPerRequest
 		})
 
-		it('limits large query when requested to do so', async () => {
-			promptMock.mockResolvedValueOnce({ answer: 'reduce' })
-			const firstItemSet = items.slice(0, maxItemsPerRequest)
-			const historyResponse = makeHistoryResponse(firstItemSet)
-			historyDevicesMock.mockResolvedValueOnce(historyResponse)
-			hasNextMock.mockReturnValue(true)
-			let nextStart = 300
-			nextMock.mockImplementation(async () => {
-				historyResponse.items = items.slice(nextStart, nextStart + maxItemsPerRequest)
-				nextStart += maxItemsPerRequest
-			})
+		const result = await getHistory(client, items.length - 5, maxItemsPerRequest, params)
+		expect(result).toStrictEqual(items.slice(0, items.length - 5))
 
-			const result = await getHistory(client, maxItemsPerRequest * maxRequestsBeforeWarning + 1,
-				maxItemsPerRequest, params)
-			expect(result).toStrictEqual(items.slice(0, maxRequestsBeforeWarning * maxItemsPerRequest))
+		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(historyDevicesMock).toHaveBeenCalledTimes(1)
+		expect(historyDevicesMock).toHaveBeenCalledWith(params)
+		expect(hasNextMock).toHaveBeenCalledTimes(6)
+		expect(nextMock).toHaveBeenCalledTimes(6)
+	})
 
-			expect(promptMock).toHaveBeenCalledTimes(1)
-			expect(historyDevicesMock).toHaveBeenCalledTimes(1)
-			expect(historyDevicesMock).toHaveBeenCalledWith(params)
-			expect(hasNextMock).toHaveBeenCalledTimes(5)
-			expect(nextMock).toHaveBeenCalledTimes(5)
-		})
+	it('stops paging when results are before specified after', async () => {
+		const epochTimestamp = 1701097200 // 2023/11/27 9:00 a.m. CST
+		const makeActivity = (index: number, epoch: number): DeviceActivity => ({
+			deviceId: 'history-device-id',
+			text: `item${index}`,
+			epoch,
+		} as DeviceActivity)
+		const firstPage = [
+			makeActivity(0, epochTimestamp + 600),
+			makeActivity(1, epochTimestamp + 500),
+			makeActivity(2, epochTimestamp + 400),
+		]
+		const secondPage = [
+			makeActivity(3, epochTimestamp + 300),
+			makeActivity(4, epochTimestamp + 200),
+			makeActivity(5, epochTimestamp + 100),
+		]
+		const historyResponse = makeHistoryResponse(firstPage)
+		historyDevicesMock.mockResolvedValueOnce(historyResponse)
+		hasNextMock.mockReturnValue(true)
+		nextMock.mockImplementationOnce(async () => historyResponse.items = secondPage)
 
-		it('makes all requests when asked to', async () => {
-			promptMock.mockResolvedValueOnce({ answer: 'yes' })
-			const firstItemSet = items.slice(0, maxItemsPerRequest)
-			const historyResponse = makeHistoryResponse(firstItemSet)
-			historyDevicesMock.mockResolvedValueOnce(historyResponse)
-			hasNextMock.mockReturnValue(true)
-			let nextStart = 300
-			nextMock.mockImplementation(async () => {
-				historyResponse.items = items.slice(nextStart, nextStart + maxItemsPerRequest)
-				nextStart += maxItemsPerRequest
-			})
+		const paramsWithAfter = { ...params, after: epochTimestamp + 350 }
 
-			const result = await getHistory(client, items.length, maxItemsPerRequest, params)
-			expect(result).toStrictEqual(items)
+		const result = await getHistory(client, 300, 3, paramsWithAfter)
+		expect(result).toStrictEqual(firstPage)
 
-			expect(promptMock).toHaveBeenCalledTimes(1)
-			expect(historyDevicesMock).toHaveBeenCalledTimes(1)
-			expect(historyDevicesMock).toHaveBeenCalledWith(params)
-			expect(hasNextMock).toHaveBeenCalledTimes(6)
-			expect(nextMock).toHaveBeenCalledTimes(6)
-		})
-
-		it('ignores some result from last request to return no more than requested limit', async () => {
-			promptMock.mockResolvedValueOnce({ answer: 'yes' })
-			const firstItemSet = items.slice(0, maxItemsPerRequest)
-			const historyResponse = makeHistoryResponse(firstItemSet)
-			historyDevicesMock.mockResolvedValueOnce(historyResponse)
-			hasNextMock.mockReturnValue(true)
-			let nextStart = 300
-			nextMock.mockImplementation(async () => {
-				historyResponse.items = items.slice(nextStart, nextStart + maxItemsPerRequest)
-				nextStart += maxItemsPerRequest
-			})
-
-			const result = await getHistory(client, items.length - 5, maxItemsPerRequest, params)
-			expect(result).toStrictEqual(items.slice(0, items.length - 5))
-
-			expect(promptMock).toHaveBeenCalledTimes(1)
-			expect(historyDevicesMock).toHaveBeenCalledTimes(1)
-			expect(historyDevicesMock).toHaveBeenCalledWith(params)
-			expect(hasNextMock).toHaveBeenCalledTimes(6)
-			expect(nextMock).toHaveBeenCalledTimes(6)
-		})
-
-		it('stops paging when results are before specified after', async () => {
-			const epochTimestamp = 1701097200 // 2023/11/27 9:00 a.m. CST
-			const makeActivity = (index: number, epoch: number): DeviceActivity => ({
-				deviceId: 'history-device-id',
-				text: `item${index}`,
-				epoch,
-			} as DeviceActivity)
-			const firstPage = [
-				makeActivity(0, epochTimestamp + 600),
-				makeActivity(1, epochTimestamp + 500),
-				makeActivity(2, epochTimestamp + 400),
-			]
-			const secondPage = [
-				makeActivity(3, epochTimestamp + 300),
-				makeActivity(4, epochTimestamp + 200),
-				makeActivity(5, epochTimestamp + 100),
-			]
-			const historyResponse = makeHistoryResponse(firstPage)
-			historyDevicesMock.mockResolvedValueOnce(historyResponse)
-			hasNextMock.mockReturnValue(true)
-			nextMock.mockImplementationOnce(async () => historyResponse.items = secondPage)
-
-			const paramsWithAfter = { ...params, after: epochTimestamp + 350 }
-
-			const result = await getHistory(client, 300, 3, paramsWithAfter)
-			expect(result).toStrictEqual(firstPage)
-
-			expect(historyDevicesMock).toHaveBeenCalledTimes(1)
-			expect(historyDevicesMock).toHaveBeenCalledWith(paramsWithAfter)
-			expect(hasNextMock).toHaveBeenCalledTimes(1)
-			expect(nextMock).toHaveBeenCalledTimes(1)
-		})
+		expect(historyDevicesMock).toHaveBeenCalledTimes(1)
+		expect(historyDevicesMock).toHaveBeenCalledWith(paramsWithAfter)
+		expect(hasNextMock).toHaveBeenCalledTimes(1)
+		expect(nextMock).toHaveBeenCalledTimes(1)
 	})
 })

--- a/packages/cli/src/__tests__/lib/commands/locations/modes-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/locations/modes-util.test.ts
@@ -9,140 +9,138 @@ import { getModesByLocation, chooseMode } from '../../../../lib/commands/locatio
 import * as modesUtil from '../../../../lib/commands/locations/modes-util'
 
 
-describe('modes-util', () => {
-	const locationId = 'locationId'
-	const locationName = 'test location'
-	const modeId = 'id'
-	const modeName = 'name'
+const locationId = 'locationId'
+const locationName = 'test location'
+const modeId = 'id'
+const modeName = 'name'
 
-	describe('getModesByLocation', () => {
-		const testClient = new SmartThingsClient(new NoOpAuthenticator)
-		const listModesSpy = jest.spyOn(ModesEndpoint.prototype, 'list').mockImplementation()
-		const getLocationsSpy = jest.spyOn(LocationsEndpoint.prototype, 'get').mockImplementation()
-		const listLocationsSpy = jest.spyOn(LocationsEndpoint.prototype, 'list').mockImplementation()
+describe('getModesByLocation', () => {
+	const testClient = new SmartThingsClient(new NoOpAuthenticator)
+	const listModesSpy = jest.spyOn(ModesEndpoint.prototype, 'list').mockImplementation()
+	const getLocationsSpy = jest.spyOn(LocationsEndpoint.prototype, 'get').mockImplementation()
+	const listLocationsSpy = jest.spyOn(LocationsEndpoint.prototype, 'list').mockImplementation()
 
-		it('throws error when no locations are found', async () => {
-			listLocationsSpy.mockResolvedValueOnce([])
-			const forbiddenError = new Error('Request failed with status code 403')
-			getLocationsSpy.mockRejectedValueOnce(forbiddenError)
+	it('throws error when no locations are found', async () => {
+		listLocationsSpy.mockResolvedValueOnce([])
+		const forbiddenError = new Error('Request failed with status code 403')
+		getLocationsSpy.mockRejectedValueOnce(forbiddenError)
 
-			await expect(getModesByLocation(testClient)).rejects.toThrow('could not find any locations')
-			await expect(getModesByLocation(testClient, locationId)).rejects.toThrow(forbiddenError)
-		})
-
-		it('returns modes with location ID and name added', async () => {
-			const location: Location = {
-				locationId,
-				name: locationName,
-				timeZoneId: '',
-				backgroundImage: '',
-				countryCode: '',
-				temperatureScale: 'C',
-			}
-			const modes: Mode[] = [
-				{
-					name: modeName,
-					id: modeId,
-					label: 'modeLabel',
-				},
-			]
-
-			getLocationsSpy.mockResolvedValueOnce(location)
-			listModesSpy.mockResolvedValueOnce(modes)
-
-			const modesWithLocations = await getModesByLocation(testClient, locationId)
-
-			expect(modesWithLocations[0]).toEqual(expect.objectContaining(modes[0]))
-			expect(modesWithLocations[0].locationId).toBe(locationId)
-			expect(modesWithLocations[0].location).toBe(locationName)
-		})
+		await expect(getModesByLocation(testClient)).rejects.toThrow('could not find any locations')
+		await expect(getModesByLocation(testClient, locationId)).rejects.toThrow(forbiddenError)
 	})
 
-	describe('chooseMode', () => {
-		const getModesByLocationSpy = jest.spyOn(modesUtil, 'getModesByLocation')
-		const chooseLocationSpy = jest.spyOn(locationsModule, 'chooseLocation')
-		class MockCommand extends APICommand<typeof MockCommand.flags> {
-			async run(): Promise<void> {
-				// eslint-disable-line @typescript-eslint/no-empty-function
-			}
+	it('returns modes with location ID and name added', async () => {
+		const location: Location = {
+			locationId,
+			name: locationName,
+			timeZoneId: '',
+			backgroundImage: '',
+			countryCode: '',
+			temperatureScale: 'C',
 		}
-		const command = new MockCommand([], new Config({ root: '' }))
-		const mockSelectFromList = jest.mocked(selectFromList)
-
-		beforeAll(() => {
-			getModesByLocationSpy.mockResolvedValue([])
-			mockSelectFromList.mockResolvedValue(modeId)
-		})
-
-		it('throws error when mode not found', async () => {
-			await expect(modesUtil.chooseMode(command)).rejects.toThrow('could not find mode')
-
-			const modesWithLocation = [{
-				id: 'notFound',
-				locationId: locationId,
-				name: 'test',
-			}]
-			getModesByLocationSpy.mockResolvedValueOnce(modesWithLocation)
-
-			await expect(chooseMode(command)).rejects.toThrow('could not find mode')
-		})
-
-		it('throws error when locationId is missing', async () => {
-			const modesWithLocation = [{
-				id: modeId,
-				name: 'test',
-			}]
-			getModesByLocationSpy.mockResolvedValueOnce(modesWithLocation)
-
-			await expect(chooseMode(command)).rejects.toThrow('could not determine location id for mode')
-		})
-
-		it('returns mode tuple when mode is found', async () => {
-			const modesWithLocation = [{
-				id: modeId,
-				locationId: locationId,
-				name: 'test',
-			},
+		const modes: Mode[] = [
 			{
-				id: 'mode2',
-				locationId: locationId,
-				name: 'mode2',
-			}]
+				name: modeName,
+				id: modeId,
+				label: 'modeLabel',
+			},
+		]
 
-			getModesByLocationSpy.mockResolvedValueOnce(modesWithLocation)
+		getLocationsSpy.mockResolvedValueOnce(location)
+		listModesSpy.mockResolvedValueOnce(modes)
 
-			await expect(chooseMode(command, locationId)).resolves.toEqual([modeId, locationId])
-		})
+		const modesWithLocations = await getModesByLocation(testClient, locationId)
 
-		it('calls selectFromList with correct config', async () => {
-			await expect(chooseMode(command, undefined, modeId)).rejects.toThrow('could not find mode')
+		expect(modesWithLocations[0]).toEqual(expect.objectContaining(modes[0]))
+		expect(modesWithLocations[0].locationId).toBe(locationId)
+		expect(modesWithLocations[0].location).toBe(locationName)
+	})
+})
 
-			expect(mockSelectFromList).toBeCalledWith(
-				expect.anything(),
-				expect.objectContaining({
-					itemName: 'mode',
-					primaryKeyName: 'id',
-					sortKeyName: 'label',
-					listTableFieldDefinitions: expect.anything(),
-				}),
-				expect.objectContaining({ preselectedId: modeId }),
-			)
-		})
+describe('chooseMode', () => {
+	const getModesByLocationSpy = jest.spyOn(modesUtil, 'getModesByLocation')
+	const chooseLocationSpy = jest.spyOn(locationsModule, 'chooseLocation')
+	class MockCommand extends APICommand<typeof MockCommand.flags> {
+		async run(): Promise<void> {
+			// eslint-disable-line @typescript-eslint/no-empty-function
+		}
+	}
+	const command = new MockCommand([], new Config({ root: '' }))
+	const mockSelectFromList = jest.mocked(selectFromList)
 
-		it('passes on locationId when retrieving modes', async () => {
-			chooseLocationSpy.mockResolvedValueOnce('chosenLocation')
-			await expect(chooseMode(command)).rejects.toThrow('could not find mode')
+	beforeAll(() => {
+		getModesByLocationSpy.mockResolvedValue([])
+		mockSelectFromList.mockResolvedValue(modeId)
+	})
 
-			expect(chooseLocationSpy).toBeCalledWith(command, undefined, true)
-			expect(getModesByLocationSpy).toBeCalledWith(expect.any(SmartThingsClient), 'chosenLocation')
+	it('throws error when mode not found', async () => {
+		await expect(modesUtil.chooseMode(command)).rejects.toThrow('could not find mode')
 
-			getModesByLocationSpy.mockClear
-			chooseLocationSpy.mockResolvedValueOnce(locationId)
+		const modesWithLocation = [{
+			id: 'notFound',
+			locationId: locationId,
+			name: 'test',
+		}]
+		getModesByLocationSpy.mockResolvedValueOnce(modesWithLocation)
 
-			await expect(chooseMode(command, locationId)).rejects.toThrow('could not find mode')
+		await expect(chooseMode(command)).rejects.toThrow('could not find mode')
+	})
 
-			expect(chooseLocationSpy).toBeCalledWith(command, locationId, true)
-			expect(getModesByLocationSpy).toBeCalledWith(expect.any(SmartThingsClient), locationId)
-		})
+	it('throws error when locationId is missing', async () => {
+		const modesWithLocation = [{
+			id: modeId,
+			name: 'test',
+		}]
+		getModesByLocationSpy.mockResolvedValueOnce(modesWithLocation)
+
+		await expect(chooseMode(command)).rejects.toThrow('could not determine location id for mode')
+	})
+
+	it('returns mode tuple when mode is found', async () => {
+		const modesWithLocation = [{
+			id: modeId,
+			locationId: locationId,
+			name: 'test',
+		},
+		{
+			id: 'mode2',
+			locationId: locationId,
+			name: 'mode2',
+		}]
+
+		getModesByLocationSpy.mockResolvedValueOnce(modesWithLocation)
+
+		await expect(chooseMode(command, locationId)).resolves.toEqual([modeId, locationId])
+	})
+
+	it('calls selectFromList with correct config', async () => {
+		await expect(chooseMode(command, undefined, modeId)).rejects.toThrow('could not find mode')
+
+		expect(mockSelectFromList).toBeCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				itemName: 'mode',
+				primaryKeyName: 'id',
+				sortKeyName: 'label',
+				listTableFieldDefinitions: expect.anything(),
+			}),
+			expect.objectContaining({ preselectedId: modeId }),
+		)
+	})
+
+	it('passes on locationId when retrieving modes', async () => {
+		chooseLocationSpy.mockResolvedValueOnce('chosenLocation')
+		await expect(chooseMode(command)).rejects.toThrow('could not find mode')
+
+		expect(chooseLocationSpy).toBeCalledWith(command, undefined, true)
+		expect(getModesByLocationSpy).toBeCalledWith(expect.any(SmartThingsClient), 'chosenLocation')
+
+		getModesByLocationSpy.mockClear
+		chooseLocationSpy.mockResolvedValueOnce(locationId)
+
+		await expect(chooseMode(command, locationId)).rejects.toThrow('could not find mode')
+
+		expect(chooseLocationSpy).toBeCalledWith(command, locationId, true)
+		expect(getModesByLocationSpy).toBeCalledWith(expect.any(SmartThingsClient), locationId)
 	})
 })

--- a/packages/cli/src/__tests__/lib/commands/rules-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/rules-util.test.ts
@@ -11,195 +11,193 @@ import {
 import * as rulesUtil from '../../../lib/commands/rules-util.js'
 
 
-describe('rules-util', () => {
-	const location1 = { locationId: 'location-id-1', name: 'location-name-1' }
-	const location2 = { locationId: 'location-id-2', name: 'location-name-2' }
-	const rule1 = { id: 'rule-id-1', name: 'rule-name-1' }
-	const rule2 = { id: 'rule-id-2', name: 'rule-name-2' }
-	const rule1WithLocation = { ...rule1, locationId: 'location-id-1', location: 'location-name-1' } as Rule & WithNamedLocation
-	const rule2WithLocation = { ...rule2, locationId: 'location-id-2', location: 'location-name-2' } as Rule & WithNamedLocation
+const location1 = { locationId: 'location-id-1', name: 'location-name-1' }
+const location2 = { locationId: 'location-id-2', name: 'location-name-2' }
+const rule1 = { id: 'rule-id-1', name: 'rule-name-1' }
+const rule2 = { id: 'rule-id-2', name: 'rule-name-2' }
+const rule1WithLocation = { ...rule1, locationId: 'location-id-1', location: 'location-name-1' } as Rule & WithNamedLocation
+const rule2WithLocation = { ...rule2, locationId: 'location-id-2', location: 'location-name-2' } as Rule & WithNamedLocation
 
-	const locations = {
-		get: jest.fn(),
-		list: jest.fn(),
-	}
-	const rules = {
-		get: jest.fn(),
-		list: jest.fn(),
-	}
+const locations = {
+	get: jest.fn(),
+	list: jest.fn(),
+}
+const rules = {
+	get: jest.fn(),
+	list: jest.fn(),
+}
 
-	const client = { locations, rules } as unknown as SmartThingsClient
+const client = { locations, rules } as unknown as SmartThingsClient
 
-	describe('tableFieldDefinitions', () => {
-		it('counts rule actions', () => {
-			const numActionsDefinition = tableFieldDefinitions[2] as { value: (rule: Rule) => string }
-			const rule = { actions: [1, 2, 3] as unknown as RuleAction[] } as Rule
-			expect(numActionsDefinition.value(rule)).toBe('3')
-		})
+describe('tableFieldDefinitions', () => {
+	it('counts rule actions', () => {
+		const numActionsDefinition = tableFieldDefinitions[2] as { value: (rule: Rule) => string }
+		const rule = { actions: [1, 2, 3] as unknown as RuleAction[] } as Rule
+		expect(numActionsDefinition.value(rule)).toBe('3')
+	})
+})
+
+describe('getRulesByLocation', () => {
+	it('looks up location when one is specified', async () => {
+		locations.get.mockResolvedValueOnce(location1)
+		rules.list.mockResolvedValueOnce([rule1])
+
+		expect(await getRulesByLocation(client, 'location-id-1')).toEqual([rule1WithLocation])
+
+		expect(locations.get).toHaveBeenCalledTimes(1)
+		expect(locations.get).toHaveBeenCalledWith('location-id-1')
+		expect(rules.list).toHaveBeenCalledTimes(1)
+		expect(rules.list).toHaveBeenCalledWith('location-id-1')
+
+		expect(locations.list).toHaveBeenCalledTimes(0)
+		expect(rules.get).toHaveBeenCalledTimes(0)
 	})
 
-	describe('getRulesByLocation', () => {
-		it('looks up location when one is specified', async () => {
-			locations.get.mockResolvedValueOnce(location1)
-			rules.list.mockResolvedValueOnce([rule1])
+	it('combines rules from all locations when none is specified', async () => {
+		locations.list.mockResolvedValueOnce([location1, location2])
+		rules.list.mockResolvedValueOnce([rule1])
+		rules.list.mockResolvedValueOnce([rule2])
 
-			expect(await getRulesByLocation(client, 'location-id-1')).toEqual([rule1WithLocation])
+		expect(await getRulesByLocation(client)).toEqual([rule1WithLocation, rule2WithLocation])
 
-			expect(locations.get).toHaveBeenCalledTimes(1)
-			expect(locations.get).toHaveBeenCalledWith('location-id-1')
-			expect(rules.list).toHaveBeenCalledTimes(1)
-			expect(rules.list).toHaveBeenCalledWith('location-id-1')
+		expect(locations.list).toHaveBeenCalledTimes(1)
+		expect(rules.list).toHaveBeenCalledTimes(2)
+		expect(rules.list).toHaveBeenCalledWith('location-id-1')
+		expect(rules.list).toHaveBeenCalledWith('location-id-2')
 
-			expect(locations.list).toHaveBeenCalledTimes(0)
-			expect(rules.get).toHaveBeenCalledTimes(0)
-		})
-
-		it('combines rules from all locations when none is specified', async () => {
-			locations.list.mockResolvedValueOnce([location1, location2])
-			rules.list.mockResolvedValueOnce([rule1])
-			rules.list.mockResolvedValueOnce([rule2])
-
-			expect(await getRulesByLocation(client)).toEqual([rule1WithLocation, rule2WithLocation])
-
-			expect(locations.list).toHaveBeenCalledTimes(1)
-			expect(rules.list).toHaveBeenCalledTimes(2)
-			expect(rules.list).toHaveBeenCalledWith('location-id-1')
-			expect(rules.list).toHaveBeenCalledWith('location-id-2')
-
-			expect(locations.get).toHaveBeenCalledTimes(0)
-			expect(rules.get).toHaveBeenCalledTimes(0)
-		})
-
-		it('throws an error when no location is found', async () => {
-			locations.list.mockResolvedValueOnce([])
-
-			await expect(getRulesByLocation(client)).rejects.toThrow(
-				'Could not find any locations for your account. Perhaps ' +
-				"you haven't created any locations yet.")
-
-			expect(locations.list).toHaveBeenCalledTimes(1)
-
-			expect(locations.get).toHaveBeenCalledTimes(0)
-			expect(rules.get).toHaveBeenCalledTimes(0)
-			expect(rules.list).toHaveBeenCalledTimes(0)
-		})
+		expect(locations.get).toHaveBeenCalledTimes(0)
+		expect(rules.get).toHaveBeenCalledTimes(0)
 	})
 
-	describe('getRuleWithLocation', () => {
-		const getRulesByLocationSpy = jest.spyOn(rulesUtil, 'getRulesByLocation')
+	it('throws an error when no location is found', async () => {
+		locations.list.mockResolvedValueOnce([])
 
-		it('uses simple location lookup when locationId specified', async () => {
-			locations.get.mockResolvedValueOnce(location1)
-			rules.get.mockResolvedValueOnce(rule1)
+		await expect(getRulesByLocation(client)).rejects.toThrow(
+			'Could not find any locations for your account. Perhaps ' +
+			"you haven't created any locations yet.")
 
-			expect(await getRuleWithLocation(client, 'rule-id-1', 'location-id-1'))
-				.toEqual(rule1WithLocation)
+		expect(locations.list).toHaveBeenCalledTimes(1)
 
-			expect(locations.get).toHaveBeenCalledTimes(1)
-			expect(locations.get).toHaveBeenCalledWith('location-id-1')
-			expect(rules.get).toHaveBeenCalledTimes(1)
-			expect(rules.get).toHaveBeenCalledWith('rule-id-1', 'location-id-1')
+		expect(locations.get).toHaveBeenCalledTimes(0)
+		expect(rules.get).toHaveBeenCalledTimes(0)
+		expect(rules.list).toHaveBeenCalledTimes(0)
+	})
+})
 
-			expect(locations.list).toHaveBeenCalledTimes(0)
-			expect(rules.list).toHaveBeenCalledTimes(0)
-			expect(getRulesByLocationSpy).toHaveBeenCalledTimes(0)
-		})
+describe('getRuleWithLocation', () => {
+	const getRulesByLocationSpy = jest.spyOn(rulesUtil, 'getRulesByLocation')
 
-		it('searches for rule by location when no location id specified', async () => {
-			getRulesByLocationSpy.mockResolvedValueOnce([rule1WithLocation, rule2WithLocation])
+	it('uses simple location lookup when locationId specified', async () => {
+		locations.get.mockResolvedValueOnce(location1)
+		rules.get.mockResolvedValueOnce(rule1)
 
-			expect(await getRuleWithLocation(client, 'rule-id-1')).toBe(rule1WithLocation)
+		expect(await getRuleWithLocation(client, 'rule-id-1', 'location-id-1'))
+			.toEqual(rule1WithLocation)
 
-			expect(getRulesByLocationSpy).toHaveBeenCalledTimes(1)
-			expect(getRulesByLocationSpy).toHaveBeenCalledWith(client, undefined)
+		expect(locations.get).toHaveBeenCalledTimes(1)
+		expect(locations.get).toHaveBeenCalledWith('location-id-1')
+		expect(rules.get).toHaveBeenCalledTimes(1)
+		expect(rules.get).toHaveBeenCalledWith('rule-id-1', 'location-id-1')
 
-			expect(locations.get).toHaveBeenCalledTimes(0)
-			expect(locations.list).toHaveBeenCalledTimes(0)
-			expect(rules.get).toHaveBeenCalledTimes(0)
-			expect(rules.list).toHaveBeenCalledTimes(0)
-		})
-
-		it('throws error when no rule found when searching', async () => {
-			getRulesByLocationSpy.mockResolvedValueOnce([rule1WithLocation, rule2WithLocation])
-
-			await expect(getRuleWithLocation(client, 'rule-id-3')).rejects
-				.toThrow('could not find rule with id rule-id-3 in any location')
-
-			expect(getRulesByLocationSpy).toHaveBeenCalledTimes(1)
-			expect(getRulesByLocationSpy).toHaveBeenCalledWith(client, undefined)
-
-			expect(locations.get).toHaveBeenCalledTimes(0)
-			expect(locations.list).toHaveBeenCalledTimes(0)
-			expect(rules.get).toHaveBeenCalledTimes(0)
-			expect(rules.list).toHaveBeenCalledTimes(0)
-		})
+		expect(locations.list).toHaveBeenCalledTimes(0)
+		expect(rules.list).toHaveBeenCalledTimes(0)
+		expect(getRulesByLocationSpy).toHaveBeenCalledTimes(0)
 	})
 
-	test('chooseRule proxies correctly to selectFromList', async () => {
-		const selectFromListMock = jest.mocked(selectFromList).mockResolvedValue('chosen-rule-id')
-		const client = {} as SmartThingsClient
-		const command = { client } as APICommand<typeof APICommand.flags>
+	it('searches for rule by location when no location id specified', async () => {
+		getRulesByLocationSpy.mockResolvedValueOnce([rule1WithLocation, rule2WithLocation])
 
-		expect(await chooseRule(command, 'prompt message', 'location-id', 'cmd-line-rule-id'))
-			.toBe('chosen-rule-id')
+		expect(await getRuleWithLocation(client, 'rule-id-1')).toBe(rule1WithLocation)
 
-		expect(selectFromListMock).toHaveBeenCalledTimes(1)
-		expect(selectFromListMock).toHaveBeenCalledWith(command,
-			expect.objectContaining({ primaryKeyName: 'id' }),
-			expect.objectContaining({
-				preselectedId: 'cmd-line-rule-id',
-				promptMessage: 'prompt message',
-			}),
-		)
+		expect(getRulesByLocationSpy).toHaveBeenCalledTimes(1)
+		expect(getRulesByLocationSpy).toHaveBeenCalledWith(client, undefined)
 
-		const ruleWithLocation = { locationId: 'location-id' } as Rule & WithNamedLocation
-		const rulesList = [ruleWithLocation]
-		const listItems = selectFromListMock.mock.calls[0][2].listItems
-		const getRulesByLocationMock = (getRulesByLocation as
-			jest.Mock<Promise<(Rule & WithNamedLocation)[]>, [SmartThingsClient, string | undefined]>)
-			.mockResolvedValue(rulesList)
-
-		expect(await listItems()).toBe(rulesList)
-
-		expect(getRulesByLocationMock).toHaveBeenCalledTimes(1)
-		expect(getRulesByLocationMock).toHaveBeenCalledWith(client, 'location-id')
+		expect(locations.get).toHaveBeenCalledTimes(0)
+		expect(locations.list).toHaveBeenCalledTimes(0)
+		expect(rules.get).toHaveBeenCalledTimes(0)
+		expect(rules.list).toHaveBeenCalledTimes(0)
 	})
 
-	describe('buildExecuteResponseTableOutput', () => {
-		const buildTableFromItemMock = jest.fn().mockReturnValue('main info')
-		const buildTableFromListMock = jest.fn().mockReturnValue('actions info')
-		const tableGenerator = {
-			buildTableFromItem: buildTableFromItemMock,
-			buildTableFromList: buildTableFromListMock,
-		} as unknown as TableGenerator
+	it('throws error when no rule found when searching', async () => {
+		getRulesByLocationSpy.mockResolvedValueOnce([rule1WithLocation, rule2WithLocation])
 
-		it('includes actions when present', () => {
-			const executeResponse = {
-				id: 'execute-response-id',
-				actions: [{ actionId: 'action-id' }],
-			} as RuleExecutionResponse
+		await expect(getRuleWithLocation(client, 'rule-id-3')).rejects
+			.toThrow('could not find rule with id rule-id-3 in any location')
 
-			expect(rulesUtil.buildExecuteResponseTableOutput(tableGenerator, executeResponse))
-				.toBe('main info\n\nActions\nactions info')
+		expect(getRulesByLocationSpy).toHaveBeenCalledTimes(1)
+		expect(getRulesByLocationSpy).toHaveBeenCalledWith(client, undefined)
 
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromItemMock).toHaveBeenCalledWith(executeResponse,
-				['executionId', 'id', 'result'])
-			expect(buildTableFromListMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromListMock).toHaveBeenCalledWith(executeResponse.actions,
-				expect.arrayContaining(['actionId', { path: 'location.locationId' }]))
-		})
+		expect(locations.get).toHaveBeenCalledTimes(0)
+		expect(locations.list).toHaveBeenCalledTimes(0)
+		expect(rules.get).toHaveBeenCalledTimes(0)
+		expect(rules.list).toHaveBeenCalledTimes(0)
+	})
+})
 
-		it('leaves out actions table when there are no actions', () => {
-			const executeResponse = { id: 'execute-response-id' } as RuleExecutionResponse
+test('chooseRule proxies correctly to selectFromList', async () => {
+	const selectFromListMock = jest.mocked(selectFromList).mockResolvedValue('chosen-rule-id')
+	const client = {} as SmartThingsClient
+	const command = { client } as APICommand<typeof APICommand.flags>
 
-			expect(rulesUtil.buildExecuteResponseTableOutput(tableGenerator, executeResponse))
-				.toBe('main info')
+	expect(await chooseRule(command, 'prompt message', 'location-id', 'cmd-line-rule-id'))
+		.toBe('chosen-rule-id')
 
-			expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
-			expect(buildTableFromItemMock).toHaveBeenCalledWith(executeResponse,
-				['executionId', 'id', 'result'])
-			expect(buildTableFromListMock).toHaveBeenCalledTimes(0)
-		})
+	expect(selectFromListMock).toHaveBeenCalledTimes(1)
+	expect(selectFromListMock).toHaveBeenCalledWith(command,
+		expect.objectContaining({ primaryKeyName: 'id' }),
+		expect.objectContaining({
+			preselectedId: 'cmd-line-rule-id',
+			promptMessage: 'prompt message',
+		}),
+	)
+
+	const ruleWithLocation = { locationId: 'location-id' } as Rule & WithNamedLocation
+	const rulesList = [ruleWithLocation]
+	const listItems = selectFromListMock.mock.calls[0][2].listItems
+	const getRulesByLocationMock = (getRulesByLocation as
+		jest.Mock<Promise<(Rule & WithNamedLocation)[]>, [SmartThingsClient, string | undefined]>)
+		.mockResolvedValue(rulesList)
+
+	expect(await listItems()).toBe(rulesList)
+
+	expect(getRulesByLocationMock).toHaveBeenCalledTimes(1)
+	expect(getRulesByLocationMock).toHaveBeenCalledWith(client, 'location-id')
+})
+
+describe('buildExecuteResponseTableOutput', () => {
+	const buildTableFromItemMock = jest.fn().mockReturnValue('main info')
+	const buildTableFromListMock = jest.fn().mockReturnValue('actions info')
+	const tableGenerator = {
+		buildTableFromItem: buildTableFromItemMock,
+		buildTableFromList: buildTableFromListMock,
+	} as unknown as TableGenerator
+
+	it('includes actions when present', () => {
+		const executeResponse = {
+			id: 'execute-response-id',
+			actions: [{ actionId: 'action-id' }],
+		} as RuleExecutionResponse
+
+		expect(rulesUtil.buildExecuteResponseTableOutput(tableGenerator, executeResponse))
+			.toBe('main info\n\nActions\nactions info')
+
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromItemMock).toHaveBeenCalledWith(executeResponse,
+			['executionId', 'id', 'result'])
+		expect(buildTableFromListMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromListMock).toHaveBeenCalledWith(executeResponse.actions,
+			expect.arrayContaining(['actionId', { path: 'location.locationId' }]))
+	})
+
+	it('leaves out actions table when there are no actions', () => {
+		const executeResponse = { id: 'execute-response-id' } as RuleExecutionResponse
+
+		expect(rulesUtil.buildExecuteResponseTableOutput(tableGenerator, executeResponse))
+			.toBe('main info')
+
+		expect(buildTableFromItemMock).toHaveBeenCalledTimes(1)
+		expect(buildTableFromItemMock).toHaveBeenCalledWith(executeResponse,
+			['executionId', 'id', 'result'])
+		expect(buildTableFromListMock).toHaveBeenCalledTimes(0)
 	})
 })

--- a/packages/cli/src/__tests__/lib/commands/virtualdevices-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/virtualdevices-util.test.ts
@@ -21,440 +21,438 @@ import { Device, DeviceIntegrationType, DeviceProfile, DeviceProfileStatus } fro
 
 jest.mock('../../../lib/commands/deviceprofiles-util')
 
-describe('virtualdevices-util', () => {
-	describe('chooseDeviceName function', () => {
-		const command = {} as unknown as APICommand<typeof APICommand.flags>
+describe('chooseDeviceName function', () => {
+	const command = {} as unknown as APICommand<typeof APICommand.flags>
 
-		test('choose with from prompt', async () => {
-			const promptSpy = jest.spyOn(inquirer, 'prompt')
-			promptSpy.mockResolvedValue({ deviceName: 'Device Name' })
+	test('choose with from prompt', async () => {
+		const promptSpy = jest.spyOn(inquirer, 'prompt')
+		promptSpy.mockResolvedValue({ deviceName: 'Device Name' })
 
-			const value = await chooseDeviceName(command)
-			expect(promptSpy).toHaveBeenCalledTimes(1)
-			expect(promptSpy).toHaveBeenCalledWith({
-				type: 'input', name: 'deviceName',
-				message: 'Device Name:',
-			})
-			expect(value).toBeDefined()
-			expect(value).toBe('Device Name')
+		const value = await chooseDeviceName(command)
+		expect(promptSpy).toHaveBeenCalledTimes(1)
+		expect(promptSpy).toHaveBeenCalledWith({
+			type: 'input', name: 'deviceName',
+			message: 'Device Name:',
 		})
-
-		test('choose with default', async () => {
-			const promptSpy = jest.spyOn(inquirer, 'prompt')
-			promptSpy.mockResolvedValue({ deviceName: 'Another Device Name' })
-
-			const value = await chooseDeviceName(command, 'Device Name')
-			expect(promptSpy).toHaveBeenCalledTimes(0)
-			expect(value).toBeDefined()
-			expect(value).toBe('Device Name')
-		})
+		expect(value).toBeDefined()
+		expect(value).toBe('Device Name')
 	})
 
-	describe('chooseDeviceProfileDefinition function', () => {
-		const chooseDeviceProfileMock = jest.mocked(chooseDeviceProfile)
-		const command = {} as unknown as APIOrganizationCommand<typeof APIOrganizationCommand.flags>
+	test('choose with default', async () => {
+		const promptSpy = jest.spyOn(inquirer, 'prompt')
+		promptSpy.mockResolvedValue({ deviceName: 'Another Device Name' })
 
-		test('choose profile ID from prompt', async () => {
-			chooseDeviceProfileMock.mockResolvedValueOnce('device-profile-id')
+		const value = await chooseDeviceName(command, 'Device Name')
+		expect(promptSpy).toHaveBeenCalledTimes(0)
+		expect(value).toBeDefined()
+		expect(value).toBe('Device Name')
+	})
+})
 
-			const value = await chooseDeviceProfileDefinition(command)
+describe('chooseDeviceProfileDefinition function', () => {
+	const chooseDeviceProfileMock = jest.mocked(chooseDeviceProfile)
+	const command = {} as unknown as APIOrganizationCommand<typeof APIOrganizationCommand.flags>
 
-			expect(chooseDeviceProfileMock).toHaveBeenCalledTimes(1)
-			expect(chooseDeviceProfileMock).toHaveBeenCalledWith(command,
-				undefined,
-				expect.objectContaining({ allowIndex: true }))
-			expect(value).toBeDefined()
-			expect(value).toEqual({ deviceProfileId: 'device-profile-id', deviceProfile: undefined })
-		})
+	test('choose profile ID from prompt', async () => {
+		chooseDeviceProfileMock.mockResolvedValueOnce('device-profile-id')
 
-		test('choose profile ID from default', async () => {
-			const value = await chooseDeviceProfileDefinition(command, 'device-profile-id')
+		const value = await chooseDeviceProfileDefinition(command)
 
-			expect(chooseDeviceProfileMock).toHaveBeenCalledTimes(0)
-			expect(value).toBeDefined()
-			expect(value).toEqual({ deviceProfileId: 'device-profile-id', deviceProfile: undefined })
-		})
+		expect(chooseDeviceProfileMock).toHaveBeenCalledTimes(1)
+		expect(chooseDeviceProfileMock).toHaveBeenCalledWith(command,
+			undefined,
+			expect.objectContaining({ allowIndex: true }))
+		expect(value).toBeDefined()
+		expect(value).toEqual({ deviceProfileId: 'device-profile-id', deviceProfile: undefined })
+	})
 
-		test('choose definition from file argument', async () => {
-			const deviceProfile: DeviceProfile = {
-				id: 'device-profile-id',
-				name: 'name',
-				components: [],
-				status: DeviceProfileStatus.PUBLISHED,
+	test('choose profile ID from default', async () => {
+		const value = await chooseDeviceProfileDefinition(command, 'device-profile-id')
+
+		expect(chooseDeviceProfileMock).toHaveBeenCalledTimes(0)
+		expect(value).toBeDefined()
+		expect(value).toEqual({ deviceProfileId: 'device-profile-id', deviceProfile: undefined })
+	})
+
+	test('choose definition from file argument', async () => {
+		const deviceProfile: DeviceProfile = {
+			id: 'device-profile-id',
+			name: 'name',
+			components: [],
+			status: DeviceProfileStatus.PUBLISHED,
+		}
+
+		const fileSpy = jest.spyOn(fileInputProcessor.prototype, 'read').mockResolvedValueOnce(deviceProfile)
+
+		const value = await chooseDeviceProfileDefinition(command, undefined, 'device-profile-file')
+
+		expect(chooseDeviceProfileMock).toHaveBeenCalledTimes(0)
+		expect(fileSpy).toHaveBeenCalledTimes(1)
+		expect(value).toBeDefined()
+		expect(value).toEqual({ deviceProfileId: undefined, deviceProfile })
+	})
+})
+
+describe('chooseDevicePrototype function', () => {
+	const selectFromListMock = jest.mocked(selectFromList)
+	const command = {} as unknown as APICommand<typeof APICommand.flags>
+
+	test('choose from default list prompt', async () => {
+		selectFromListMock.mockResolvedValueOnce('VIRTUAL_SWITCH')
+
+		const value = await chooseDevicePrototype(command)
+
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(command,
+			expect.objectContaining({
+				primaryKeyName: 'id',
+				listTableFieldDefinitions: ['name', 'id'],
+			}),
+			expect.not.objectContaining({ preselectedId: expect.anything() }))
+		expect(value).toBeDefined()
+		expect(value).toBe('VIRTUAL_SWITCH')
+	})
+
+	test('choose with command line value', async () => {
+		selectFromListMock.mockResolvedValueOnce('VIRTUAL_SWITCH')
+
+		const value = await chooseDevicePrototype(command, 'VIRTUAL_SWITCH')
+
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(command,
+			expect.objectContaining({
+				primaryKeyName: 'id',
+				listTableFieldDefinitions: ['name', 'id'],
+			}),
+			expect.objectContaining({ preselectedId: 'VIRTUAL_SWITCH' }))
+		expect(value).toBeDefined()
+		expect(value).toBe('VIRTUAL_SWITCH')
+	})
+
+	test('choose from extended list prompt', async () => {
+		selectFromListMock.mockResolvedValueOnce('more')
+		selectFromListMock.mockResolvedValueOnce('VIRTUAL_CONTACT_SENSOR')
+
+		const value = await chooseDevicePrototype(command)
+
+		expect(selectFromListMock).toHaveBeenCalledTimes(2)
+		expect(selectFromListMock).toHaveBeenNthCalledWith(1, command,
+			expect.objectContaining({
+				primaryKeyName: 'id',
+				listTableFieldDefinitions: ['name', 'id'],
+			}),
+			expect.toBeObject())
+		expect(selectFromListMock).toHaveBeenNthCalledWith(2, command,
+			expect.objectContaining({
+				primaryKeyName: 'id',
+				listTableFieldDefinitions: ['name', 'id'],
+			}),
+			expect.toBeObject())
+		expect(value).toBeDefined()
+		expect(value).toBe('VIRTUAL_CONTACT_SENSOR')
+	})
+
+	describe('chooseComponent', () => {
+		const command = {} as unknown as APICommand<typeof APICommand.flags>
+		const selectFromListMock = jest.mocked(selectFromList)
+
+		it('returns single component when only one', async () => {
+			selectFromListMock.mockImplementation(async () => 'main')
+			const device: Device = {
+				deviceId: 'device-id',
+				presentationId: 'presentation-id',
+				manufacturerName: 'manufacturer-name',
+				restrictionTier: 1,
+				type: DeviceIntegrationType.VIRTUAL,
+				components: [
+					{
+						id: 'main',
+						capabilities: [],
+						categories: [],
+					},
+				],
 			}
 
-			const fileSpy = jest.spyOn(fileInputProcessor.prototype, 'read').mockResolvedValueOnce(deviceProfile)
+			const component = await chooseComponent(command, device)
+			expect(selectFromListMock).toHaveBeenCalledTimes(1)
+			expect(selectFromListMock).toHaveBeenCalledWith(command,
+				expect.objectContaining({ primaryKeyName: 'id', sortKeyName: 'id' }),
+				expect.objectContaining({ preselectedId: 'main' }))
+			expect(component).toBeDefined()
+			expect(component.id).toBe('main')
+		})
 
-			const value = await chooseDeviceProfileDefinition(command, undefined, 'device-profile-file')
+		it('prompts when multiple components', async () => {
+			selectFromListMock.mockImplementation(async () => 'channel1')
 
-			expect(chooseDeviceProfileMock).toHaveBeenCalledTimes(0)
-			expect(fileSpy).toHaveBeenCalledTimes(1)
-			expect(value).toBeDefined()
-			expect(value).toEqual({ deviceProfileId: undefined, deviceProfile })
+			const device: Device = {
+				deviceId: 'device-id',
+				presentationId: 'presentation-id',
+				manufacturerName: 'manufacturer-name',
+				restrictionTier: 1,
+				type: DeviceIntegrationType.VIRTUAL,
+				components: [
+					{
+						id: 'main',
+						capabilities: [],
+						categories: [],
+					},
+					{
+						id: 'channel1',
+						capabilities: [],
+						categories: [],
+					},
+					{
+						id: 'channel2',
+						capabilities: [],
+						categories: [],
+					},
+				],
+			}
+
+			const component = await chooseComponent(command, device)
+			expect(selectFromListMock).toHaveBeenCalledTimes(1)
+
+			expect(selectFromListMock).toHaveBeenCalledWith(command,
+				expect.objectContaining({ primaryKeyName: 'id', sortKeyName: 'id' }),
+				expect.not.objectContaining({ preselectedId: 'main' }))
+			expect(component).toBeDefined()
+			expect(component.id).toBe('channel1')
 		})
 	})
 
-	describe('chooseDevicePrototype function', () => {
-		const selectFromListMock = jest.mocked(selectFromList)
+	describe('chooseCapability', () => {
 		const command = {} as unknown as APICommand<typeof APICommand.flags>
+		const selectFromListMock = jest.mocked(selectFromList)
 
-		test('choose from default list prompt', async () => {
-			selectFromListMock.mockResolvedValueOnce('VIRTUAL_SWITCH')
+		it('returns single capability when only one', async () => {
+			selectFromListMock.mockImplementation(async () => 'switch')
+			const component = {
+				id: 'main',
+				capabilities: [
+					{
+						id: 'switch',
+						version: 1,
+					},
+				],
+				categories: [],
+			}
 
-			const value = await chooseDevicePrototype(command)
-
+			const capability = await chooseCapability(command, component)
 			expect(selectFromListMock).toHaveBeenCalledTimes(1)
 			expect(selectFromListMock).toHaveBeenCalledWith(command,
-				expect.objectContaining({
-					primaryKeyName: 'id',
-					listTableFieldDefinitions: ['name', 'id'],
-				}),
+				expect.objectContaining({ primaryKeyName: 'id', sortKeyName: 'id' }),
+				expect.objectContaining({ preselectedId: 'switch' }))
+			expect(capability).toBeDefined()
+			expect(capability.id).toBe('switch')
+		})
+
+		it('prompts when multiple capabilities', async () => {
+			selectFromListMock.mockImplementation(async () => 'switchLevel')
+
+			const component = {
+				id: 'main',
+				capabilities: [
+					{
+						id: 'switch',
+						version: 1,
+					},
+					{
+						id: 'switchLevel',
+						version: 1,
+					},
+				],
+				categories: [],
+			}
+
+			const capability = await chooseCapability(command, component)
+			expect(selectFromListMock).toHaveBeenCalledTimes(1)
+			expect(selectFromListMock).toHaveBeenCalledWith(command,
+				expect.objectContaining({ primaryKeyName: 'id', sortKeyName: 'id' }),
 				expect.not.objectContaining({ preselectedId: expect.anything() }))
-			expect(value).toBeDefined()
-			expect(value).toBe('VIRTUAL_SWITCH')
+			expect(capability).toBeDefined()
+			expect(capability.id).toBe('switchLevel')
 		})
+	})
 
-		test('choose with command line value', async () => {
-			selectFromListMock.mockResolvedValueOnce('VIRTUAL_SWITCH')
+	describe('chooseAttribute', () => {
+		const selectFromListMock = jest.mocked(selectFromList)
+		const getCapabilityMock = jest.fn()
+		const client = { capabilities: { get: getCapabilityMock } }
+		const command = { client } as unknown as APICommand<typeof APICommand.flags>
 
-			const value = await chooseDevicePrototype(command, 'VIRTUAL_SWITCH')
-
-			expect(selectFromListMock).toHaveBeenCalledTimes(1)
-			expect(selectFromListMock).toHaveBeenCalledWith(command,
-				expect.objectContaining({
-					primaryKeyName: 'id',
-					listTableFieldDefinitions: ['name', 'id'],
-				}),
-				expect.objectContaining({ preselectedId: 'VIRTUAL_SWITCH' }))
-			expect(value).toBeDefined()
-			expect(value).toBe('VIRTUAL_SWITCH')
-		})
-
-		test('choose from extended list prompt', async () => {
-			selectFromListMock.mockResolvedValueOnce('more')
-			selectFromListMock.mockResolvedValueOnce('VIRTUAL_CONTACT_SENSOR')
-
-			const value = await chooseDevicePrototype(command)
-
-			expect(selectFromListMock).toHaveBeenCalledTimes(2)
-			expect(selectFromListMock).toHaveBeenNthCalledWith(1, command,
-				expect.objectContaining({
-					primaryKeyName: 'id',
-					listTableFieldDefinitions: ['name', 'id'],
-				}),
-				expect.toBeObject())
-			expect(selectFromListMock).toHaveBeenNthCalledWith(2, command,
-				expect.objectContaining({
-					primaryKeyName: 'id',
-					listTableFieldDefinitions: ['name', 'id'],
-				}),
-				expect.toBeObject())
-			expect(value).toBeDefined()
-			expect(value).toBe('VIRTUAL_CONTACT_SENSOR')
-		})
-
-		describe('chooseComponent', () => {
-			const command = {} as unknown as APICommand<typeof APICommand.flags>
-			const selectFromListMock = jest.mocked(selectFromList)
-
-			it('returns single component when only one', async () => {
-				selectFromListMock.mockImplementation(async () => 'main')
-				const device: Device = {
-					deviceId: 'device-id',
-					presentationId: 'presentation-id',
-					manufacturerName: 'manufacturer-name',
-					restrictionTier: 1,
-					type: DeviceIntegrationType.VIRTUAL,
-					components: [
-						{
-							id: 'main',
-							capabilities: [],
-							categories: [],
-						},
-					],
-				}
-
-				const component = await chooseComponent(command, device)
-				expect(selectFromListMock).toHaveBeenCalledTimes(1)
-				expect(selectFromListMock).toHaveBeenCalledWith(command,
-					expect.objectContaining({ primaryKeyName: 'id', sortKeyName: 'id' }),
-					expect.objectContaining({ preselectedId: 'main' }))
-				expect(component).toBeDefined()
-				expect(component.id).toBe('main')
-			})
-
-			it('prompts when multiple components', async () => {
-				selectFromListMock.mockImplementation(async () => 'channel1')
-
-				const device: Device = {
-					deviceId: 'device-id',
-					presentationId: 'presentation-id',
-					manufacturerName: 'manufacturer-name',
-					restrictionTier: 1,
-					type: DeviceIntegrationType.VIRTUAL,
-					components: [
-						{
-							id: 'main',
-							capabilities: [],
-							categories: [],
-						},
-						{
-							id: 'channel1',
-							capabilities: [],
-							categories: [],
-						},
-						{
-							id: 'channel2',
-							capabilities: [],
-							categories: [],
-						},
-					],
-				}
-
-				const component = await chooseComponent(command, device)
-				expect(selectFromListMock).toHaveBeenCalledTimes(1)
-
-				expect(selectFromListMock).toHaveBeenCalledWith(command,
-					expect.objectContaining({ primaryKeyName: 'id', sortKeyName: 'id' }),
-					expect.not.objectContaining({ preselectedId: 'main' }))
-				expect(component).toBeDefined()
-				expect(component.id).toBe('channel1')
-			})
-		})
-
-		describe('chooseCapability', () => {
-			const command = {} as unknown as APICommand<typeof APICommand.flags>
-			const selectFromListMock = jest.mocked(selectFromList)
-
-			it('returns single capability when only one', async () => {
-				selectFromListMock.mockImplementation(async () => 'switch')
-				const component = {
-					id: 'main',
-					capabilities: [
-						{
-							id: 'switch',
-							version: 1,
-						},
-					],
-					categories: [],
-				}
-
-				const capability = await chooseCapability(command, component)
-				expect(selectFromListMock).toHaveBeenCalledTimes(1)
-				expect(selectFromListMock).toHaveBeenCalledWith(command,
-					expect.objectContaining({ primaryKeyName: 'id', sortKeyName: 'id' }),
-					expect.objectContaining({ preselectedId: 'switch' }))
-				expect(capability).toBeDefined()
-				expect(capability.id).toBe('switch')
-			})
-
-			it('prompts when multiple capabilities', async () => {
-				selectFromListMock.mockImplementation(async () => 'switchLevel')
-
-				const component = {
-					id: 'main',
-					capabilities: [
-						{
-							id: 'switch',
-							version: 1,
-						},
-						{
-							id: 'switchLevel',
-							version: 1,
-						},
-					],
-					categories: [],
-				}
-
-				const capability = await chooseCapability(command, component)
-				expect(selectFromListMock).toHaveBeenCalledTimes(1)
-				expect(selectFromListMock).toHaveBeenCalledWith(command,
-					expect.objectContaining({ primaryKeyName: 'id', sortKeyName: 'id' }),
-					expect.not.objectContaining({ preselectedId: expect.anything() }))
-				expect(capability).toBeDefined()
-				expect(capability.id).toBe('switchLevel')
-			})
-		})
-
-		describe('chooseAttribute', () => {
-			const selectFromListMock = jest.mocked(selectFromList)
-			const getCapabilityMock = jest.fn()
-			const client = { capabilities: { get: getCapabilityMock } }
-			const command = { client } as unknown as APICommand<typeof APICommand.flags>
-
-			it('returns single attribute when only one', async () => {
-				selectFromListMock.mockImplementation(async () => 'switch')
-				const capabilityReference = {
-					id: 'switch',
-					version: 1,
-				}
-				const capabilityDefinition = {
-					id: 'switch',
-					version: 1,
-					attributes: {
-						switch: {
-							schema: {
-								type: 'object',
-								properties: {
-									value: {
-										title: 'SwitchState',
-										type: 'string',
-										enum: [
-											'on',
-											'off',
-										],
-									},
+		it('returns single attribute when only one', async () => {
+			selectFromListMock.mockImplementation(async () => 'switch')
+			const capabilityReference = {
+				id: 'switch',
+				version: 1,
+			}
+			const capabilityDefinition = {
+				id: 'switch',
+				version: 1,
+				attributes: {
+					switch: {
+						schema: {
+							type: 'object',
+							properties: {
+								value: {
+									title: 'SwitchState',
+									type: 'string',
+									enum: [
+										'on',
+										'off',
+									],
 								},
 							},
 						},
 					},
-				}
-				getCapabilityMock.mockImplementation(async () => capabilityDefinition)
+				},
+			}
+			getCapabilityMock.mockImplementation(async () => capabilityDefinition)
 
-				const attribute = await chooseAttribute(command, capabilityReference)
-				expect(selectFromListMock).toHaveBeenCalledTimes(1)
-				expect(selectFromListMock).toHaveBeenCalledWith(command,
-					expect.objectContaining({ primaryKeyName: 'attributeName', sortKeyName: 'attributeName' }),
-					expect.objectContaining({ preselectedId: 'switch' }))
-				expect(attribute).toBeDefined()
-				expect(attribute.attributeName).toBe('switch')
-			})
+			const attribute = await chooseAttribute(command, capabilityReference)
+			expect(selectFromListMock).toHaveBeenCalledTimes(1)
+			expect(selectFromListMock).toHaveBeenCalledWith(command,
+				expect.objectContaining({ primaryKeyName: 'attributeName', sortKeyName: 'attributeName' }),
+				expect.objectContaining({ preselectedId: 'switch' }))
+			expect(attribute).toBeDefined()
+			expect(attribute.attributeName).toBe('switch')
+		})
+	})
+
+	describe('chooseValue', () => {
+		const selectFromListMock = jest.mocked(selectFromList)
+		const command = {} as unknown as APICommand<typeof APICommand.flags>
+
+		test('enum value', async () => {
+			selectFromListMock.mockImplementation(async () => 'on')
+			const attribute = {
+				schema: {
+					type: 'object',
+					properties: {
+						value: {
+							title: 'SwitchState',
+							type: 'string',
+							enum: [
+								'on',
+								'off',
+							],
+						},
+					},
+					additionalProperties: false,
+				},
+			}
+
+			const value = await chooseValue(command, attribute, 'switch')
+			expect(selectFromListMock).toHaveBeenCalledTimes(1)
+			expect(selectFromListMock).toHaveBeenCalledWith(command,
+				expect.objectContaining({ primaryKeyName: 'value', sortKeyName: 'value' }),
+				expect.toBeObject())
+			expect(value).toBeDefined()
+			expect(value).toBe('on')
 		})
 
-		describe('chooseValue', () => {
-			const selectFromListMock = jest.mocked(selectFromList)
-			const command = {} as unknown as APICommand<typeof APICommand.flags>
-
-			test('enum value', async () => {
-				selectFromListMock.mockImplementation(async () => 'on')
-				const attribute = {
-					schema: {
-						type: 'object',
-						properties: {
-							value: {
-								title: 'SwitchState',
-								type: 'string',
-								enum: [
-									'on',
-									'off',
-								],
-							},
+		test('numeric value', async () => {
+			const promptSpy = jest.spyOn(inquirer, 'prompt')
+			promptSpy.mockResolvedValue({ value: '72' })
+			const attribute = {
+				schema: {
+					type: 'object',
+					properties: {
+						value: {
+							title: 'TemperatureValue',
+							type: 'number',
+							minimum: -460,
+							maximum: 10000,
 						},
-						additionalProperties: false,
-					},
-				}
-
-				const value = await chooseValue(command, attribute, 'switch')
-				expect(selectFromListMock).toHaveBeenCalledTimes(1)
-				expect(selectFromListMock).toHaveBeenCalledWith(command,
-					expect.objectContaining({ primaryKeyName: 'value', sortKeyName: 'value' }),
-					expect.toBeObject())
-				expect(value).toBeDefined()
-				expect(value).toBe('on')
-			})
-
-			test('numeric value', async () => {
-				const promptSpy = jest.spyOn(inquirer, 'prompt')
-				promptSpy.mockResolvedValue({ value: '72' })
-				const attribute = {
-					schema: {
-						type: 'object',
-						properties: {
-							value: {
-								title: 'TemperatureValue',
-								type: 'number',
-								minimum: -460,
-								maximum: 10000,
-							},
-							unit: {
-								type: 'string',
-								enum: [
-									'F',
-									'C',
-								],
-							},
+						unit: {
+							type: 'string',
+							enum: [
+								'F',
+								'C',
+							],
 						},
-						additionalProperties: false,
 					},
-				}
+					additionalProperties: false,
+				},
+			}
 
-				const value = await chooseValue(command, attribute, 'temperature')
-				expect(selectFromListMock).toHaveBeenCalledTimes(0)
-				expect(promptSpy).toHaveBeenCalledTimes(1)
-				expect(promptSpy).toHaveBeenCalledWith({
-					type: 'input', name: 'value',
-					message: 'Enter \'temperature\' attribute value:',
-				})
-				expect(value).toBeDefined()
-				expect(value).toBe('72')
+			const value = await chooseValue(command, attribute, 'temperature')
+			expect(selectFromListMock).toHaveBeenCalledTimes(0)
+			expect(promptSpy).toHaveBeenCalledTimes(1)
+			expect(promptSpy).toHaveBeenCalledWith({
+				type: 'input', name: 'value',
+				message: 'Enter \'temperature\' attribute value:',
 			})
+			expect(value).toBeDefined()
+			expect(value).toBe('72')
+		})
+	})
+
+	describe('chooseUnit', () => {
+		const selectFromListMock = jest.mocked(selectFromList)
+		const command = {} as unknown as APICommand<typeof APICommand.flags>
+
+		it('prompts when multiple units', async () => {
+			selectFromListMock.mockImplementation(async () => 'F')
+			const attribute = {
+				schema: {
+					type: 'object',
+					properties: {
+						value: {
+							title: 'TemperatureValue',
+							type: 'number',
+							minimum: -460,
+							maximum: 10000,
+						},
+						unit: {
+							type: 'string',
+							enum: [
+								'F',
+								'C',
+							],
+						},
+					},
+					additionalProperties: false,
+				},
+			}
+
+			const unit = await chooseUnit(command, attribute)
+			expect(selectFromListMock).toHaveBeenCalledTimes(1)
+			expect(selectFromListMock).toHaveBeenCalledWith(command,
+				expect.objectContaining({ primaryKeyName: 'unit', sortKeyName: 'unit' }),
+				expect.not.objectContaining({ preselectedId: expect.anything() }))
+			expect(unit).toBeDefined()
+			expect(unit).toBe('F')
 		})
 
-		describe('chooseUnit', () => {
-			const selectFromListMock = jest.mocked(selectFromList)
-			const command = {} as unknown as APICommand<typeof APICommand.flags>
-
-			it('prompts when multiple units', async () => {
-				selectFromListMock.mockImplementation(async () => 'F')
-				const attribute = {
-					schema: {
-						type: 'object',
-						properties: {
-							value: {
-								title: 'TemperatureValue',
-								type: 'number',
-								minimum: -460,
-								maximum: 10000,
-							},
-							unit: {
-								type: 'string',
-								enum: [
-									'F',
-									'C',
-								],
-							},
+		it('does not prompt when only one unit', async () => {
+			selectFromListMock.mockImplementation(async () => 'ppm')
+			const attribute = {
+				schema: {
+					type: 'object',
+					properties: {
+						value: {
+							type: 'number',
+							minimum: 0,
+							maximum: 1000000,
 						},
-						additionalProperties: false,
-					},
-				}
-
-				const unit = await chooseUnit(command, attribute)
-				expect(selectFromListMock).toHaveBeenCalledTimes(1)
-				expect(selectFromListMock).toHaveBeenCalledWith(command,
-					expect.objectContaining({ primaryKeyName: 'unit', sortKeyName: 'unit' }),
-					expect.not.objectContaining({ preselectedId: expect.anything() }))
-				expect(unit).toBeDefined()
-				expect(unit).toBe('F')
-			})
-
-			it('does not prompt when only one unit', async () => {
-				selectFromListMock.mockImplementation(async () => 'ppm')
-				const attribute = {
-					schema: {
-						type: 'object',
-						properties: {
-							value: {
-								type: 'number',
-								minimum: 0,
-								maximum: 1000000,
-							},
-							unit: {
-								type: 'string',
-								enum: ['ppm'],
-							},
+						unit: {
+							type: 'string',
+							enum: ['ppm'],
 						},
-						additionalProperties: false,
 					},
-				}
+					additionalProperties: false,
+				},
+			}
 
-				const unit = await chooseUnit(command, attribute)
-				expect(selectFromListMock).toHaveBeenCalledTimes(1)
-				expect(selectFromListMock).toHaveBeenCalledWith(command,
-					expect.objectContaining({ primaryKeyName: 'unit', sortKeyName: 'unit' }),
-					expect.objectContaining({ preselectedId: 'ppm' }))
-				expect(unit).toBeDefined()
-				expect(unit).toBe('ppm')
-			})
+			const unit = await chooseUnit(command, attribute)
+			expect(selectFromListMock).toHaveBeenCalledTimes(1)
+			expect(selectFromListMock).toHaveBeenCalledWith(command,
+				expect.objectContaining({ primaryKeyName: 'unit', sortKeyName: 'unit' }),
+				expect.objectContaining({ preselectedId: 'ppm' }))
+			expect(unit).toBeDefined()
+			expect(unit).toBe('ppm')
 		})
 	})
 })

--- a/packages/edge/src/__tests__/lib/commands/channels-util.test.ts
+++ b/packages/edge/src/__tests__/lib/commands/channels-util.test.ts
@@ -17,308 +17,306 @@ jest.mock('@smartthings/cli-lib', () => ({
 }))
 
 
-describe('channels-util', () => {
-	describe('chooseChannelOptionsWithDefaults', () => {
-		const chooseOptionsWithDefaultsMock = jest.mocked(chooseOptionsWithDefaults)
+describe('chooseChannelOptionsWithDefaults', () => {
+	const chooseOptionsWithDefaultsMock = jest.mocked(chooseOptionsWithDefaults)
 
-		it('has a reasonable default', () => {
-			chooseOptionsWithDefaultsMock.mockReturnValue({} as ChooseChannelOptions)
+	it('has a reasonable default', () => {
+		chooseOptionsWithDefaultsMock.mockReturnValue({} as ChooseChannelOptions)
 
-			expect(chooseChannelOptionsWithDefaults())
-				.toEqual(expect.objectContaining({ includeReadOnly: false }))
+		expect(chooseChannelOptionsWithDefaults())
+			.toEqual(expect.objectContaining({ includeReadOnly: false }))
 
-			expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledTimes(1)
-			expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledWith(undefined)
-		})
-
-		it('accepts true value', () => {
-			chooseOptionsWithDefaultsMock.mockReturnValue({ includeReadOnly: true } as ChooseChannelOptions)
-
-			expect(chooseChannelOptionsWithDefaults({ includeReadOnly: true }))
-				.toEqual(expect.objectContaining({ includeReadOnly: true }))
-
-			expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledTimes(1)
-			expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledWith({ includeReadOnly: true })
-		})
+		expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledTimes(1)
+		expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledWith(undefined)
 	})
 
-	describe('chooseChannel', () => {
-		const channel = { channelId: 'channel-id', name: 'channel name' } as Channel
+	it('accepts true value', () => {
+		chooseOptionsWithDefaultsMock.mockReturnValue({ includeReadOnly: true } as ChooseChannelOptions)
 
-		const selectFromListMock = jest.mocked(selectFromList)
+		expect(chooseChannelOptionsWithDefaults({ includeReadOnly: true }))
+			.toEqual(expect.objectContaining({ includeReadOnly: true }))
 
-		const listChannelsMock = jest.fn()
-		const getChannelsMock = jest.fn()
-		const client = { channels: { list: listChannelsMock, get: getChannelsMock } }
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		const flags = { 'all-organizations': false, 'include-read-only': false }
-		const command = { client, flags } as unknown as APICommand<typeof APICommand.flags>
+		expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledTimes(1)
+		expect(chooseOptionsWithDefaultsMock).toHaveBeenCalledWith({ includeReadOnly: true })
+	})
+})
 
-		const chooseChannelOptionsWithDefaultsSpy = jest.spyOn(channelsUtil, 'chooseChannelOptionsWithDefaults')
-		const stringTranslateToIdMock = jest.mocked(stringTranslateToId)
+describe('chooseChannel', () => {
+	const channel = { channelId: 'channel-id', name: 'channel name' } as Channel
 
-		it('uses default channel if specified', async () => {
+	const selectFromListMock = jest.mocked(selectFromList)
+
+	const listChannelsMock = jest.fn()
+	const getChannelsMock = jest.fn()
+	const client = { channels: { list: listChannelsMock, get: getChannelsMock } }
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	const flags = { 'all-organizations': false, 'include-read-only': false }
+	const command = { client, flags } as unknown as APICommand<typeof APICommand.flags>
+
+	const chooseChannelOptionsWithDefaultsSpy = jest.spyOn(channelsUtil, 'chooseChannelOptionsWithDefaults')
+	const stringTranslateToIdMock = jest.mocked(stringTranslateToId)
+
+	it('uses default channel if specified', async () => {
+		chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce(
+			{ allowIndex: false, useConfigDefault: true } as ChooseChannelOptions)
+		selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
+
+		expect(await chooseChannel(command, 'prompt message', undefined, { useConfigDefault: true }))
+			.toBe('chosen-channel-id')
+
+		expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
+		expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith({ useConfigDefault: true })
+		expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(command,
+			expect.objectContaining({ primaryKeyName: 'channelId', sortKeyName: 'name' }),
+			expect.objectContaining({
+				defaultValue: { configKey: 'defaultChannel', getItem: expect.any(Function), userMessage: expect.any(Function) },
+				promptMessage: 'prompt message',
+			}))
+	})
+
+	it('translates id from index if allowed', async () => {
+		chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce(
+			{ allowIndex: true } as ChooseChannelOptions)
+		stringTranslateToIdMock.mockResolvedValueOnce('translated-id')
+		selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
+
+		expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id',
+			{ allowIndex: true })).toBe('chosen-channel-id')
+
+		expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
+		expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith({ allowIndex: true })
+		expect(stringTranslateToIdMock).toHaveBeenCalledTimes(1)
+		expect(stringTranslateToIdMock).toHaveBeenCalledWith(
+			expect.objectContaining({ primaryKeyName: 'channelId', sortKeyName: 'name' }),
+			'command-line-channel-id', expect.any(Function))
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(command,
+			expect.objectContaining({ primaryKeyName: 'channelId', sortKeyName: 'name' }),
+			expect.objectContaining({ preselectedId: 'translated-id' }))
+	})
+
+	it('uses listItems from options', async () => {
+		const listItemsMock = jest.fn()
+
+		chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce({} as ChooseChannelOptions)
+		selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
+
+		expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id',
+			{ listItems: listItemsMock })).toBe('chosen-channel-id')
+
+		expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
+		expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith({ listItems: listItemsMock })
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(command,
+			expect.objectContaining({ primaryKeyName: 'channelId', sortKeyName: 'name' }),
+			expect.objectContaining({ listItems: listItemsMock }))
+	})
+
+	it('uses list function that lists channels', async () => {
+		chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce(
+			{ allowIndex: false, includeReadOnly: false } as ChooseChannelOptions)
+		selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
+
+		expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id'))
+			.toBe('chosen-channel-id')
+
+		expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
+		expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith(undefined)
+		expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(command,
+			expect.objectContaining({ primaryKeyName: 'channelId', sortKeyName: 'name' }),
+			expect.objectContaining({ preselectedId: 'command-line-channel-id' }))
+
+		const listItems = selectFromListMock.mock.calls[0][2].listItems
+
+		const list = [{ name: 'Channel' }] as Channel[]
+		listChannelsMock.mockResolvedValueOnce(list)
+
+		expect(await listItems()).toBe(list)
+
+		expect(listChannelsMock).toHaveBeenCalledTimes(1)
+		expect(listChannelsMock).toHaveBeenCalledWith({ includeReadOnly: false })
+	})
+
+	it('requests read-only channels when needed', async () => {
+		chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce(
+			{ allowIndex: false, includeReadOnly: true } as ChooseChannelOptions)
+		selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
+
+		expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id'))
+			.toBe('chosen-channel-id')
+
+		expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
+		expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith(undefined)
+		expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(command,
+			expect.objectContaining({ primaryKeyName: 'channelId', sortKeyName: 'name' }),
+			expect.objectContaining({ preselectedId: 'command-line-channel-id' }))
+
+		const listItems = selectFromListMock.mock.calls[0][2].listItems
+
+		const list = [{ name: 'Channel' }] as Channel[]
+		listChannelsMock.mockResolvedValueOnce(list)
+
+		expect(await listItems()).toBe(list)
+
+		expect(listChannelsMock).toHaveBeenCalledTimes(1)
+		expect(listChannelsMock).toHaveBeenCalledWith({ includeReadOnly: true })
+	})
+
+	describe('defaultConfig', () => {
+		test('getItem uses channels.get', async () => {
 			chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce(
 				{ allowIndex: false, useConfigDefault: true } as ChooseChannelOptions)
 			selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
 
-			expect(await chooseChannel(command, 'prompt message', undefined, { useConfigDefault: true }))
-				.toBe('chosen-channel-id')
+			expect(await chooseChannel(command, 'prompt message', undefined,
+				{ useConfigDefault: true })).toBe('chosen-channel-id')
 
-			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
-			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith({ useConfigDefault: true })
-			expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
-			expect(selectFromListMock).toHaveBeenCalledTimes(1)
-			expect(selectFromListMock).toHaveBeenCalledWith(command,
-				expect.objectContaining({ primaryKeyName: 'channelId', sortKeyName: 'name' }),
-				expect.objectContaining({
-					defaultValue: { configKey: 'defaultChannel', getItem: expect.any(Function), userMessage: expect.any(Function) },
-					promptMessage: 'prompt message',
-				}))
+			const defaultValue = selectFromListMock.mock.calls[0][2].defaultValue
+
+			expect(defaultValue).toBeDefined()
+			const getItem = defaultValue?.getItem as (id: string) => Promise<Channel>
+			expect(getItem).toBeDefined()
+			getChannelsMock.mockResolvedValueOnce(channel)
+
+			expect(await getItem('id-to-check')).toBe(channel)
+
+			expect(getChannelsMock).toHaveBeenCalledTimes(1)
+			expect(getChannelsMock).toHaveBeenCalledWith('id-to-check')
 		})
 
-		it('translates id from index if allowed', async () => {
+		test('userMessage returns expected message', async () => {
 			chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce(
-				{ allowIndex: true } as ChooseChannelOptions)
-			stringTranslateToIdMock.mockResolvedValueOnce('translated-id')
+				{ allowIndex: false, useConfigDefault: true } as ChooseChannelOptions)
 			selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
 
-			expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id',
-				{ allowIndex: true })).toBe('chosen-channel-id')
+			expect(await chooseChannel(command, 'prompt message', undefined,
+				{ useConfigDefault: true })).toBe('chosen-channel-id')
 
-			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
-			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith({ allowIndex: true })
-			expect(stringTranslateToIdMock).toHaveBeenCalledTimes(1)
-			expect(stringTranslateToIdMock).toHaveBeenCalledWith(
-				expect.objectContaining({ primaryKeyName: 'channelId', sortKeyName: 'name' }),
-				'command-line-channel-id', expect.any(Function))
-			expect(selectFromListMock).toHaveBeenCalledTimes(1)
-			expect(selectFromListMock).toHaveBeenCalledWith(command,
-				expect.objectContaining({ primaryKeyName: 'channelId', sortKeyName: 'name' }),
-				expect.objectContaining({ preselectedId: 'translated-id' }))
-		})
+			const defaultValue = selectFromListMock.mock.calls[0][2].defaultValue
 
-		it('uses listItems from options', async () => {
-			const listItemsMock = jest.fn()
+			expect(defaultValue).toBeDefined()
+			const userMessage = defaultValue?.userMessage as (channel: Channel) => string
+			expect(userMessage).toBeDefined()
 
-			chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce({} as ChooseChannelOptions)
-			selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
-
-			expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id',
-				{ listItems: listItemsMock })).toBe('chosen-channel-id')
-
-			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
-			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith({ listItems: listItemsMock })
-			expect(selectFromListMock).toHaveBeenCalledTimes(1)
-			expect(selectFromListMock).toHaveBeenCalledWith(command,
-				expect.objectContaining({ primaryKeyName: 'channelId', sortKeyName: 'name' }),
-				expect.objectContaining({ listItems: listItemsMock }))
-		})
-
-		it('uses list function that lists channels', async () => {
-			chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce(
-				{ allowIndex: false, includeReadOnly: false } as ChooseChannelOptions)
-			selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
-
-			expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id'))
-				.toBe('chosen-channel-id')
-
-			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
-			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith(undefined)
-			expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
-			expect(selectFromListMock).toHaveBeenCalledTimes(1)
-			expect(selectFromListMock).toHaveBeenCalledWith(command,
-				expect.objectContaining({ primaryKeyName: 'channelId', sortKeyName: 'name' }),
-				expect.objectContaining({ preselectedId: 'command-line-channel-id' }))
-
-			const listItems = selectFromListMock.mock.calls[0][2].listItems
-
-			const list = [{ name: 'Channel' }] as Channel[]
-			listChannelsMock.mockResolvedValueOnce(list)
-
-			expect(await listItems()).toBe(list)
-
-			expect(listChannelsMock).toHaveBeenCalledTimes(1)
-			expect(listChannelsMock).toHaveBeenCalledWith({ includeReadOnly: false })
-		})
-
-		it('requests read-only channels when needed', async () => {
-			chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce(
-				{ allowIndex: false, includeReadOnly: true } as ChooseChannelOptions)
-			selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
-
-			expect(await chooseChannel(command, 'prompt message', 'command-line-channel-id'))
-				.toBe('chosen-channel-id')
-
-			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledTimes(1)
-			expect(chooseChannelOptionsWithDefaultsSpy).toHaveBeenCalledWith(undefined)
-			expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
-			expect(selectFromListMock).toHaveBeenCalledTimes(1)
-			expect(selectFromListMock).toHaveBeenCalledWith(command,
-				expect.objectContaining({ primaryKeyName: 'channelId', sortKeyName: 'name' }),
-				expect.objectContaining({ preselectedId: 'command-line-channel-id' }))
-
-			const listItems = selectFromListMock.mock.calls[0][2].listItems
-
-			const list = [{ name: 'Channel' }] as Channel[]
-			listChannelsMock.mockResolvedValueOnce(list)
-
-			expect(await listItems()).toBe(list)
-
-			expect(listChannelsMock).toHaveBeenCalledTimes(1)
-			expect(listChannelsMock).toHaveBeenCalledWith({ includeReadOnly: true })
-		})
-
-		describe('defaultConfig', () => {
-			test('getItem uses channels.get', async () => {
-				chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce(
-					{ allowIndex: false, useConfigDefault: true } as ChooseChannelOptions)
-				selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
-
-				expect(await chooseChannel(command, 'prompt message', undefined,
-					{ useConfigDefault: true })).toBe('chosen-channel-id')
-
-				const defaultValue = selectFromListMock.mock.calls[0][2].defaultValue
-
-				expect(defaultValue).toBeDefined()
-				const getItem = defaultValue?.getItem as (id: string) => Promise<Channel>
-				expect(getItem).toBeDefined()
-				getChannelsMock.mockResolvedValueOnce(channel)
-
-				expect(await getItem('id-to-check')).toBe(channel)
-
-				expect(getChannelsMock).toHaveBeenCalledTimes(1)
-				expect(getChannelsMock).toHaveBeenCalledWith('id-to-check')
-			})
-
-			test('userMessage returns expected message', async () => {
-				chooseChannelOptionsWithDefaultsSpy.mockReturnValueOnce(
-					{ allowIndex: false, useConfigDefault: true } as ChooseChannelOptions)
-				selectFromListMock.mockImplementation(async () => 'chosen-channel-id')
-
-				expect(await chooseChannel(command, 'prompt message', undefined,
-					{ useConfigDefault: true })).toBe('chosen-channel-id')
-
-				const defaultValue = selectFromListMock.mock.calls[0][2].defaultValue
-
-				expect(defaultValue).toBeDefined()
-				const userMessage = defaultValue?.userMessage as (channel: Channel) => string
-				expect(userMessage).toBeDefined()
-
-				expect(userMessage(channel)).toBe('using previously specified default channel named "channel name" (channel-id)')
-			})
+			expect(userMessage(channel)).toBe('using previously specified default channel named "channel name" (channel-id)')
 		})
 	})
+})
 
-	const apiListChannelsMock = jest.fn()
-	const apiGetChannelsMock = jest.fn()
-	const client = {
-		channels: {
-			list: apiListChannelsMock,
-			get: apiGetChannelsMock,
+const apiListChannelsMock = jest.fn()
+const apiGetChannelsMock = jest.fn()
+const client = {
+	channels: {
+		list: apiListChannelsMock,
+		get: apiGetChannelsMock,
+	},
+} as unknown as SmartThingsClient
+
+describe('listChannels', () => {
+	const result = [
+		{
+			'channelId': 'channel-id',
+			'name': 'Channel Name',
 		},
-	} as unknown as SmartThingsClient
+	]
+	apiListChannelsMock.mockResolvedValue(result)
 
-	describe('listChannels', () => {
-		const result = [
-			{
-				'channelId': 'channel-id',
-				'name': 'Channel Name',
-			},
-		]
-		apiListChannelsMock.mockResolvedValue(result)
+	it('lists channels', async () => {
+		expect(await listChannels(client)).toBe(result)
 
-		it('lists channels', async () => {
-			expect(await listChannels(client)).toBe(result)
+		expect(apiListChannelsMock).toHaveBeenCalledTimes(1)
+		expect(apiListChannelsMock).toHaveBeenCalledWith(expect.not.objectContaining({ includeReadOnly: true }))
+	})
 
-			expect(apiListChannelsMock).toHaveBeenCalledTimes(1)
-			expect(apiListChannelsMock).toHaveBeenCalledWith(expect.not.objectContaining({ includeReadOnly: true }))
-		})
+	it('lists channels including read-only', async () => {
+		expect(await listChannels(client, { allOrganizations: false, includeReadOnly: true })).toBe(result)
 
-		it('lists channels including read-only', async () => {
-			expect(await listChannels(client, { allOrganizations: false, includeReadOnly: true })).toBe(result)
+		expect(apiListChannelsMock).toHaveBeenCalledTimes(1)
+		expect(apiListChannelsMock).toHaveBeenCalledWith({ includeReadOnly: true })
+	})
 
-			expect(apiListChannelsMock).toHaveBeenCalledTimes(1)
-			expect(apiListChannelsMock).toHaveBeenCalledWith({ includeReadOnly: true })
-		})
+	it('passes subscriber filters on', async () => {
+		expect(await listChannels(client, { subscriberType: 'HUB', subscriberId: 'subscriber-id', allOrganizations: false, includeReadOnly: false })).toBe(result)
 
-		it('passes subscriber filters on', async () => {
-			expect(await listChannels(client, { subscriberType: 'HUB', subscriberId: 'subscriber-id', allOrganizations: false, includeReadOnly: false })).toBe(result)
-
-			expect(apiListChannelsMock).toHaveBeenCalledTimes(1)
-			expect(apiListChannelsMock).toHaveBeenCalledWith({
-				includeReadOnly: false, subscriberType: 'HUB', subscriberId: 'subscriber-id',
-			})
-		})
-
-		it('lists channels in all organizations', async () => {
-			const thisResult = [
-				{ ...result[0], organization: 'Organization One' },
-				{ ...result[0], organization: 'Organization Two' },
-			]
-			const forAllOrganizationsMock = jest.mocked(forAllOrganizations).mockResolvedValueOnce(thisResult)
-
-			expect(await listChannels(client, { allOrganizations: true, includeReadOnly: false })).toStrictEqual(thisResult)
-
-			expect(forAllOrganizationsMock).toHaveBeenCalledTimes(1)
-			expect(forAllOrganizationsMock).toHaveBeenCalledWith(client, expect.any(Function))
-			expect(apiListChannelsMock).toHaveBeenCalledTimes(0)
-
-			const listChannelsFunction = forAllOrganizationsMock.mock.calls[0][1]
-
-			expect(await listChannelsFunction(client, { organizationId: 'unused' } as OrganizationResponse)).toBe(result)
-		})
-
-		it('throws error when both allOrganizations and includeReadOnly included', async () => {
-			await expect(listChannels(client, { allOrganizations: true, includeReadOnly: true }))
-				.rejects.toThrow('includeReadOnly and allOrganizations options are incompatible')
+		expect(apiListChannelsMock).toHaveBeenCalledTimes(1)
+		expect(apiListChannelsMock).toHaveBeenCalledWith({
+			includeReadOnly: false, subscriberType: 'HUB', subscriberId: 'subscriber-id',
 		})
 	})
 
-	describe('withChannelNames', () => {
-		const thingWithChannel1 = { channelId: 'channel-id-1' }
-		const channel1 = { channelId: 'channel-id-1', name: 'Channel 1' } as Channel
-		const thingWithChannel2 = { channelId: 'channel-id-2' }
-		const channel2 = { channelId: 'channel-id-2', name: 'Channel 2' } as Channel
+	it('lists channels in all organizations', async () => {
+		const thisResult = [
+			{ ...result[0], organization: 'Organization One' },
+			{ ...result[0], organization: 'Organization Two' },
+		]
+		const forAllOrganizationsMock = jest.mocked(forAllOrganizations).mockResolvedValueOnce(thisResult)
 
-		it('adds channel name to single item', async () => {
-			apiGetChannelsMock.mockResolvedValueOnce(channel1)
+		expect(await listChannels(client, { allOrganizations: true, includeReadOnly: false })).toStrictEqual(thisResult)
 
-			expect(await withChannelNames(client, thingWithChannel1)).toStrictEqual(
-				{ channelId: 'channel-id-1', channelName: 'Channel 1' },
-			)
+		expect(forAllOrganizationsMock).toHaveBeenCalledTimes(1)
+		expect(forAllOrganizationsMock).toHaveBeenCalledWith(client, expect.any(Function))
+		expect(apiListChannelsMock).toHaveBeenCalledTimes(0)
 
-			expect(apiListChannelsMock).toHaveBeenCalledTimes(0)
-			expect(apiGetChannelsMock).toHaveBeenCalledTimes(1)
-			expect(apiGetChannelsMock).toHaveBeenCalledWith('channel-id-1')
-		})
+		const listChannelsFunction = forAllOrganizationsMock.mock.calls[0][1]
 
-		it('adds channel name to multiple items', async () => {
-			apiListChannelsMock.mockResolvedValueOnce([channel1, channel2])
+		expect(await listChannelsFunction(client, { organizationId: 'unused' } as OrganizationResponse)).toBe(result)
+	})
 
-			expect(await withChannelNames(client, [thingWithChannel1, thingWithChannel2])).toStrictEqual([
-				{ channelId: 'channel-id-1', channelName: 'Channel 1' },
-				{ channelId: 'channel-id-2', channelName: 'Channel 2' },
-			])
+	it('throws error when both allOrganizations and includeReadOnly included', async () => {
+		await expect(listChannels(client, { allOrganizations: true, includeReadOnly: true }))
+			.rejects.toThrow('includeReadOnly and allOrganizations options are incompatible')
+	})
+})
 
-			expect(apiListChannelsMock).toHaveBeenCalledTimes(1)
-			expect(apiListChannelsMock).toHaveBeenCalledWith(expect.objectContaining({ includeReadOnly: true }))
-			expect(apiGetChannelsMock).toHaveBeenCalledTimes(0)
-		})
+describe('withChannelNames', () => {
+	const thingWithChannel1 = { channelId: 'channel-id-1' }
+	const channel1 = { channelId: 'channel-id-1', name: 'Channel 1' } as Channel
+	const thingWithChannel2 = { channelId: 'channel-id-2' }
+	const channel2 = { channelId: 'channel-id-2', name: 'Channel 2' } as Channel
 
-		it('looks up and adds channel name when missing from list', async () => {
-			apiListChannelsMock.mockResolvedValueOnce([channel1])
-			apiGetChannelsMock.mockResolvedValueOnce(channel2)
+	it('adds channel name to single item', async () => {
+		apiGetChannelsMock.mockResolvedValueOnce(channel1)
 
-			expect(await withChannelNames(client, [thingWithChannel1, thingWithChannel2])).toStrictEqual([
-				{ channelId: 'channel-id-1', channelName: 'Channel 1' },
-				{ channelId: 'channel-id-2', channelName: 'Channel 2' },
-			])
+		expect(await withChannelNames(client, thingWithChannel1)).toStrictEqual(
+			{ channelId: 'channel-id-1', channelName: 'Channel 1' },
+		)
 
-			expect(apiListChannelsMock).toHaveBeenCalledTimes(1)
-			expect(apiListChannelsMock).toHaveBeenCalledWith(expect.objectContaining({ includeReadOnly: true }))
-			expect(apiGetChannelsMock).toHaveBeenCalledTimes(1)
-			expect(apiGetChannelsMock).toHaveBeenCalledWith('channel-id-2')
-		})
+		expect(apiListChannelsMock).toHaveBeenCalledTimes(0)
+		expect(apiGetChannelsMock).toHaveBeenCalledTimes(1)
+		expect(apiGetChannelsMock).toHaveBeenCalledWith('channel-id-1')
+	})
+
+	it('adds channel name to multiple items', async () => {
+		apiListChannelsMock.mockResolvedValueOnce([channel1, channel2])
+
+		expect(await withChannelNames(client, [thingWithChannel1, thingWithChannel2])).toStrictEqual([
+			{ channelId: 'channel-id-1', channelName: 'Channel 1' },
+			{ channelId: 'channel-id-2', channelName: 'Channel 2' },
+		])
+
+		expect(apiListChannelsMock).toHaveBeenCalledTimes(1)
+		expect(apiListChannelsMock).toHaveBeenCalledWith(expect.objectContaining({ includeReadOnly: true }))
+		expect(apiGetChannelsMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('looks up and adds channel name when missing from list', async () => {
+		apiListChannelsMock.mockResolvedValueOnce([channel1])
+		apiGetChannelsMock.mockResolvedValueOnce(channel2)
+
+		expect(await withChannelNames(client, [thingWithChannel1, thingWithChannel2])).toStrictEqual([
+			{ channelId: 'channel-id-1', channelName: 'Channel 1' },
+			{ channelId: 'channel-id-2', channelName: 'Channel 2' },
+		])
+
+		expect(apiListChannelsMock).toHaveBeenCalledTimes(1)
+		expect(apiListChannelsMock).toHaveBeenCalledWith(expect.objectContaining({ includeReadOnly: true }))
+		expect(apiGetChannelsMock).toHaveBeenCalledTimes(1)
+		expect(apiGetChannelsMock).toHaveBeenCalledWith('channel-id-2')
 	})
 })

--- a/packages/edge/src/__tests__/lib/commands/drivers/package-util.test.ts
+++ b/packages/edge/src/__tests__/lib/commands/drivers/package-util.test.ts
@@ -31,483 +31,481 @@ jest.mock('js-yaml')
 jest.mock('picomatch')
 jest.mock('../../../../../src/lib/file-util')
 
-describe('package-utils', () => {
-	// For some reason jest.mocked produces the wrong type signature for readdirSyncMock
-	const readdirSyncMock = fs.readdirSync as unknown as jest.Mock<string[], [string]>
-	const readStreamMock: fs.ReadStream = {} as fs.ReadStream
-	const createReadStreamMock = jest.mocked(fs.createReadStream)
+// For some reason jest.mocked produces the wrong type signature for readdirSyncMock
+const readdirSyncMock = fs.readdirSync as unknown as jest.Mock<string[], [string]>
+const readStreamMock: fs.ReadStream = {} as fs.ReadStream
+const createReadStreamMock = jest.mocked(fs.createReadStream)
 
-	const isFileMock = jest.mocked(isFile)
-	const isDirMock = jest.mocked(isDir)
-	const findYAMLFilenameMock = jest.mocked(findYAMLFilename)
-	const requireDirMock = jest.mocked(requireDir)
-	const readYAMLFileMock = jest.mocked(readYAMLFile)
-	const fileExistsMock = jest.mocked(fileExists)
-	const isSymbolicLinkMock = jest.mocked(isSymbolicLink)
-	const realPathForSymbolicLinkMock = jest.mocked(realPathForSymbolicLink)
+const isFileMock = jest.mocked(isFile)
+const isDirMock = jest.mocked(isDir)
+const findYAMLFilenameMock = jest.mocked(findYAMLFilename)
+const requireDirMock = jest.mocked(requireDir)
+const readYAMLFileMock = jest.mocked(readYAMLFile)
+const fileExistsMock = jest.mocked(fileExists)
+const isSymbolicLinkMock = jest.mocked(isSymbolicLink)
+const realPathForSymbolicLinkMock = jest.mocked(realPathForSymbolicLink)
 
-	const zipFileMock = jest.fn()
-	const zipMock = {
-		file: zipFileMock,
-	} as unknown as JSZip
+const zipFileMock = jest.fn()
+const zipMock = {
+	file: zipFileMock,
+} as unknown as JSZip
 
-	const errorSpy = jest.spyOn(CliUx.ux, 'error').mockImplementation()
+const errorSpy = jest.spyOn(CliUx.ux, 'error').mockImplementation()
 
-	describe('resolveProjectDirName', () => {
-		it('returns directory from arg if it exists', async () => {
-			isDirMock.mockResolvedValueOnce(true)
+describe('resolveProjectDirName', () => {
+	it('returns directory from arg if it exists', async () => {
+		isDirMock.mockResolvedValueOnce(true)
 
-			expect(await resolveProjectDirName('my-project-dir')).toBe('my-project-dir')
+		expect(await resolveProjectDirName('my-project-dir')).toBe('my-project-dir')
 
-			expect(isDirMock).toHaveBeenCalledTimes(1)
-			expect(isDirMock).toHaveBeenCalledWith('my-project-dir')
-		})
-
-		it('strips trailing slash', async () => {
-			isDirMock.mockResolvedValueOnce(true)
-
-			expect(await resolveProjectDirName('my-project-dir/')).toBe('my-project-dir')
-
-			expect(isDirMock).toHaveBeenCalledTimes(1)
-			expect(isDirMock).toHaveBeenCalledWith('my-project-dir')
-		})
-
-		it('throws exception if directory does not exist', async () => {
-			isDirMock.mockResolvedValueOnce(false)
-
-			await expect(resolveProjectDirName('my-bad-directory')).rejects.toThrow(Errors.CLIError)
-		})
+		expect(isDirMock).toHaveBeenCalledTimes(1)
+		expect(isDirMock).toHaveBeenCalledWith('my-project-dir')
 	})
 
-	describe('processConfigFile', () => {
-		it('returns parsed config yaml file data', async () => {
-			findYAMLFilenameMock.mockResolvedValueOnce('config.yaml filename')
-			readYAMLFileMock.mockReturnValueOnce({ yaml: 'file contents' })
-			createReadStreamMock.mockReturnValueOnce(readStreamMock)
+	it('strips trailing slash', async () => {
+		isDirMock.mockResolvedValueOnce(true)
 
-			expect(await processConfigFile('my-project-dir', zipMock))
-				.toEqual({ yaml: 'file contents' })
+		expect(await resolveProjectDirName('my-project-dir/')).toBe('my-project-dir')
 
-			expect(findYAMLFilenameMock).toHaveBeenCalledTimes(1)
-			expect(findYAMLFilenameMock).toHaveBeenCalledWith('my-project-dir/config')
-			expect(readYAMLFileMock).toHaveBeenCalledTimes(1)
-			expect(readYAMLFileMock).toHaveBeenCalledWith('config.yaml filename')
-			expect(createReadStreamMock).toHaveBeenCalledTimes(1)
-			expect(createReadStreamMock).toHaveBeenCalledWith('config.yaml filename')
-			expect(zipFileMock).toHaveBeenCalledTimes(1)
-			expect(zipFileMock).toHaveBeenCalledWith('config.yml', readStreamMock)
-		})
-
-		it('throws error when config file is missing', async () => {
-			findYAMLFilenameMock.mockResolvedValueOnce(false)
-
-			await expect(processConfigFile('my-project-dir', zipMock))
-				.rejects.toThrow(new Errors.CLIError('missing main config.yaml (or config.yml) file'))
-
-			expect(findYAMLFilenameMock).toHaveBeenCalledTimes(1)
-			expect(findYAMLFilenameMock).toHaveBeenCalledWith('my-project-dir/config')
-			expect(readYAMLFileMock).toHaveBeenCalledTimes(0)
-			expect(zipFileMock).toHaveBeenCalledTimes(0)
-		})
+		expect(isDirMock).toHaveBeenCalledTimes(1)
+		expect(isDirMock).toHaveBeenCalledWith('my-project-dir')
 	})
 
-	describe('processOptionalYAMLFile', () => {
-		it('includes fingerprint file if found', async () => {
-			findYAMLFilenameMock.mockResolvedValueOnce('yaml filename')
-			readYAMLFileMock.mockReturnValueOnce({ yaml: 'file contents' })
-			createReadStreamMock.mockReturnValueOnce(readStreamMock)
+	it('throws exception if directory does not exist', async () => {
+		isDirMock.mockResolvedValueOnce(false)
 
-			await processOptionalYAMLFile('optional yaml file', 'project dir', zipMock)
+		await expect(resolveProjectDirName('my-bad-directory')).rejects.toThrow(Errors.CLIError)
+	})
+})
 
-			expect(findYAMLFilenameMock).toHaveBeenCalledTimes(1)
-			expect(findYAMLFilenameMock).toHaveBeenCalledWith('project dir/optional yaml file')
-			expect(readYAMLFileMock).toHaveBeenCalledTimes(1)
-			expect(readYAMLFileMock).toHaveBeenCalledWith('yaml filename')
-			expect(createReadStreamMock).toHaveBeenCalledTimes(1)
-			expect(createReadStreamMock).toHaveBeenCalledWith('yaml filename')
-			expect(zipFileMock).toHaveBeenCalledTimes(1)
-			expect(zipFileMock).toHaveBeenCalledWith('optional yaml file.yml', readStreamMock)
-		})
+describe('processConfigFile', () => {
+	it('returns parsed config yaml file data', async () => {
+		findYAMLFilenameMock.mockResolvedValueOnce('config.yaml filename')
+		readYAMLFileMock.mockReturnValueOnce({ yaml: 'file contents' })
+		createReadStreamMock.mockReturnValueOnce(readStreamMock)
 
-		it('skips fingerprint file if none', async () => {
-			findYAMLFilenameMock.mockResolvedValueOnce(false)
+		expect(await processConfigFile('my-project-dir', zipMock))
+			.toEqual({ yaml: 'file contents' })
 
-			await processOptionalYAMLFile('optional yaml file', 'project dir', zipMock)
-
-			expect(findYAMLFilenameMock).toHaveBeenCalledTimes(1)
-			expect(findYAMLFilenameMock).toHaveBeenCalledWith('project dir/optional yaml file')
-			expect(readYAMLFileMock).toHaveBeenCalledTimes(0)
-			expect(zipFileMock).toHaveBeenCalledTimes(0)
-		})
+		expect(findYAMLFilenameMock).toHaveBeenCalledTimes(1)
+		expect(findYAMLFilenameMock).toHaveBeenCalledWith('my-project-dir/config')
+		expect(readYAMLFileMock).toHaveBeenCalledTimes(1)
+		expect(readYAMLFileMock).toHaveBeenCalledWith('config.yaml filename')
+		expect(createReadStreamMock).toHaveBeenCalledTimes(1)
+		expect(createReadStreamMock).toHaveBeenCalledWith('config.yaml filename')
+		expect(zipFileMock).toHaveBeenCalledTimes(1)
+		expect(zipFileMock).toHaveBeenCalledWith('config.yml', readStreamMock)
 	})
 
-	test('processFingerprintsFile calls processOptionalYAMLFile', async () => {
-		const processOptionalYAMLFileSpy = jest.spyOn(packageUtilModule, 'processOptionalYAMLFile')
-			.mockImplementationOnce(async () => { /* do nothing */ })
+	it('throws error when config file is missing', async () => {
+		findYAMLFilenameMock.mockResolvedValueOnce(false)
 
-		await processFingerprintsFile('project dir', zipMock)
+		await expect(processConfigFile('my-project-dir', zipMock))
+			.rejects.toThrow(new Errors.CLIError('missing main config.yaml (or config.yml) file'))
 
-		expect(processOptionalYAMLFileSpy).toHaveBeenCalledTimes(1)
-		expect(processOptionalYAMLFileSpy).toHaveBeenCalledWith('fingerprints', 'project dir', zipMock)
+		expect(findYAMLFilenameMock).toHaveBeenCalledTimes(1)
+		expect(findYAMLFilenameMock).toHaveBeenCalledWith('my-project-dir/config')
+		expect(readYAMLFileMock).toHaveBeenCalledTimes(0)
+		expect(zipFileMock).toHaveBeenCalledTimes(0)
+	})
+})
+
+describe('processOptionalYAMLFile', () => {
+	it('includes fingerprint file if found', async () => {
+		findYAMLFilenameMock.mockResolvedValueOnce('yaml filename')
+		readYAMLFileMock.mockReturnValueOnce({ yaml: 'file contents' })
+		createReadStreamMock.mockReturnValueOnce(readStreamMock)
+
+		await processOptionalYAMLFile('optional yaml file', 'project dir', zipMock)
+
+		expect(findYAMLFilenameMock).toHaveBeenCalledTimes(1)
+		expect(findYAMLFilenameMock).toHaveBeenCalledWith('project dir/optional yaml file')
+		expect(readYAMLFileMock).toHaveBeenCalledTimes(1)
+		expect(readYAMLFileMock).toHaveBeenCalledWith('yaml filename')
+		expect(createReadStreamMock).toHaveBeenCalledTimes(1)
+		expect(createReadStreamMock).toHaveBeenCalledWith('yaml filename')
+		expect(zipFileMock).toHaveBeenCalledTimes(1)
+		expect(zipFileMock).toHaveBeenCalledWith('optional yaml file.yml', readStreamMock)
 	})
 
-	test('processSearchParametersFile calls processOptionalYAMLFile', async () => {
-		const processOptionalYAMLFileSpy = jest.spyOn(packageUtilModule, 'processOptionalYAMLFile')
-			.mockImplementationOnce(async () => { /* do nothing */ })
+	it('skips fingerprint file if none', async () => {
+		findYAMLFilenameMock.mockResolvedValueOnce(false)
 
-		await processSearchParametersFile('project dir', zipMock)
+		await processOptionalYAMLFile('optional yaml file', 'project dir', zipMock)
 
-		expect(processOptionalYAMLFileSpy).toHaveBeenCalledTimes(1)
-		expect(processOptionalYAMLFileSpy).toHaveBeenCalledWith('search-parameters', 'project dir', zipMock)
+		expect(findYAMLFilenameMock).toHaveBeenCalledTimes(1)
+		expect(findYAMLFilenameMock).toHaveBeenCalledWith('project dir/optional yaml file')
+		expect(readYAMLFileMock).toHaveBeenCalledTimes(0)
+		expect(zipFileMock).toHaveBeenCalledTimes(0)
+	})
+})
+
+test('processFingerprintsFile calls processOptionalYAMLFile', async () => {
+	const processOptionalYAMLFileSpy = jest.spyOn(packageUtilModule, 'processOptionalYAMLFile')
+		.mockImplementationOnce(async () => { /* do nothing */ })
+
+	await processFingerprintsFile('project dir', zipMock)
+
+	expect(processOptionalYAMLFileSpy).toHaveBeenCalledTimes(1)
+	expect(processOptionalYAMLFileSpy).toHaveBeenCalledWith('fingerprints', 'project dir', zipMock)
+})
+
+test('processSearchParametersFile calls processOptionalYAMLFile', async () => {
+	const processOptionalYAMLFileSpy = jest.spyOn(packageUtilModule, 'processOptionalYAMLFile')
+		.mockImplementationOnce(async () => { /* do nothing */ })
+
+	await processSearchParametersFile('project dir', zipMock)
+
+	expect(processOptionalYAMLFileSpy).toHaveBeenCalledTimes(1)
+	expect(processOptionalYAMLFileSpy).toHaveBeenCalledWith('search-parameters', 'project dir', zipMock)
+})
+
+test('buildTestFileMatchers converts to matchers', () => {
+	const picomatchMock = jest.mocked(picomatch)
+	const matcher1 = (): boolean => true
+	const matcher2 = (): boolean => false
+
+	picomatchMock.mockReturnValueOnce(matcher1)
+	picomatchMock.mockReturnValueOnce(matcher2)
+
+	expect(buildTestFileMatchers(['1', '2'])).toEqual([matcher1, matcher2])
+
+	expect(picomatchMock).toHaveBeenCalledTimes(2)
+	expect(picomatchMock).toHaveBeenCalledWith('1')
+	expect(picomatchMock).toHaveBeenCalledWith('2')
+})
+
+describe('processSrcDir', () => {
+	createReadStreamMock.mockReturnValue(readStreamMock)
+
+	it('throws error when there is no init.lua file', async () => {
+		requireDirMock.mockResolvedValueOnce('src dir')
+		isFileMock.mockResolvedValueOnce(false)
+
+		await expect(() => processSrcDir('project dir', zipMock, []))
+			.rejects.toThrow(Errors.CLIError)
+
+		expect(requireDirMock).toHaveBeenCalledTimes(1)
+		expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
+		expect(isFileMock).toHaveBeenCalledTimes(1)
+		expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
 	})
 
-	test('buildTestFileMatchers converts to matchers', () => {
-		const picomatchMock = jest.mocked(picomatch)
-		const matcher1 = (): boolean => true
-		const matcher2 = (): boolean => false
+	it('includes files at top level', async () => {
+		requireDirMock.mockResolvedValueOnce('src dir')
+		isFileMock.mockResolvedValueOnce(true) // init.lua specific check
+		readdirSyncMock.mockReturnValueOnce(['init.lua'])
+		fileExistsMock.mockResolvedValueOnce(true) // init.lua
+		isSymbolicLinkMock.mockResolvedValueOnce(false)
+		isDirMock.mockResolvedValueOnce(false) // init.lua is not a directory
+		createReadStreamMock.mockReturnValueOnce(readStreamMock)
 
-		picomatchMock.mockReturnValueOnce(matcher1)
-		picomatchMock.mockReturnValueOnce(matcher2)
+		expect(await processSrcDir('project dir', zipMock, [])).toBe(true)
 
-		expect(buildTestFileMatchers(['1', '2'])).toEqual([matcher1, matcher2])
-
-		expect(picomatchMock).toHaveBeenCalledTimes(2)
-		expect(picomatchMock).toHaveBeenCalledWith('1')
-		expect(picomatchMock).toHaveBeenCalledWith('2')
+		expect(requireDirMock).toHaveBeenCalledTimes(1)
+		expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
+		expect(isFileMock).toHaveBeenCalledTimes(1)
+		expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(readdirSyncMock).toHaveBeenCalledTimes(1)
+		expect(readdirSyncMock).toHaveBeenCalledWith('src dir')
+		expect(fileExistsMock).toHaveBeenCalledTimes(1)
+		expect(fileExistsMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(isSymbolicLinkMock).toHaveBeenCalledTimes(1)
+		expect(isSymbolicLinkMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(isDirMock).toHaveBeenCalledTimes(1)
+		expect(isDirMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(createReadStreamMock).toHaveBeenCalledTimes(1)
+		expect(createReadStreamMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(zipFileMock).toHaveBeenCalledTimes(1)
+		expect(zipFileMock).toHaveBeenCalledWith('src/init.lua', readStreamMock)
+		expect(realPathForSymbolicLinkMock).toHaveBeenCalledTimes(0)
 	})
 
-	describe('processSrcDir', () => {
-		createReadStreamMock.mockReturnValue(readStreamMock)
+	it('includes nested files', async () => {
+		requireDirMock.mockResolvedValueOnce('src dir')
+		isFileMock.mockResolvedValueOnce(true) // init.lua specific check
+		readdirSyncMock.mockReturnValueOnce(['init.lua', 'subdirectory'])
+		fileExistsMock.mockResolvedValueOnce(true) // init.lua
+		isSymbolicLinkMock.mockResolvedValueOnce(false) // init.lua
+		isDirMock.mockResolvedValueOnce(false) // init.lua is not a directory
+		createReadStreamMock.mockReturnValueOnce(readStreamMock) // init.lua
+		fileExistsMock.mockResolvedValueOnce(true) // subdirectory
+		isSymbolicLinkMock.mockResolvedValueOnce(false) // subdirectory
+		isDirMock.mockResolvedValueOnce(true) // subdirectory is a directory
+		readdirSyncMock.mockReturnValueOnce(['lib.lua'])
+		fileExistsMock.mockResolvedValueOnce(true) // lib.lua
+		isDirMock.mockResolvedValueOnce(false) // lib.lua
+		createReadStreamMock.mockReturnValueOnce(readStreamMock) // lib.lua
 
-		it('throws error when there is no init.lua file', async () => {
-			requireDirMock.mockResolvedValueOnce('src dir')
-			isFileMock.mockResolvedValueOnce(false)
+		expect(await processSrcDir('project dir', zipMock, [])).toBe(true)
 
-			await expect(() => processSrcDir('project dir', zipMock, []))
-				.rejects.toThrow(Errors.CLIError)
+		expect(requireDirMock).toHaveBeenCalledTimes(1)
+		expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
+		expect(isFileMock).toHaveBeenCalledTimes(1)
+		expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(readdirSyncMock).toHaveBeenCalledTimes(2)
+		expect(readdirSyncMock).toHaveBeenCalledWith('src dir')
+		expect(readdirSyncMock).toHaveBeenCalledWith('src dir/subdirectory')
+		expect(isDirMock).toHaveBeenCalledTimes(3)
+		expect(isDirMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(isDirMock).toHaveBeenCalledWith('src dir/subdirectory')
+		expect(isDirMock).toHaveBeenCalledWith('src dir/subdirectory/lib.lua')
+		expect(createReadStreamMock).toHaveBeenCalledTimes(2)
+		expect(createReadStreamMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(createReadStreamMock).toHaveBeenCalledWith('src dir/subdirectory/lib.lua')
+		expect(zipFileMock).toHaveBeenCalledTimes(2)
+		expect(zipFileMock).toHaveBeenCalledWith('src/init.lua', readStreamMock)
+		expect(zipFileMock).toHaveBeenCalledWith('src/subdirectory/lib.lua', readStreamMock)
+		expect(realPathForSymbolicLinkMock).toHaveBeenCalledTimes(0)
+	})
 
-			expect(requireDirMock).toHaveBeenCalledTimes(1)
-			expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
-			expect(isFileMock).toHaveBeenCalledTimes(1)
-			expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
-		})
+	it('follows sym links to files', async () => {
+		requireDirMock.mockResolvedValueOnce('src dir')
+		isFileMock.mockResolvedValueOnce(true) // init.lua specific check
+		readdirSyncMock.mockReturnValueOnce(['file link'])
+		fileExistsMock.mockResolvedValueOnce(true)
+		isSymbolicLinkMock.mockResolvedValueOnce(true)
+		realPathForSymbolicLinkMock.mockResolvedValueOnce('real file')
+		isDirMock.mockResolvedValueOnce(false)
 
-		it('includes files at top level', async () => {
-			requireDirMock.mockResolvedValueOnce('src dir')
-			isFileMock.mockResolvedValueOnce(true) // init.lua specific check
-			readdirSyncMock.mockReturnValueOnce(['init.lua'])
-			fileExistsMock.mockResolvedValueOnce(true) // init.lua
-			isSymbolicLinkMock.mockResolvedValueOnce(false)
-			isDirMock.mockResolvedValueOnce(false) // init.lua is not a directory
-			createReadStreamMock.mockReturnValueOnce(readStreamMock)
+		expect(await processSrcDir('project dir', zipMock, [])).toBe(true)
 
-			expect(await processSrcDir('project dir', zipMock, [])).toBe(true)
+		expect(requireDirMock).toHaveBeenCalledTimes(1)
+		expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
+		expect(isFileMock).toHaveBeenCalledTimes(1)
+		expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(readdirSyncMock).toHaveBeenCalledTimes(1)
+		expect(readdirSyncMock).toHaveBeenCalledWith('src dir')
+		expect(fileExistsMock).toHaveBeenCalledTimes(1)
+		expect(fileExistsMock).toHaveBeenCalledWith('src dir/file link')
+		expect(isSymbolicLinkMock).toHaveBeenCalledTimes(1)
+		expect(isSymbolicLinkMock).toHaveBeenCalledWith('src dir/file link')
+		expect(realPathForSymbolicLinkMock).toHaveBeenCalledTimes(1)
+		expect(realPathForSymbolicLinkMock).toHaveBeenCalledWith('src dir/file link')
+		expect(isDirMock).toHaveBeenCalledTimes(1)
+		expect(isDirMock).toHaveBeenCalledWith('real file')
+		expect(createReadStreamMock).toHaveBeenCalledTimes(1)
+		expect(createReadStreamMock).toHaveBeenCalledWith('src dir/file link')
+		expect(zipFileMock).toHaveBeenCalledTimes(1)
+		expect(zipFileMock).toHaveBeenCalledWith('src/file link', readStreamMock)
+		expect(errorSpy).toHaveBeenCalledTimes(0)
+	})
 
-			expect(requireDirMock).toHaveBeenCalledTimes(1)
-			expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
-			expect(isFileMock).toHaveBeenCalledTimes(1)
-			expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(readdirSyncMock).toHaveBeenCalledTimes(1)
-			expect(readdirSyncMock).toHaveBeenCalledWith('src dir')
-			expect(fileExistsMock).toHaveBeenCalledTimes(1)
-			expect(fileExistsMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(isSymbolicLinkMock).toHaveBeenCalledTimes(1)
-			expect(isSymbolicLinkMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(isDirMock).toHaveBeenCalledTimes(1)
-			expect(isDirMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(createReadStreamMock).toHaveBeenCalledTimes(1)
-			expect(createReadStreamMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(zipFileMock).toHaveBeenCalledTimes(1)
-			expect(zipFileMock).toHaveBeenCalledWith('src/init.lua', readStreamMock)
-			expect(realPathForSymbolicLinkMock).toHaveBeenCalledTimes(0)
-		})
+	it('skips files that match test dir pattern', async () => {
+		requireDirMock.mockResolvedValueOnce('src dir')
+		isFileMock.mockResolvedValueOnce(true) // init.lua specific check
 
-		it('includes nested files', async () => {
-			requireDirMock.mockResolvedValueOnce('src dir')
-			isFileMock.mockResolvedValueOnce(true) // init.lua specific check
-			readdirSyncMock.mockReturnValueOnce(['init.lua', 'subdirectory'])
-			fileExistsMock.mockResolvedValueOnce(true) // init.lua
-			isSymbolicLinkMock.mockResolvedValueOnce(false) // init.lua
-			isDirMock.mockResolvedValueOnce(false) // init.lua is not a directory
-			createReadStreamMock.mockReturnValueOnce(readStreamMock) // init.lua
+		readdirSyncMock.mockReturnValueOnce(['init.lua', 'test.lua'])
+		fileExistsMock.mockResolvedValueOnce(true) // init.lua
+		isSymbolicLinkMock.mockResolvedValueOnce(false) // init.lua
+		isDirMock.mockResolvedValueOnce(false) // init.lua is not a directory
+		fileExistsMock.mockResolvedValueOnce(true) // test.lua
+		isSymbolicLinkMock.mockResolvedValueOnce(false) // test.lua
+		isDirMock.mockResolvedValueOnce(false) // test.lua is not a directory
+
+		const matcher = jest.fn()
+			.mockReturnValueOnce(false) // init.lua is not a test file
+			.mockReturnValueOnce(true) // test.lua is a test file
+
+		expect(await processSrcDir('project dir', zipMock, [matcher])).toBe(true)
+
+		expect(requireDirMock).toHaveBeenCalledTimes(1)
+		expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
+		expect(isFileMock).toHaveBeenCalledTimes(1)
+		expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(readdirSyncMock).toHaveBeenCalledTimes(1)
+		expect(readdirSyncMock).toHaveBeenCalledWith('src dir')
+		expect(isDirMock).toHaveBeenCalledTimes(2)
+		expect(isDirMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(isDirMock).toHaveBeenCalledWith('src dir/test.lua')
+		expect(createReadStreamMock).toHaveBeenCalledTimes(1)
+		expect(createReadStreamMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(zipFileMock).toHaveBeenCalledTimes(1) // NOT 2! :-)
+		expect(zipFileMock).toHaveBeenCalledWith('src/init.lua', readStreamMock)
+		expect(realPathForSymbolicLinkMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('throws error if nesting is too deep', async () => {
+		requireDirMock.mockResolvedValueOnce('src dir')
+		isFileMock.mockResolvedValueOnce(true) // init.lua exists
+
+		readdirSyncMock.mockReturnValueOnce(['init.lua', 'subdirectory'])
+		fileExistsMock.mockResolvedValueOnce(true) // init.lua
+		isSymbolicLinkMock.mockResolvedValueOnce(false) // init.lua
+		isDirMock.mockResolvedValueOnce(false) // init.lua is not a directory
+		fileExistsMock.mockResolvedValueOnce(true) // subdirectory
+		isSymbolicLinkMock.mockResolvedValueOnce(false) // subdirectory
+		isDirMock.mockResolvedValueOnce(true) // subdirectory is a directory
+		// The services limit nesting to 10 but count both the main directory and the source
+		// directory, so we only need to add a total of 9 directories to get one too many.
+		for (let count = 1; count <= 8; count++) {
+			readdirSyncMock.mockReturnValueOnce(['subdirectory'])
 			fileExistsMock.mockResolvedValueOnce(true) // subdirectory
 			isSymbolicLinkMock.mockResolvedValueOnce(false) // subdirectory
-			isDirMock.mockResolvedValueOnce(true) // subdirectory is a directory
-			readdirSyncMock.mockReturnValueOnce(['lib.lua'])
-			fileExistsMock.mockResolvedValueOnce(true) // lib.lua
-			isDirMock.mockResolvedValueOnce(false) // lib.lua
-			createReadStreamMock.mockReturnValueOnce(readStreamMock) // lib.lua
-
-			expect(await processSrcDir('project dir', zipMock, [])).toBe(true)
-
-			expect(requireDirMock).toHaveBeenCalledTimes(1)
-			expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
-			expect(isFileMock).toHaveBeenCalledTimes(1)
-			expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(readdirSyncMock).toHaveBeenCalledTimes(2)
-			expect(readdirSyncMock).toHaveBeenCalledWith('src dir')
-			expect(readdirSyncMock).toHaveBeenCalledWith('src dir/subdirectory')
-			expect(isDirMock).toHaveBeenCalledTimes(3)
-			expect(isDirMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(isDirMock).toHaveBeenCalledWith('src dir/subdirectory')
-			expect(isDirMock).toHaveBeenCalledWith('src dir/subdirectory/lib.lua')
-			expect(createReadStreamMock).toHaveBeenCalledTimes(2)
-			expect(createReadStreamMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(createReadStreamMock).toHaveBeenCalledWith('src dir/subdirectory/lib.lua')
-			expect(zipFileMock).toHaveBeenCalledTimes(2)
-			expect(zipFileMock).toHaveBeenCalledWith('src/init.lua', readStreamMock)
-			expect(zipFileMock).toHaveBeenCalledWith('src/subdirectory/lib.lua', readStreamMock)
-			expect(realPathForSymbolicLinkMock).toHaveBeenCalledTimes(0)
-		})
-
-		it('follows sym links to files', async () => {
-			requireDirMock.mockResolvedValueOnce('src dir')
-			isFileMock.mockResolvedValueOnce(true) // init.lua specific check
-			readdirSyncMock.mockReturnValueOnce(['file link'])
-			fileExistsMock.mockResolvedValueOnce(true)
-			isSymbolicLinkMock.mockResolvedValueOnce(true)
-			realPathForSymbolicLinkMock.mockResolvedValueOnce('real file')
-			isDirMock.mockResolvedValueOnce(false)
-
-			expect(await processSrcDir('project dir', zipMock, [])).toBe(true)
-
-			expect(requireDirMock).toHaveBeenCalledTimes(1)
-			expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
-			expect(isFileMock).toHaveBeenCalledTimes(1)
-			expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(readdirSyncMock).toHaveBeenCalledTimes(1)
-			expect(readdirSyncMock).toHaveBeenCalledWith('src dir')
-			expect(fileExistsMock).toHaveBeenCalledTimes(1)
-			expect(fileExistsMock).toHaveBeenCalledWith('src dir/file link')
-			expect(isSymbolicLinkMock).toHaveBeenCalledTimes(1)
-			expect(isSymbolicLinkMock).toHaveBeenCalledWith('src dir/file link')
-			expect(realPathForSymbolicLinkMock).toHaveBeenCalledTimes(1)
-			expect(realPathForSymbolicLinkMock).toHaveBeenCalledWith('src dir/file link')
-			expect(isDirMock).toHaveBeenCalledTimes(1)
-			expect(isDirMock).toHaveBeenCalledWith('real file')
-			expect(createReadStreamMock).toHaveBeenCalledTimes(1)
-			expect(createReadStreamMock).toHaveBeenCalledWith('src dir/file link')
-			expect(zipFileMock).toHaveBeenCalledTimes(1)
-			expect(zipFileMock).toHaveBeenCalledWith('src/file link', readStreamMock)
-			expect(errorSpy).toHaveBeenCalledTimes(0)
-		})
-
-		it('skips files that match test dir pattern', async () => {
-			requireDirMock.mockResolvedValueOnce('src dir')
-			isFileMock.mockResolvedValueOnce(true) // init.lua specific check
-
-			readdirSyncMock.mockReturnValueOnce(['init.lua', 'test.lua'])
-			fileExistsMock.mockResolvedValueOnce(true) // init.lua
-			isSymbolicLinkMock.mockResolvedValueOnce(false) // init.lua
-			isDirMock.mockResolvedValueOnce(false) // init.lua is not a directory
-			fileExistsMock.mockResolvedValueOnce(true) // test.lua
-			isSymbolicLinkMock.mockResolvedValueOnce(false) // test.lua
-			isDirMock.mockResolvedValueOnce(false) // test.lua is not a directory
-
-			const matcher = jest.fn()
-				.mockReturnValueOnce(false) // init.lua is not a test file
-				.mockReturnValueOnce(true) // test.lua is a test file
-
-			expect(await processSrcDir('project dir', zipMock, [matcher])).toBe(true)
-
-			expect(requireDirMock).toHaveBeenCalledTimes(1)
-			expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
-			expect(isFileMock).toHaveBeenCalledTimes(1)
-			expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(readdirSyncMock).toHaveBeenCalledTimes(1)
-			expect(readdirSyncMock).toHaveBeenCalledWith('src dir')
-			expect(isDirMock).toHaveBeenCalledTimes(2)
-			expect(isDirMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(isDirMock).toHaveBeenCalledWith('src dir/test.lua')
-			expect(createReadStreamMock).toHaveBeenCalledTimes(1)
-			expect(createReadStreamMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(zipFileMock).toHaveBeenCalledTimes(1) // NOT 2! :-)
-			expect(zipFileMock).toHaveBeenCalledWith('src/init.lua', readStreamMock)
-			expect(realPathForSymbolicLinkMock).toHaveBeenCalledTimes(0)
-		})
-
-		it('throws error if nesting is too deep', async () => {
-			requireDirMock.mockResolvedValueOnce('src dir')
-			isFileMock.mockResolvedValueOnce(true) // init.lua exists
-
-			readdirSyncMock.mockReturnValueOnce(['init.lua', 'subdirectory'])
-			fileExistsMock.mockResolvedValueOnce(true) // init.lua
-			isSymbolicLinkMock.mockResolvedValueOnce(false) // init.lua
-			isDirMock.mockResolvedValueOnce(false) // init.lua is not a directory
-			fileExistsMock.mockResolvedValueOnce(true) // subdirectory
-			isSymbolicLinkMock.mockResolvedValueOnce(false) // subdirectory
-			isDirMock.mockResolvedValueOnce(true) // subdirectory is a directory
-			// The services limit nesting to 10 but count both the main directory and the source
-			// directory, so we only need to add a total of 9 directories to get one too many.
-			for (let count = 1; count <= 8; count++) {
-				readdirSyncMock.mockReturnValueOnce(['subdirectory'])
-				fileExistsMock.mockResolvedValueOnce(true) // subdirectory
-				isSymbolicLinkMock.mockResolvedValueOnce(false) // subdirectory
-				isDirMock.mockResolvedValueOnce(true)
-			}
-
-			expect(await processSrcDir('project dir', zipMock, [])).toBe(false)
-
-			expect(requireDirMock).toHaveBeenCalledTimes(1)
-			expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
-			expect(isFileMock).toHaveBeenCalledTimes(1)
-			expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(readdirSyncMock).toHaveBeenCalledTimes(9)
-			expect(isDirMock).toHaveBeenCalledTimes(10)
-			expect(isDirMock).toHaveBeenCalledWith('src dir/init.lua')
-			for (let count = 0; count <= 8; count++) {
-				expect(readdirSyncMock).toHaveBeenCalledWith(`src dir${'/subdirectory'.repeat(count)}`)
-				expect(isDirMock).toHaveBeenCalledWith(`src dir${'/subdirectory'.repeat(count + 1)}`)
-			}
-			expect(errorSpy).toHaveBeenCalledTimes(1)
-			expect(errorSpy).toHaveBeenCalledWith(
-				`drivers directory nested too deeply (at src dir${'/subdirectory'.repeat(9)}); max depth is 10`,
-				{ 'exit': false },
-			)
-			expect(createReadStreamMock).toHaveBeenCalledTimes(1)
-			expect(createReadStreamMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(zipFileMock).toHaveBeenCalledTimes(1)
-			expect(zipFileMock).toHaveBeenCalledWith('src/init.lua', readStreamMock)
-			expect(realPathForSymbolicLinkMock).toHaveBeenCalledTimes(0)
-		})
-
-		it('logs error for sym link to directory', async () => {
-			requireDirMock.mockResolvedValueOnce('src dir')
-			isFileMock.mockResolvedValueOnce(true) // init.lua specific check
-			readdirSyncMock.mockReturnValueOnce(['dir link'])
-			fileExistsMock.mockResolvedValueOnce(true)
-			isSymbolicLinkMock.mockResolvedValueOnce(true)
-			realPathForSymbolicLinkMock.mockResolvedValueOnce('real dir')
 			isDirMock.mockResolvedValueOnce(true)
+		}
 
-			expect(await processSrcDir('project dir', zipMock, [])).toBe(false)
+		expect(await processSrcDir('project dir', zipMock, [])).toBe(false)
 
-			expect(requireDirMock).toHaveBeenCalledTimes(1)
-			expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
-			expect(isFileMock).toHaveBeenCalledTimes(1)
-			expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(readdirSyncMock).toHaveBeenCalledTimes(1)
-			expect(readdirSyncMock).toHaveBeenCalledWith('src dir')
-			expect(fileExistsMock).toHaveBeenCalledTimes(1)
-			expect(fileExistsMock).toHaveBeenCalledWith('src dir/dir link')
-			expect(isSymbolicLinkMock).toHaveBeenCalledTimes(1)
-			expect(isSymbolicLinkMock).toHaveBeenCalledWith('src dir/dir link')
-			expect(realPathForSymbolicLinkMock).toHaveBeenCalledTimes(1)
-			expect(realPathForSymbolicLinkMock).toHaveBeenCalledWith('src dir/dir link')
-			expect(isDirMock).toHaveBeenCalledTimes(1)
-			expect(isDirMock).toHaveBeenCalledWith('real dir')
-			expect(errorSpy).toHaveBeenCalledTimes(1)
-			expect(errorSpy).toHaveBeenCalledWith(
-				'sym links to directories are not allowed (src dir/dir link)',
-				{ 'exit': false },
-			)
-			expect(createReadStreamMock).toHaveBeenCalledTimes(0)
-			expect(zipFileMock).toHaveBeenCalledTimes(0)
-		})
-
-		it('logs error for broken sym link', async () => {
-			requireDirMock.mockResolvedValueOnce('src dir')
-			isFileMock.mockResolvedValueOnce(true) // init.lua specific check
-			readdirSyncMock.mockReturnValueOnce(['file link'])
-			fileExistsMock.mockResolvedValueOnce(false)
-
-			expect(await processSrcDir('project dir', zipMock, [])).toBe(false)
-
-			expect(requireDirMock).toHaveBeenCalledTimes(1)
-			expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
-			expect(isFileMock).toHaveBeenCalledTimes(1)
-			expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
-			expect(readdirSyncMock).toHaveBeenCalledTimes(1)
-			expect(readdirSyncMock).toHaveBeenCalledWith('src dir')
-			expect(fileExistsMock).toHaveBeenCalledTimes(1)
-			expect(fileExistsMock).toHaveBeenCalledWith('src dir/file link')
-			expect(isSymbolicLinkMock).toHaveBeenCalledTimes(0)
-			expect(realPathForSymbolicLinkMock).toHaveBeenCalledTimes(0)
-			expect(isDirMock).toHaveBeenCalledTimes(0)
-			expect(errorSpy).toHaveBeenCalledTimes(1)
-			expect(errorSpy).toHaveBeenCalledWith(
-				'sym link src dir/file link points to non-existent file',
-				{ 'exit': false },
-			)
-			expect(createReadStreamMock).toHaveBeenCalledTimes(0)
-			expect(zipFileMock).toHaveBeenCalledTimes(0)
-		})
+		expect(requireDirMock).toHaveBeenCalledTimes(1)
+		expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
+		expect(isFileMock).toHaveBeenCalledTimes(1)
+		expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(readdirSyncMock).toHaveBeenCalledTimes(9)
+		expect(isDirMock).toHaveBeenCalledTimes(10)
+		expect(isDirMock).toHaveBeenCalledWith('src dir/init.lua')
+		for (let count = 0; count <= 8; count++) {
+			expect(readdirSyncMock).toHaveBeenCalledWith(`src dir${'/subdirectory'.repeat(count)}`)
+			expect(isDirMock).toHaveBeenCalledWith(`src dir${'/subdirectory'.repeat(count + 1)}`)
+		}
+		expect(errorSpy).toHaveBeenCalledTimes(1)
+		expect(errorSpy).toHaveBeenCalledWith(
+			`drivers directory nested too deeply (at src dir${'/subdirectory'.repeat(9)}); max depth is 10`,
+			{ 'exit': false },
+		)
+		expect(createReadStreamMock).toHaveBeenCalledTimes(1)
+		expect(createReadStreamMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(zipFileMock).toHaveBeenCalledTimes(1)
+		expect(zipFileMock).toHaveBeenCalledWith('src/init.lua', readStreamMock)
+		expect(realPathForSymbolicLinkMock).toHaveBeenCalledTimes(0)
 	})
 
-	describe('processProfiles', () => {
-		readYAMLFileMock.mockReturnValue({})
+	it('logs error for sym link to directory', async () => {
+		requireDirMock.mockResolvedValueOnce('src dir')
+		isFileMock.mockResolvedValueOnce(true) // init.lua specific check
+		readdirSyncMock.mockReturnValueOnce(['dir link'])
+		fileExistsMock.mockResolvedValueOnce(true)
+		isSymbolicLinkMock.mockResolvedValueOnce(true)
+		realPathForSymbolicLinkMock.mockResolvedValueOnce('real dir')
+		isDirMock.mockResolvedValueOnce(true)
 
-		it('adds nothing with no profiles', async () => {
-			requireDirMock.mockResolvedValueOnce('profiles dir')
-			readdirSyncMock.mockReturnValueOnce([])
+		expect(await processSrcDir('project dir', zipMock, [])).toBe(false)
 
-			await expect(processProfiles('project dir', zipMock)).resolves.not.toThrow()
+		expect(requireDirMock).toHaveBeenCalledTimes(1)
+		expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
+		expect(isFileMock).toHaveBeenCalledTimes(1)
+		expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(readdirSyncMock).toHaveBeenCalledTimes(1)
+		expect(readdirSyncMock).toHaveBeenCalledWith('src dir')
+		expect(fileExistsMock).toHaveBeenCalledTimes(1)
+		expect(fileExistsMock).toHaveBeenCalledWith('src dir/dir link')
+		expect(isSymbolicLinkMock).toHaveBeenCalledTimes(1)
+		expect(isSymbolicLinkMock).toHaveBeenCalledWith('src dir/dir link')
+		expect(realPathForSymbolicLinkMock).toHaveBeenCalledTimes(1)
+		expect(realPathForSymbolicLinkMock).toHaveBeenCalledWith('src dir/dir link')
+		expect(isDirMock).toHaveBeenCalledTimes(1)
+		expect(isDirMock).toHaveBeenCalledWith('real dir')
+		expect(errorSpy).toHaveBeenCalledTimes(1)
+		expect(errorSpy).toHaveBeenCalledWith(
+			'sym links to directories are not allowed (src dir/dir link)',
+			{ 'exit': false },
+		)
+		expect(createReadStreamMock).toHaveBeenCalledTimes(0)
+		expect(zipFileMock).toHaveBeenCalledTimes(0)
+	})
 
-			expect(requireDirMock).toHaveBeenCalledTimes(1)
-			expect(requireDirMock).toHaveBeenCalledWith('project dir/profiles')
-			expect(readdirSyncMock).toHaveBeenCalledTimes(1)
-			expect(readdirSyncMock).toHaveBeenCalledWith('profiles dir')
-			expect(readYAMLFileMock).toHaveBeenCalledTimes(0)
-			expect(createReadStreamMock).toHaveBeenCalledTimes(0)
-			expect(zipFileMock).toHaveBeenCalledTimes(0)
-		})
+	it('logs error for broken sym link', async () => {
+		requireDirMock.mockResolvedValueOnce('src dir')
+		isFileMock.mockResolvedValueOnce(true) // init.lua specific check
+		readdirSyncMock.mockReturnValueOnce(['file link'])
+		fileExistsMock.mockResolvedValueOnce(false)
 
-		it('adds yaml files with .yml extension', async () => {
-			requireDirMock.mockResolvedValueOnce('profiles dir')
-			readdirSyncMock.mockReturnValueOnce(['profile1.yml', 'profile2.yml'])
-			createReadStreamMock.mockReturnValueOnce(readStreamMock)
+		expect(await processSrcDir('project dir', zipMock, [])).toBe(false)
 
-			await expect(processProfiles('project dir', zipMock)).resolves.not.toThrow()
+		expect(requireDirMock).toHaveBeenCalledTimes(1)
+		expect(requireDirMock).toHaveBeenCalledWith('project dir/src')
+		expect(isFileMock).toHaveBeenCalledTimes(1)
+		expect(isFileMock).toHaveBeenCalledWith('src dir/init.lua')
+		expect(readdirSyncMock).toHaveBeenCalledTimes(1)
+		expect(readdirSyncMock).toHaveBeenCalledWith('src dir')
+		expect(fileExistsMock).toHaveBeenCalledTimes(1)
+		expect(fileExistsMock).toHaveBeenCalledWith('src dir/file link')
+		expect(isSymbolicLinkMock).toHaveBeenCalledTimes(0)
+		expect(realPathForSymbolicLinkMock).toHaveBeenCalledTimes(0)
+		expect(isDirMock).toHaveBeenCalledTimes(0)
+		expect(errorSpy).toHaveBeenCalledTimes(1)
+		expect(errorSpy).toHaveBeenCalledWith(
+			'sym link src dir/file link points to non-existent file',
+			{ 'exit': false },
+		)
+		expect(createReadStreamMock).toHaveBeenCalledTimes(0)
+		expect(zipFileMock).toHaveBeenCalledTimes(0)
+	})
+})
 
-			expect(requireDirMock).toHaveBeenCalledTimes(1)
-			expect(requireDirMock).toHaveBeenCalledWith('project dir/profiles')
-			expect(readdirSyncMock).toHaveBeenCalledTimes(1)
-			expect(readdirSyncMock).toHaveBeenCalledWith('profiles dir')
-			expect(readYAMLFileMock).toHaveBeenCalledTimes(2)
-			expect(readYAMLFileMock).toHaveBeenCalledWith('profiles dir/profile1.yml')
-			expect(readYAMLFileMock).toHaveBeenCalledWith('profiles dir/profile2.yml')
-			expect(createReadStreamMock).toHaveBeenCalledTimes(2)
-			expect(createReadStreamMock).toHaveBeenCalledWith('profiles dir/profile1.yml')
-			expect(createReadStreamMock).toHaveBeenCalledWith('profiles dir/profile2.yml')
-			expect(zipFileMock).toHaveBeenCalledTimes(2)
-			expect(zipFileMock).toHaveBeenCalledWith('profiles/profile1.yml', readStreamMock)
-			expect(zipFileMock).toHaveBeenCalledWith('profiles/profile2.yml', readStreamMock)
-		})
+describe('processProfiles', () => {
+	readYAMLFileMock.mockReturnValue({})
 
-		it('adds yaml files with .yaml extension as .yml', async () => {
-			requireDirMock.mockResolvedValueOnce('profiles dir')
-			readdirSyncMock.mockReturnValueOnce(['profile.yaml'])
-			createReadStreamMock.mockReturnValueOnce(readStreamMock)
+	it('adds nothing with no profiles', async () => {
+		requireDirMock.mockResolvedValueOnce('profiles dir')
+		readdirSyncMock.mockReturnValueOnce([])
 
-			await expect(processProfiles('project dir', zipMock)).resolves.not.toThrow()
+		await expect(processProfiles('project dir', zipMock)).resolves.not.toThrow()
 
-			expect(requireDirMock).toHaveBeenCalledTimes(1)
-			expect(requireDirMock).toHaveBeenCalledWith('project dir/profiles')
-			expect(readdirSyncMock).toHaveBeenCalledTimes(1)
-			expect(readdirSyncMock).toHaveBeenCalledWith('profiles dir')
-			expect(readYAMLFileMock).toHaveBeenCalledTimes(1)
-			expect(readYAMLFileMock).toHaveBeenCalledWith('profiles dir/profile.yaml')
-			expect(createReadStreamMock).toHaveBeenCalledTimes(1)
-			expect(createReadStreamMock).toHaveBeenCalledWith('profiles dir/profile.yaml')
-			expect(zipFileMock).toHaveBeenCalledTimes(1)
-			expect(zipFileMock).toHaveBeenCalledWith('profiles/profile.yml', readStreamMock)
-		})
+		expect(requireDirMock).toHaveBeenCalledTimes(1)
+		expect(requireDirMock).toHaveBeenCalledWith('project dir/profiles')
+		expect(readdirSyncMock).toHaveBeenCalledTimes(1)
+		expect(readdirSyncMock).toHaveBeenCalledWith('profiles dir')
+		expect(readYAMLFileMock).toHaveBeenCalledTimes(0)
+		expect(createReadStreamMock).toHaveBeenCalledTimes(0)
+		expect(zipFileMock).toHaveBeenCalledTimes(0)
+	})
 
-		it('throws exception for non-yaml files in profiles directory', async () => {
-			requireDirMock.mockResolvedValueOnce('profiles dir')
-			readdirSyncMock.mockReturnValueOnce(['profile.exe'])
+	it('adds yaml files with .yml extension', async () => {
+		requireDirMock.mockResolvedValueOnce('profiles dir')
+		readdirSyncMock.mockReturnValueOnce(['profile1.yml', 'profile2.yml'])
+		createReadStreamMock.mockReturnValueOnce(readStreamMock)
 
-			await expect(processProfiles('project dir', zipMock))
-				.rejects
-				.toThrow(new Errors.CLIError('invalid profile file "profiles dir/profile.exe" (must have .yaml or .yml extension)'))
+		await expect(processProfiles('project dir', zipMock)).resolves.not.toThrow()
 
-			expect(requireDirMock).toHaveBeenCalledTimes(1)
-			expect(requireDirMock).toHaveBeenCalledWith('project dir/profiles')
-			expect(readdirSyncMock).toHaveBeenCalledTimes(1)
-			expect(readdirSyncMock).toHaveBeenCalledWith('profiles dir')
-			expect(readYAMLFileMock).toHaveBeenCalledTimes(0)
-			expect(createReadStreamMock).toHaveBeenCalledTimes(0)
-			expect(zipFileMock).toHaveBeenCalledTimes(0)
-		})
+		expect(requireDirMock).toHaveBeenCalledTimes(1)
+		expect(requireDirMock).toHaveBeenCalledWith('project dir/profiles')
+		expect(readdirSyncMock).toHaveBeenCalledTimes(1)
+		expect(readdirSyncMock).toHaveBeenCalledWith('profiles dir')
+		expect(readYAMLFileMock).toHaveBeenCalledTimes(2)
+		expect(readYAMLFileMock).toHaveBeenCalledWith('profiles dir/profile1.yml')
+		expect(readYAMLFileMock).toHaveBeenCalledWith('profiles dir/profile2.yml')
+		expect(createReadStreamMock).toHaveBeenCalledTimes(2)
+		expect(createReadStreamMock).toHaveBeenCalledWith('profiles dir/profile1.yml')
+		expect(createReadStreamMock).toHaveBeenCalledWith('profiles dir/profile2.yml')
+		expect(zipFileMock).toHaveBeenCalledTimes(2)
+		expect(zipFileMock).toHaveBeenCalledWith('profiles/profile1.yml', readStreamMock)
+		expect(zipFileMock).toHaveBeenCalledWith('profiles/profile2.yml', readStreamMock)
+	})
+
+	it('adds yaml files with .yaml extension as .yml', async () => {
+		requireDirMock.mockResolvedValueOnce('profiles dir')
+		readdirSyncMock.mockReturnValueOnce(['profile.yaml'])
+		createReadStreamMock.mockReturnValueOnce(readStreamMock)
+
+		await expect(processProfiles('project dir', zipMock)).resolves.not.toThrow()
+
+		expect(requireDirMock).toHaveBeenCalledTimes(1)
+		expect(requireDirMock).toHaveBeenCalledWith('project dir/profiles')
+		expect(readdirSyncMock).toHaveBeenCalledTimes(1)
+		expect(readdirSyncMock).toHaveBeenCalledWith('profiles dir')
+		expect(readYAMLFileMock).toHaveBeenCalledTimes(1)
+		expect(readYAMLFileMock).toHaveBeenCalledWith('profiles dir/profile.yaml')
+		expect(createReadStreamMock).toHaveBeenCalledTimes(1)
+		expect(createReadStreamMock).toHaveBeenCalledWith('profiles dir/profile.yaml')
+		expect(zipFileMock).toHaveBeenCalledTimes(1)
+		expect(zipFileMock).toHaveBeenCalledWith('profiles/profile.yml', readStreamMock)
+	})
+
+	it('throws exception for non-yaml files in profiles directory', async () => {
+		requireDirMock.mockResolvedValueOnce('profiles dir')
+		readdirSyncMock.mockReturnValueOnce(['profile.exe'])
+
+		await expect(processProfiles('project dir', zipMock))
+			.rejects
+			.toThrow(new Errors.CLIError('invalid profile file "profiles dir/profile.exe" (must have .yaml or .yml extension)'))
+
+		expect(requireDirMock).toHaveBeenCalledTimes(1)
+		expect(requireDirMock).toHaveBeenCalledWith('project dir/profiles')
+		expect(readdirSyncMock).toHaveBeenCalledTimes(1)
+		expect(readdirSyncMock).toHaveBeenCalledWith('profiles dir')
+		expect(readYAMLFileMock).toHaveBeenCalledTimes(0)
+		expect(createReadStreamMock).toHaveBeenCalledTimes(0)
+		expect(zipFileMock).toHaveBeenCalledTimes(0)
 	})
 })

--- a/packages/edge/src/__tests__/lib/live-logging.test.ts
+++ b/packages/edge/src/__tests__/lib/live-logging.test.ts
@@ -12,266 +12,264 @@ jest.mock('axios', () => ({
 	request: jest.fn(),
 }))
 
-describe('live-logging', () => {
-	const driverId = 'driverId'
+const driverId = 'driverId'
 
-	describe('liveLogMessageFormatter', () => {
-		const errorEvent: LiveLogMessage = {
-			timestamp: new Date().toISOString(),
-			/* eslint-disable @typescript-eslint/naming-convention */
-			driver_id: driverId,
-			driver_name: 'Driver',
-			log_level: LogLevel.ERROR,
-			/* eslint-enable @typescript-eslint/naming-convention */
-			message: 'Something bad happened.',
-		}
+describe('liveLogMessageFormatter', () => {
+	const errorEvent: LiveLogMessage = {
+		timestamp: new Date().toISOString(),
+		/* eslint-disable @typescript-eslint/naming-convention */
+		driver_id: driverId,
+		driver_name: 'Driver',
+		log_level: LogLevel.ERROR,
+		/* eslint-enable @typescript-eslint/naming-convention */
+		message: 'Something bad happened.',
+	}
 
-		const randomEvent = {
-			field1: 'one',
-			field2: 2,
-		}
+	const randomEvent = {
+		field1: 'one',
+		field2: 2,
+	}
 
-		it('returns timestamp in event format', () => {
-			const format = liveLogMessageFormatter(errorEvent)
-			expect(format.time).toBe(errorEvent.timestamp)
-		})
-
-		it('errors out if passed bad event type', () => {
-			expect(() => liveLogMessageFormatter(randomEvent)).toThrowError('Unexpected log message type.')
-		})
-
-		it('has expected formatString', () => {
-			const format = liveLogMessageFormatter(errorEvent)
-
-			// remove ANSI color codes
-			const rawFormat = stripAnsi(format.formatString)
-
-			expect(rawFormat).toBe(`ERROR ${errorEvent.driver_name}  ${errorEvent.message}`)
-		})
+	it('returns timestamp in event format', () => {
+		const format = liveLogMessageFormatter(errorEvent)
+		expect(format.time).toBe(errorEvent.timestamp)
 	})
 
-	describe('parseIpAndPort', () => {
-		it.each`
-			address                | expected
-			${'192.168.0.1'}       | ${['192.168.0.1', undefined]}
-			${'192.168.0.1:0'}     | ${['192.168.0.1', '0']}
-			${'192.168.0.1:1234'}  | ${['192.168.0.1', '1234']}
-			${'192.168.0.1:65535'} | ${['192.168.0.1', '65535']}
-		`('returns $expected when $address is parsed', ({ address, expected }) => {
-			expect(parseIpAndPort(address)).toStrictEqual(expected)
-		})
-
-		it.each([
-			'192.168.0.1::1234',
-			'fe80::af:7f6a:9613:aa15',
-			'[fe80::af:7f6a:9613:aa15]:1234',
-		])('throws invalid address and port error when %s is parsed', (address) => {
-			expect(() => parseIpAndPort(address)).toThrow('Invalid IPv4 address and port format.')
-		})
-
-		it.each([
-			'',
-			'123',
-			'abc',
-		])('throws invalid address error when %s is parsed', (address) => {
-			expect(() => parseIpAndPort(address)).toThrow('Invalid IPv4 address format.')
-		})
-
-		it.each([
-			'192.168.0.1:123.4',
-			'192.168.0.1:-1',
-			'192.168.0.1:abc',
-			`192.168.0.1: ${Number.MAX_SAFE_INTEGER + 1}`,
-			`192.168.0.1: ${Number.MIN_SAFE_INTEGER - 1}`,
-		])('throws invalid port error when %s is parsed', (address) => {
-			expect(() => parseIpAndPort(address)).toThrow('Invalid port format.')
-		})
+	it('errors out if passed bad event type', () => {
+		expect(() => liveLogMessageFormatter(randomEvent)).toThrowError('Unexpected log message type.')
 	})
 
-	describe('handleConnectionErrors', () => {
-		it.each`
-			error             | message
-			${'ECONNREFUSED'} | ${'Unable to connect'}
-			${'EHOSTUNREACH'} | ${'Unable to connect'}
-			${'ETIMEDOUT'}    | ${'timed out'}
-			${'EHOSTDOWN'}    | ${'192.168.0.1 is down'}
-		`('throws $message when $error is handled', ({ error, message }) => {
-			expect(() => handleConnectionErrors('192.168.0.1', error)).toThrow(message)
-		})
+	it('has expected formatString', () => {
+		const format = liveLogMessageFormatter(errorEvent)
 
-		it.each([
-			'ETIME',
-			'econnrefused',
-			'Unauthorized',
-		])('does not throw when %s is handled', (error) => {
-			expect(() => handleConnectionErrors('192.168.0.1', error)).not.toThrow()
-		})
+		// remove ANSI color codes
+		const rawFormat = stripAnsi(format.formatString)
+
+		expect(rawFormat).toBe(`ERROR ${errorEvent.driver_name}  ${errorEvent.message}`)
+	})
+})
+
+describe('parseIpAndPort', () => {
+	it.each`
+		address                | expected
+		${'192.168.0.1'}       | ${['192.168.0.1', undefined]}
+		${'192.168.0.1:0'}     | ${['192.168.0.1', '0']}
+		${'192.168.0.1:1234'}  | ${['192.168.0.1', '1234']}
+		${'192.168.0.1:65535'} | ${['192.168.0.1', '65535']}
+	`('returns $expected when $address is parsed', ({ address, expected }) => {
+		expect(parseIpAndPort(address)).toStrictEqual(expected)
 	})
 
-	describe('LiveLogClient', () => {
-		const axiosRequestSpy = jest.spyOn(axios, 'request')
+	it.each([
+		'192.168.0.1::1234',
+		'fe80::af:7f6a:9613:aa15',
+		'[fe80::af:7f6a:9613:aa15]:1234',
+	])('throws invalid address and port error when %s is parsed', (address) => {
+		expect(() => parseIpAndPort(address)).toThrow('Invalid IPv4 address and port format.')
+	})
 
-		const authority = '192.168.0.1:9495'
-		const authenticator = new NoOpAuthenticator()
-		const timeout = 1000
-		const userAgent = 'userAgent'
-		const token = 'token'
-		const config: LiveLogClientConfig = {
-			authority,
-			authenticator,
-			timeout,
-			userAgent,
+	it.each([
+		'',
+		'123',
+		'abc',
+	])('throws invalid address error when %s is parsed', (address) => {
+		expect(() => parseIpAndPort(address)).toThrow('Invalid IPv4 address format.')
+	})
+
+	it.each([
+		'192.168.0.1:123.4',
+		'192.168.0.1:-1',
+		'192.168.0.1:abc',
+		`192.168.0.1: ${Number.MAX_SAFE_INTEGER + 1}`,
+		`192.168.0.1: ${Number.MIN_SAFE_INTEGER - 1}`,
+	])('throws invalid port error when %s is parsed', (address) => {
+		expect(() => parseIpAndPort(address)).toThrow('Invalid port format.')
+	})
+})
+
+describe('handleConnectionErrors', () => {
+	it.each`
+		error             | message
+		${'ECONNREFUSED'} | ${'Unable to connect'}
+		${'EHOSTUNREACH'} | ${'Unable to connect'}
+		${'ETIMEDOUT'}    | ${'timed out'}
+		${'EHOSTDOWN'}    | ${'192.168.0.1 is down'}
+	`('throws $message when $error is handled', ({ error, message }) => {
+		expect(() => handleConnectionErrors('192.168.0.1', error)).toThrow(message)
+	})
+
+	it.each([
+		'ETIME',
+		'econnrefused',
+		'Unauthorized',
+	])('does not throw when %s is handled', (error) => {
+		expect(() => handleConnectionErrors('192.168.0.1', error)).not.toThrow()
+	})
+})
+
+describe('LiveLogClient', () => {
+	const axiosRequestSpy = jest.spyOn(axios, 'request')
+
+	const authority = '192.168.0.1:9495'
+	const authenticator = new NoOpAuthenticator()
+	const timeout = 1000
+	const userAgent = 'userAgent'
+	const token = 'token'
+	const config: LiveLogClientConfig = {
+		authority,
+		authenticator,
+		timeout,
+		userAgent,
+	}
+	let testClient: LiveLogClient
+
+	beforeEach(() => {
+		testClient = new LiveLogClient(config)
+	})
+
+	it('returns log source for all drivers', () => {
+		const sourceURL = testClient.getLogSource()
+		expect(sourceURL).not.toContain('?')
+	})
+
+	it('returns log source for a specific driver', () => {
+		const sourceURL = testClient.getLogSource(driverId)
+
+		expect(sourceURL).toContain('?')
+		expect(sourceURL).toContain(driverId)
+	})
+
+	it('calls drivers endpoint with auth and timeout', async () => {
+		const bearerAuthenticator = new BearerTokenAuthenticator(token)
+		const bearerConfig = {
+			...config,
+			authenticator: bearerAuthenticator,
 		}
-		let testClient: LiveLogClient
+		testClient = new LiveLogClient(bearerConfig)
 
-		beforeEach(() => {
-			testClient = new LiveLogClient(config)
-		})
-
-		it('returns log source for all drivers', () => {
-			const sourceURL = testClient.getLogSource()
-			expect(sourceURL).not.toContain('?')
-		})
-
-		it('returns log source for a specific driver', () => {
-			const sourceURL = testClient.getLogSource(driverId)
-
-			expect(sourceURL).toContain('?')
-			expect(sourceURL).toContain(driverId)
-		})
-
-		it('calls drivers endpoint with auth and timeout', async () => {
-			const bearerAuthenticator = new BearerTokenAuthenticator(token)
-			const bearerConfig = {
-				...config,
-				authenticator: bearerAuthenticator,
-			}
-			testClient = new LiveLogClient(bearerConfig)
-
-			const axiosResponse = {
-				status: 200,
-				statusText: 'OK',
-				data: [
-					/* eslint-disable @typescript-eslint/naming-convention */
-					{
-						driver_id: driverId,
-						driver_name: 'Driver 0',
-						archive_hash: null,
-						status: DriverInfoStatus.Installed,
-					},
-					{
-						driver_id: driverId,
-						driver_name: 'Driver 1',
-						archive_hash: null,
-						status: DriverInfoStatus.Installed,
-					},
-					/* eslint-enable @typescript-eslint/naming-convention */
-				],
-			} as AxiosResponse<DriverInfo[]>
-
-			axiosRequestSpy.mockResolvedValueOnce(axiosResponse)
-
-			await testClient.getDrivers()
-
-			expect(axiosRequestSpy).toBeCalledWith(
-				expect.objectContaining({
-					headers: expect.objectContaining({ Authorization: `Bearer ${token}` }),
-					timeout: timeout,
-				}),
-			)
-		})
-
-		it('calls axios with transitional options to enable ETIMEDOUT', async () => {
-			axiosRequestSpy.mockResolvedValueOnce({ data: [] })
-
-			await testClient.getDrivers()
-
-			expect(axiosRequestSpy).toBeCalledWith(
-				expect.objectContaining({
-					transitional: expect.objectContaining({
-						clarifyTimeoutError: true,
-					}),
-				}),
-			)
-		})
-
-		it('uses CLI User-Agent in axios requests', async () => {
-			axiosRequestSpy.mockResolvedValueOnce({ data: [] })
-
-			await testClient.getDrivers()
-
-			expect(axiosRequestSpy).toBeCalledWith(
-				expect.objectContaining({
-					headers: expect.objectContaining({
-						// eslint-disable-next-line @typescript-eslint/naming-convention
-						'User-Agent': userAgent,
-					}),
-				}),
-			)
-		})
-
-		it('handles axios errors with user facing message', async () => {
-			const axiosError = {
-				message: 'connect ECONNREFUSED 192.168.0.1:9495',
-				errno: 'ECONNREFUSED',
-				code: 'ECONNREFUSED',
-				syscall: 'connect',
-				address: '192.168.0.1',
-				port: 9495,
-				config: {
-					url: 'https://192.168.0.1:9495/drivers',
-					method: 'get',
-					headers: {
-						Accept: 'application/json, text/plain, */*',
-						Authorization: `Bearer ${token}`,
-						// eslint-disable-next-line @typescript-eslint/naming-convention
-						'User-Agent': 'axios/0.21.1',
-					},
-					timeout: 5000,
-					data: undefined,
+		const axiosResponse = {
+			status: 200,
+			statusText: 'OK',
+			data: [
+				/* eslint-disable @typescript-eslint/naming-convention */
+				{
+					driver_id: driverId,
+					driver_name: 'Driver 0',
+					archive_hash: null,
+					status: DriverInfoStatus.Installed,
 				},
-				response: undefined,
-				isAxiosError: true,
-				toJSON: () => ({}),
-			}
+				{
+					driver_id: driverId,
+					driver_name: 'Driver 1',
+					archive_hash: null,
+					status: DriverInfoStatus.Installed,
+				},
+				/* eslint-enable @typescript-eslint/naming-convention */
+			],
+		} as AxiosResponse<DriverInfo[]>
 
-			axiosRequestSpy.mockRejectedValueOnce(axiosError)
+		axiosRequestSpy.mockResolvedValueOnce(axiosResponse)
 
-			await expect(testClient.getDrivers()).rejects.toThrow('Ensure hub address is correct and try again')
-		})
+		await testClient.getDrivers()
 
-		it('verifies host with provided verifier on first request only', async () => {
-			const cert = { fingerprint: 'fingerprint' } as PeerCertificate
-			jest.spyOn(TLSSocket.prototype, 'getPeerCertificate').mockReturnValue(cert)
-			const request: Partial<ClientRequest> = {
-				socket: new TLSSocket(new Socket()),
-			}
+		expect(axiosRequestSpy).toBeCalledWith(
+			expect.objectContaining({
+				headers: expect.objectContaining({ Authorization: `Bearer ${token}` }),
+				timeout: timeout,
+			}),
+		)
+	})
 
-			const certResponse = {
-				data: '',
-				status: 200,
-				statusText: 'OK',
-				request: request,
-			} as AxiosResponse
+	it('calls axios with transitional options to enable ETIMEDOUT', async () => {
+		axiosRequestSpy.mockResolvedValueOnce({ data: [] })
 
-			const mockHostVerifier = jest.fn()
-			const verifierConfig = {
-				...config,
-				verifier: mockHostVerifier,
-			}
-			testClient = new LiveLogClient(verifierConfig)
-			axiosRequestSpy.mockResolvedValue(certResponse)
+		await testClient.getDrivers()
 
-			await testClient.getDrivers()
+		expect(axiosRequestSpy).toBeCalledWith(
+			expect.objectContaining({
+				transitional: expect.objectContaining({
+					clarifyTimeoutError: true,
+				}),
+			}),
+		)
+	})
 
-			expect(mockHostVerifier).toBeCalledTimes(1)
-			expect(mockHostVerifier).toBeCalledWith(cert)
+	it('uses CLI User-Agent in axios requests', async () => {
+		axiosRequestSpy.mockResolvedValueOnce({ data: [] })
 
-			mockHostVerifier.mockClear()
+		await testClient.getDrivers()
 
-			await testClient.getDrivers()
+		expect(axiosRequestSpy).toBeCalledWith(
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					// eslint-disable-next-line @typescript-eslint/naming-convention
+					'User-Agent': userAgent,
+				}),
+			}),
+		)
+	})
 
-			expect(mockHostVerifier).not.toBeCalled()
-		})
+	it('handles axios errors with user facing message', async () => {
+		const axiosError = {
+			message: 'connect ECONNREFUSED 192.168.0.1:9495',
+			errno: 'ECONNREFUSED',
+			code: 'ECONNREFUSED',
+			syscall: 'connect',
+			address: '192.168.0.1',
+			port: 9495,
+			config: {
+				url: 'https://192.168.0.1:9495/drivers',
+				method: 'get',
+				headers: {
+					Accept: 'application/json, text/plain, */*',
+					Authorization: `Bearer ${token}`,
+					// eslint-disable-next-line @typescript-eslint/naming-convention
+					'User-Agent': 'axios/0.21.1',
+				},
+				timeout: 5000,
+				data: undefined,
+			},
+			response: undefined,
+			isAxiosError: true,
+			toJSON: () => ({}),
+		}
+
+		axiosRequestSpy.mockRejectedValueOnce(axiosError)
+
+		await expect(testClient.getDrivers()).rejects.toThrow('Ensure hub address is correct and try again')
+	})
+
+	it('verifies host with provided verifier on first request only', async () => {
+		const cert = { fingerprint: 'fingerprint' } as PeerCertificate
+		jest.spyOn(TLSSocket.prototype, 'getPeerCertificate').mockReturnValue(cert)
+		const request: Partial<ClientRequest> = {
+			socket: new TLSSocket(new Socket()),
+		}
+
+		const certResponse = {
+			data: '',
+			status: 200,
+			statusText: 'OK',
+			request: request,
+		} as AxiosResponse
+
+		const mockHostVerifier = jest.fn()
+		const verifierConfig = {
+			...config,
+			verifier: mockHostVerifier,
+		}
+		testClient = new LiveLogClient(verifierConfig)
+		axiosRequestSpy.mockResolvedValue(certResponse)
+
+		await testClient.getDrivers()
+
+		expect(mockHostVerifier).toBeCalledTimes(1)
+		expect(mockHostVerifier).toBeCalledWith(cert)
+
+		mockHostVerifier.mockClear()
+
+		await testClient.getDrivers()
+
+		expect(mockHostVerifier).not.toBeCalled()
 	})
 })

--- a/packages/lib/src/__tests__/device-util.test.ts
+++ b/packages/lib/src/__tests__/device-util.test.ts
@@ -9,152 +9,150 @@ import { selectFromList } from '../select.js'
 jest.mock('../command-util')
 jest.mock('../select')
 
-describe('device-util', () => {
-	const listDevicesMock = jest.fn()
-	const client = { devices: { list: listDevicesMock } }
-	const command = { client } as unknown as APICommand<typeof APICommand.flags>
+const listDevicesMock = jest.fn()
+const client = { devices: { list: listDevicesMock } }
+const command = { client } as unknown as APICommand<typeof APICommand.flags>
 
-	const selectFromListMock = jest.mocked(selectFromList)
-	const stringTranslateToIdMock = jest.mocked(stringTranslateToId)
+const selectFromListMock = jest.mocked(selectFromList)
+const stringTranslateToIdMock = jest.mocked(stringTranslateToId)
 
-	describe('chooseDevice', () => {
-		it('proxies correctly to selectFromList', async () => {
-			selectFromListMock.mockImplementation(async () => 'chosen-device-id')
+describe('chooseDevice', () => {
+	it('proxies correctly to selectFromList', async () => {
+		selectFromListMock.mockImplementation(async () => 'chosen-device-id')
 
-			expect(await chooseDevice(command, 'command-line-device-id')).toBe('chosen-device-id')
+		expect(await chooseDevice(command, 'command-line-device-id')).toBe('chosen-device-id')
 
-			expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
-			expect(selectFromListMock).toHaveBeenCalledTimes(1)
-			expect(selectFromListMock).toHaveBeenCalledWith(command,
-				expect.objectContaining({ primaryKeyName: 'deviceId', sortKeyName: 'label' }),
-				expect.objectContaining({ preselectedId: 'command-line-device-id' }))
+		expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(command,
+			expect.objectContaining({ primaryKeyName: 'deviceId', sortKeyName: 'label' }),
+			expect.objectContaining({ preselectedId: 'command-line-device-id' }))
 
-			const listItems = selectFromListMock.mock.calls[0][2].listItems
+		const listItems = selectFromListMock.mock.calls[0][2].listItems
 
-			const list = [{ deviceId: 'listed-device-id' }] as Device[]
-			listDevicesMock.mockResolvedValueOnce(list)
+		const list = [{ deviceId: 'listed-device-id' }] as Device[]
+		listDevicesMock.mockResolvedValueOnce(list)
 
-			expect(await listItems()).toStrictEqual(list)
+		expect(await listItems()).toStrictEqual(list)
 
-			expect(listDevicesMock).toHaveBeenCalledTimes(1)
-			expect(listDevicesMock).toHaveBeenCalledWith(undefined)
-		})
-
-		it('passes on deviceListOptions to list', async () => {
-			selectFromListMock.mockImplementation(async () => 'chosen-device-id')
-			const deviceListOptions = { locationId: 'locationId' }
-
-			expect(await chooseDevice(command, 'command-line-device-id', { deviceListOptions })).toBe('chosen-device-id')
-
-			expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
-			expect(selectFromListMock).toHaveBeenCalledTimes(1)
-			expect(selectFromListMock).toHaveBeenCalledWith(command,
-				expect.objectContaining({ primaryKeyName: 'deviceId', sortKeyName: 'label' }),
-				expect.objectContaining({ preselectedId: 'command-line-device-id' }))
-
-			const listItems = selectFromListMock.mock.calls[0][2].listItems
-
-			const list = [{ deviceId: 'listed-device-id' }] as Device[]
-			listDevicesMock.mockResolvedValueOnce(list)
-
-			expect(await listItems()).toStrictEqual(list)
-
-			expect(listDevicesMock).toHaveBeenCalledTimes(1)
-			expect(listDevicesMock).toHaveBeenCalledWith(deviceListOptions)
-		})
-
-		it('filters items if requested', async () => {
-			selectFromListMock.mockImplementation(async () => 'chosen-device-id')
-			const deviceListFilter = (device: Device): boolean => device.deviceId !== 'skip-me'
-
-			expect(await chooseDevice(command, 'command-line-device-id', { deviceListFilter })).toBe('chosen-device-id')
-
-			expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
-			expect(selectFromListMock).toHaveBeenCalledTimes(1)
-			expect(selectFromListMock).toHaveBeenCalledWith(command,
-				expect.objectContaining({ primaryKeyName: 'deviceId', sortKeyName: 'label' }),
-				expect.objectContaining({ preselectedId: 'command-line-device-id' }))
-
-			const listItems = selectFromListMock.mock.calls[0][2].listItems
-
-			const list = [
-				{ deviceId: 'listed-device-id' },
-				{ deviceId: 'skip-me' },
-				{ deviceId: 'keep-me' },
-			] as Device[]
-			listDevicesMock.mockResolvedValueOnce(list)
-
-			const expected = [
-				{ deviceId: 'listed-device-id' },
-				{ deviceId: 'keep-me' },
-			]
-			expect(await listItems()).toStrictEqual(expected)
-
-			expect(listDevicesMock).toHaveBeenCalledTimes(1)
-			expect(listDevicesMock).toHaveBeenCalledWith(undefined)
-		})
-
-		it('translates input from index if allowed', async () => {
-			stringTranslateToIdMock.mockResolvedValueOnce('translated-id')
-			selectFromListMock.mockImplementation(async () => 'chosen-device-id')
-
-			expect(await chooseDevice(command, 'command-line-device-id', { allowIndex: true }))
-				.toBe('chosen-device-id')
-
-			expect(stringTranslateToIdMock).toHaveBeenCalledTimes(1)
-			expect(stringTranslateToIdMock).toHaveBeenCalledWith(
-				expect.objectContaining({ primaryKeyName: 'deviceId', sortKeyName: 'label' }),
-				'command-line-device-id', expect.any(Function))
-			expect(selectFromListMock).toHaveBeenCalledTimes(1)
-			expect(selectFromListMock).toHaveBeenCalledWith(command,
-				expect.objectContaining({ primaryKeyName: 'deviceId', sortKeyName: 'label' }),
-				expect.objectContaining({ preselectedId: 'translated-id' }))
-		})
+		expect(listDevicesMock).toHaveBeenCalledTimes(1)
+		expect(listDevicesMock).toHaveBeenCalledWith(undefined)
 	})
 
-	describe('chooseComponent', () => {
-		const components = [{ id: 'componentId' }] as Component[]
+	it('passes on deviceListOptions to list', async () => {
+		selectFromListMock.mockImplementation(async () => 'chosen-device-id')
+		const deviceListOptions = { locationId: 'locationId' }
 
-		it('returns "main" by default if components are empty', async () => {
-			expect(await chooseComponent(command, 'command-line-component-id')).toBe('main')
-			expect(await chooseComponent(command, 'command-line-component-id', [])).toBe('main')
+		expect(await chooseDevice(command, 'command-line-device-id', { deviceListOptions })).toBe('chosen-device-id')
+
+		expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(command,
+			expect.objectContaining({ primaryKeyName: 'deviceId', sortKeyName: 'label' }),
+			expect.objectContaining({ preselectedId: 'command-line-device-id' }))
+
+		const listItems = selectFromListMock.mock.calls[0][2].listItems
+
+		const list = [{ deviceId: 'listed-device-id' }] as Device[]
+		listDevicesMock.mockResolvedValueOnce(list)
+
+		expect(await listItems()).toStrictEqual(list)
+
+		expect(listDevicesMock).toHaveBeenCalledTimes(1)
+		expect(listDevicesMock).toHaveBeenCalledWith(deviceListOptions)
+	})
+
+	it('filters items if requested', async () => {
+		selectFromListMock.mockImplementation(async () => 'chosen-device-id')
+		const deviceListFilter = (device: Device): boolean => device.deviceId !== 'skip-me'
+
+		expect(await chooseDevice(command, 'command-line-device-id', { deviceListFilter })).toBe('chosen-device-id')
+
+		expect(stringTranslateToIdMock).toHaveBeenCalledTimes(0)
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(command,
+			expect.objectContaining({ primaryKeyName: 'deviceId', sortKeyName: 'label' }),
+			expect.objectContaining({ preselectedId: 'command-line-device-id' }))
+
+		const listItems = selectFromListMock.mock.calls[0][2].listItems
+
+		const list = [
+			{ deviceId: 'listed-device-id' },
+			{ deviceId: 'skip-me' },
+			{ deviceId: 'keep-me' },
+		] as Device[]
+		listDevicesMock.mockResolvedValueOnce(list)
+
+		const expected = [
+			{ deviceId: 'listed-device-id' },
+			{ deviceId: 'keep-me' },
+		]
+		expect(await listItems()).toStrictEqual(expected)
+
+		expect(listDevicesMock).toHaveBeenCalledTimes(1)
+		expect(listDevicesMock).toHaveBeenCalledWith(undefined)
+	})
+
+	it('translates input from index if allowed', async () => {
+		stringTranslateToIdMock.mockResolvedValueOnce('translated-id')
+		selectFromListMock.mockImplementation(async () => 'chosen-device-id')
+
+		expect(await chooseDevice(command, 'command-line-device-id', { allowIndex: true }))
+			.toBe('chosen-device-id')
+
+		expect(stringTranslateToIdMock).toHaveBeenCalledTimes(1)
+		expect(stringTranslateToIdMock).toHaveBeenCalledWith(
+			expect.objectContaining({ primaryKeyName: 'deviceId', sortKeyName: 'label' }),
+			'command-line-device-id', expect.any(Function))
+		expect(selectFromListMock).toHaveBeenCalledTimes(1)
+		expect(selectFromListMock).toHaveBeenCalledWith(command,
+			expect.objectContaining({ primaryKeyName: 'deviceId', sortKeyName: 'label' }),
+			expect.objectContaining({ preselectedId: 'translated-id' }))
+	})
+})
+
+describe('chooseComponent', () => {
+	const components = [{ id: 'componentId' }] as Component[]
+
+	it('returns "main" by default if components are empty', async () => {
+		expect(await chooseComponent(command, 'command-line-component-id')).toBe('main')
+		expect(await chooseComponent(command, 'command-line-component-id', [])).toBe('main')
+	})
+
+	it('uses components as listItems when prompting', async () => {
+		await chooseComponent(command, 'command-line-component-id', components)
+
+		const listFunction = stringTranslateToIdMock.mock.calls[0][2]
+		expect(await listFunction()).toStrictEqual(components)
+	})
+
+	it('calls prompt functions with correct config', async () => {
+		selectFromListMock.mockResolvedValueOnce('componentId')
+		stringTranslateToIdMock.mockResolvedValueOnce('componentId')
+
+		expect(await chooseComponent(command, 'command-line-component-id', components)).toBe('componentId')
+
+		const expectedConfig = expect.objectContaining({
+			itemName: 'component',
+			primaryKeyName: 'id',
+			sortKeyName: 'id',
+			listTableFieldDefinitions: [{ label: 'Id', value: expect.any(Function) }],
 		})
 
-		it('uses components as listItems when prompting', async () => {
-			await chooseComponent(command, 'command-line-component-id', components)
+		expect(stringTranslateToIdMock).toBeCalledWith(
+			expectedConfig,
+			'command-line-component-id',
+			expect.any(Function),
+		)
 
-			const listFunction = stringTranslateToIdMock.mock.calls[0][2]
-			expect(await listFunction()).toStrictEqual(components)
-		})
-
-		it('calls prompt functions with correct config', async () => {
-			selectFromListMock.mockResolvedValueOnce('componentId')
-			stringTranslateToIdMock.mockResolvedValueOnce('componentId')
-
-			expect(await chooseComponent(command, 'command-line-component-id', components)).toBe('componentId')
-
-			const expectedConfig = expect.objectContaining({
-				itemName: 'component',
-				primaryKeyName: 'id',
-				sortKeyName: 'id',
-				listTableFieldDefinitions: [{ label: 'Id', value: expect.any(Function) }],
-			})
-
-			expect(stringTranslateToIdMock).toBeCalledWith(
-				expectedConfig,
-				'command-line-component-id',
-				expect.any(Function),
-			)
-
-			expect(selectFromListMock).toBeCalledWith(
-				expect.anything(),
-				expectedConfig,
-				expect.objectContaining({
-					preselectedId: 'componentId',
-					listItems: expect.any(Function),
-					autoChoose: true,
-				}),
-			)
-		})
+		expect(selectFromListMock).toBeCalledWith(
+			expect.anything(),
+			expectedConfig,
+			expect.objectContaining({
+				preselectedId: 'componentId',
+				listItems: expect.any(Function),
+				autoChoose: true,
+			}),
+		)
 	})
 })

--- a/packages/lib/src/__tests__/sse-io.test.ts
+++ b/packages/lib/src/__tests__/sse-io.test.ts
@@ -8,54 +8,52 @@ import { CliUx } from '@oclif/core'
 
 jest.mock('@oclif/core')
 
-describe('sse-io', () => {
-	describe('logEvent', () => {
-		const event = new MessageEvent('message', { data: '{}' })
-		const format = {
-			formatString: '%s %s',
-			formatArgs: ['one', 'two'],
+describe('logEvent', () => {
+	const event = new MessageEvent('message', { data: '{}' })
+	const format = {
+		formatString: '%s %s',
+		formatArgs: ['one', 'two'],
+		time: new Date().toISOString(),
+	}
+
+	const formatter = jest.fn(() => {
+		return format
+	})
+
+	const logSpy = jest.spyOn(CliUx.ux, 'log')
+
+	it('calls formatter function', () => {
+		logEvent(event, formatter)
+
+		expect(formatter).toBeCalledTimes(1)
+	})
+
+	it('does not call formatter or throw when unable to parse event', () => {
+		const badEvent = new MessageEvent('message', { data: '' })
+		expect(() => logEvent(badEvent, formatter)).not.toThrow()
+		expect(formatter).not.toBeCalled
+	})
+
+	it('logs time string as prefix by default', () => {
+		const emptyFormat = {
+			formatString: '',
 			time: new Date().toISOString(),
 		}
 
-		const formatter = jest.fn(() => {
-			return format
+		const emptyFormatter = jest.fn(() => {
+			return emptyFormat
 		})
 
-		const logSpy = jest.spyOn(CliUx.ux, 'log')
+		logEvent(event, emptyFormatter)
 
-		it('calls formatter function', () => {
-			logEvent(event, formatter)
+		expect(logSpy.mock.calls[0][0]).not.toBe(emptyFormat.formatString)
+		expect(logSpy.mock.calls[0][1]).toBe(emptyFormat.time)
+	})
 
-			expect(formatter).toBeCalledTimes(1)
-		})
+	it('logs formatArgs as specified by formatter', () => {
+		logEvent(event, formatter)
 
-		it('does not call formatter or throw when unable to parse event', () => {
-			const badEvent = new MessageEvent('message', { data: '' })
-			expect(() => logEvent(badEvent, formatter)).not.toThrow()
-			expect(formatter).not.toBeCalled
-		})
-
-		it('logs time string as prefix by default', () => {
-			const emptyFormat = {
-				formatString: '',
-				time: new Date().toISOString(),
-			}
-
-			const emptyFormatter = jest.fn(() => {
-				return emptyFormat
-			})
-
-			logEvent(event, emptyFormatter)
-
-			expect(logSpy.mock.calls[0][0]).not.toBe(emptyFormat.formatString)
-			expect(logSpy.mock.calls[0][1]).toBe(emptyFormat.time)
-		})
-
-		it('logs formatArgs as specified by formatter', () => {
-			logEvent(event, formatter)
-
-			expect(logSpy.mock.calls[0][0]).toContain(format.formatString)
-			expect(logSpy).toBeCalledWith(expect.anything(), expect.anything(), ...format.formatArgs)
-		})
+		expect(logSpy.mock.calls[0][0]).toContain(format.formatString)
+		expect(logSpy).toBeCalledWith(expect.anything(), expect.anything(), ...format.formatArgs)
 	})
 })

--- a/src/__tests__/lib/cli-config.test.ts
+++ b/src/__tests__/lib/cli-config.test.ts
@@ -46,363 +46,361 @@ const {
 } = await import('../../lib/cli-config.js')
 
 
-describe('cli-config', () => {
-	describe('loadConfigFile', () => {
-		it('returns empty object when filename does not exist', async () => {
-			yamlExistsMock.mockReturnValueOnce(false)
+describe('loadConfigFile', () => {
+	it('returns empty object when filename does not exist', async () => {
+		yamlExistsMock.mockReturnValueOnce(false)
 
-			expect(await loadConfigFile('does/not/exist')).toEqual({})
+		expect(await loadConfigFile('does/not/exist')).toEqual({})
 
-			expect(yamlExistsMock).toHaveBeenCalledTimes(1)
-			expect(yamlExistsMock).toHaveBeenCalledWith('does/not/exist')
-			expect(yamlLoadMock).toHaveBeenCalledTimes(0)
-			expect(readFileMock).toHaveBeenCalledTimes(0)
+		expect(yamlExistsMock).toHaveBeenCalledTimes(1)
+		expect(yamlExistsMock).toHaveBeenCalledWith('does/not/exist')
+		expect(yamlLoadMock).toHaveBeenCalledTimes(0)
+		expect(readFileMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('returns empty object for empty file', async () => {
+		readFileMock.mockResolvedValueOnce('empty contents')
+		yamlLoadMock.mockReturnValueOnce('')
+
+		expect(await loadConfigFile('empty file')).toEqual({})
+
+		expect(yamlExistsMock).toHaveBeenCalledTimes(1)
+		expect(yamlExistsMock).toHaveBeenCalledWith('empty file')
+		expect(readFileMock).toHaveBeenCalledTimes(1)
+		expect(readFileMock).toHaveBeenCalledWith('empty file', 'utf-8')
+		expect(yamlLoadMock).toHaveBeenCalledTimes(1)
+		expect(yamlLoadMock).toHaveBeenCalledWith('empty contents')
+	})
+
+	it.each(['string', ['array']])('throws error for non-object yaml file', async (parsedYAML) => {
+		readFileMock.mockResolvedValueOnce('file contents')
+		yamlLoadMock.mockReturnValueOnce(parsedYAML)
+
+		await expect(loadConfigFile('configFilename.json'))
+			.rejects.toThrow('invalid config file format\n' + seeConfigDocs)
+
+		expect(yamlExistsMock).toHaveBeenCalledTimes(1)
+		expect(yamlExistsMock).toHaveBeenCalledWith('configFilename.json')
+		expect(readFileMock).toHaveBeenCalledTimes(1)
+		expect(readFileMock).toHaveBeenCalledWith('configFilename.json', 'utf-8')
+		expect(yamlLoadMock).toHaveBeenCalledTimes(1)
+		expect(yamlLoadMock).toHaveBeenCalledWith('file contents')
+	})
+
+	it('combines errors for individual profiles', async () => {
+		readFileMock.mockResolvedValueOnce('config with multiple errors')
+		yamlLoadMock.mockReturnValueOnce({
+			goodProfile: {},
+			badProfile1: 'just a string',
+			badProfile2: ['array', 'of', 'strings'],
 		})
 
-		it('returns empty object for empty file', async () => {
-			readFileMock.mockResolvedValueOnce('empty contents')
-			yamlLoadMock.mockReturnValueOnce('')
+		await expect(loadConfigFile('file with bad configs'))
+			.rejects.toThrow('bad profile badProfile1; profile must be an object\n' +
+				'bad profile badProfile2; profile must be an object\n' +  seeConfigDocs)
 
-			expect(await loadConfigFile('empty file')).toEqual({})
+		expect(yamlExistsMock).toHaveBeenCalledTimes(1)
+		expect(yamlExistsMock).toHaveBeenCalledWith('file with bad configs')
+		expect(readFileMock).toHaveBeenCalledTimes(1)
+		expect(readFileMock).toHaveBeenCalledWith('file with bad configs', 'utf-8')
+		expect(yamlLoadMock).toHaveBeenCalledTimes(1)
+		expect(yamlLoadMock).toHaveBeenCalledWith('config with multiple errors')
+	})
 
-			expect(yamlExistsMock).toHaveBeenCalledTimes(1)
-			expect(yamlExistsMock).toHaveBeenCalledWith('empty file')
-			expect(readFileMock).toHaveBeenCalledTimes(1)
-			expect(readFileMock).toHaveBeenCalledWith('empty file', 'utf-8')
-			expect(yamlLoadMock).toHaveBeenCalledTimes(1)
-			expect(yamlLoadMock).toHaveBeenCalledWith('empty contents')
-		})
+	it('returns properly formatted config file', async () => {
+		const goodConfig = {
+			goodProfile1: {
+				config1: 'configured value',
+				config2: ['array', 'of', 'strings'],
+			},
+			goodProfile2: {
+				config1: 'another value',
+				config3: { complex: 'config' },
+			},
+		}
+		readFileMock.mockResolvedValueOnce('good contents')
+		yamlLoadMock.mockReturnValueOnce(goodConfig)
 
-		it.each(['string', ['array']])('throws error for non-object yaml file', async (parsedYAML) => {
-			readFileMock.mockResolvedValueOnce('file contents')
-			yamlLoadMock.mockReturnValueOnce(parsedYAML)
+		expect(await loadConfigFile('good file')).toEqual(goodConfig)
 
-			await expect(loadConfigFile('configFilename.json'))
-				.rejects.toThrow('invalid config file format\n' + seeConfigDocs)
+		expect(yamlExistsMock).toHaveBeenCalledTimes(1)
+		expect(yamlExistsMock).toHaveBeenCalledWith('good file')
+		expect(readFileMock).toHaveBeenCalledTimes(1)
+		expect(readFileMock).toHaveBeenCalledWith('good file', 'utf-8')
+		expect(yamlLoadMock).toHaveBeenCalledTimes(1)
+		expect(yamlLoadMock).toHaveBeenCalledWith('good contents')
+	})
+})
 
-			expect(yamlExistsMock).toHaveBeenCalledTimes(1)
-			expect(yamlExistsMock).toHaveBeenCalledWith('configFilename.json')
-			expect(readFileMock).toHaveBeenCalledTimes(1)
-			expect(readFileMock).toHaveBeenCalledWith('configFilename.json', 'utf-8')
-			expect(yamlLoadMock).toHaveBeenCalledTimes(1)
-			expect(yamlLoadMock).toHaveBeenCalledWith('file contents')
-		})
+describe('mergeProfiles', () => {
+	it('returns empty config given two empty configs', () => {
+		const preferred = {} as ProfilesByName
+		const secondary = {} as ProfilesByName
 
-		it('combines errors for individual profiles', async () => {
-			readFileMock.mockResolvedValueOnce('config with multiple errors')
-			yamlLoadMock.mockReturnValueOnce({
-				goodProfile: {},
-				badProfile1: 'just a string',
-				badProfile2: ['array', 'of', 'strings'],
-			})
+		expect(mergeProfiles(preferred, secondary)).toEqual({})
+	})
 
-			await expect(loadConfigFile('file with bad configs'))
-				.rejects.toThrow('bad profile badProfile1; profile must be an object\n' +
-					'bad profile badProfile2; profile must be an object\n' +  seeConfigDocs)
+	it('includes profiles from both inputs', () => {
+		const preferred = { profile1: { configItem1: 'value 1' } } as ProfilesByName
+		const secondary = { profile2: { configItem2: 'value 2' } } as ProfilesByName
 
-			expect(yamlExistsMock).toHaveBeenCalledTimes(1)
-			expect(yamlExistsMock).toHaveBeenCalledWith('file with bad configs')
-			expect(readFileMock).toHaveBeenCalledTimes(1)
-			expect(readFileMock).toHaveBeenCalledWith('file with bad configs', 'utf-8')
-			expect(yamlLoadMock).toHaveBeenCalledTimes(1)
-			expect(yamlLoadMock).toHaveBeenCalledWith('config with multiple errors')
-		})
-
-		it('returns properly formatted config file', async () => {
-			const goodConfig = {
-				goodProfile1: {
-					config1: 'configured value',
-					config2: ['array', 'of', 'strings'],
-				},
-				goodProfile2: {
-					config1: 'another value',
-					config3: { complex: 'config' },
-				},
-			}
-			readFileMock.mockResolvedValueOnce('good contents')
-			yamlLoadMock.mockReturnValueOnce(goodConfig)
-
-			expect(await loadConfigFile('good file')).toEqual(goodConfig)
-
-			expect(yamlExistsMock).toHaveBeenCalledTimes(1)
-			expect(yamlExistsMock).toHaveBeenCalledWith('good file')
-			expect(readFileMock).toHaveBeenCalledTimes(1)
-			expect(readFileMock).toHaveBeenCalledWith('good file', 'utf-8')
-			expect(yamlLoadMock).toHaveBeenCalledTimes(1)
-			expect(yamlLoadMock).toHaveBeenCalledWith('good contents')
+		expect(mergeProfiles(preferred, secondary)).toEqual({
+			profile1: { configItem1: 'value 1' },
+			profile2: { configItem2: 'value 2' },
 		})
 	})
 
-	describe('mergeProfiles', () => {
-		it('returns empty config given two empty configs', () => {
-			const preferred = {} as ProfilesByName
-			const secondary = {} as ProfilesByName
+	it('combines config values from both inputs', () => {
+		const preferred = { profile1: { configItem1: 'value 1' } } as ProfilesByName
+		const secondary = { profile1: { configItem2: 'value 2' } } as ProfilesByName
 
-			expect(mergeProfiles(preferred, secondary)).toEqual({})
-		})
-
-		it('includes profiles from both inputs', () => {
-			const preferred = { profile1: { configItem1: 'value 1' } } as ProfilesByName
-			const secondary = { profile2: { configItem2: 'value 2' } } as ProfilesByName
-
-			expect(mergeProfiles(preferred, secondary)).toEqual({
-				profile1: { configItem1: 'value 1' },
-				profile2: { configItem2: 'value 2' },
-			})
-		})
-
-		it('combines config values from both inputs', () => {
-			const preferred = { profile1: { configItem1: 'value 1' } } as ProfilesByName
-			const secondary = { profile1: { configItem2: 'value 2' } } as ProfilesByName
-
-			expect(mergeProfiles(preferred, secondary)).toEqual({
-				profile1: {
-					configItem1: 'value 1',
-					configItem2: 'value 2',
-				},
-			})
-		})
-
-		it('config values from preferred are used over secondary values', () => {
-			const preferred = { profile1: { configItem1: 'preferred value' } } as ProfilesByName
-			const secondary = { profile1: { configItem1: 'overridden value' } } as ProfilesByName
-
-			expect(mergeProfiles(preferred, secondary)).toEqual({
-				profile1: {
-					configItem1: 'preferred value',
-				},
-			})
-		})
-
-		it('processes complicated example properly', () => {
-			const preferred = {
-				profileInBoth: {
-					onlyInPreferred: 'only in preferred',
-					inBoth: 'preferred value',
-				},
-				profileOnlyInPreferred: {
-					configItem1: 'value 1',
-					configItem2: 'value 2',
-				},
-			} as ProfilesByName
-			const secondary = {
-				profileInBoth: {
-					inBoth: 'overridden value',
-					onlyInSecondary: 'only in secondary',
-				},
-				profileOnlyInSecondary: {
-					configItem1: 'value 1',
-					configItem2: 'value 2',
-				},
-			} as ProfilesByName
-
-			expect(mergeProfiles(preferred, secondary)).toEqual({
-				profileInBoth: {
-					onlyInPreferred: 'only in preferred',
-					inBoth: 'preferred value',
-					onlyInSecondary: 'only in secondary',
-				},
-				profileOnlyInPreferred: {
-					configItem1: 'value 1',
-					configItem2: 'value 2',
-				},
-				profileOnlyInSecondary: {
-					configItem1: 'value 1',
-					configItem2: 'value 2',
-				},
-			})
+		expect(mergeProfiles(preferred, secondary)).toEqual({
+			profile1: {
+				configItem1: 'value 1',
+				configItem2: 'value 2',
+			},
 		})
 	})
 
-	const descriptionTemplate: CLIConfigDescription = {
-		configFilename: 'config-filename.yaml',
-		managedConfigFilename: 'managed-config-filename.yaml',
-		profileName: 'chosenProfile',
-	}
+	it('config values from preferred are used over secondary values', () => {
+		const preferred = { profile1: { configItem1: 'preferred value' } } as ProfilesByName
+		const secondary = { profile1: { configItem1: 'overridden value' } } as ProfilesByName
 
-	const profiles: ProfilesByName = {
-		mainConfigProfile: { key: 'value' },
-		chosenProfile: { configKey: 'configured value' },
-	}
-	const managedProfiles: ProfilesByName = { managedConfigProfile: { key: 'value' } }
-	const mergedProfiles: ProfilesByName = {
-		...profiles,
-		...managedProfiles,
-		chosenProfile: { configKey: 'configured value' },
-	}
-
-	describe('loadConfig', () => {
-		it('merges main and managed configurations', async () => {
-			const description = descriptionTemplate
-			const expected: CLIConfig = {
-				...description,
-				profiles,
-				managedProfiles,
-				mergedProfiles,
-				profile: mergedProfiles.chosenProfile,
-			}
-
-			readFileMock.mockResolvedValue('good contents')
-			yamlLoadMock.mockReturnValueOnce(profiles)
-			yamlLoadMock.mockReturnValueOnce(managedProfiles)
-
-			expect(await loadConfig(description)).toStrictEqual(expected)
-
-			expect(readFileMock).toHaveBeenCalledTimes(2)
-			expect(readFileMock).toHaveBeenCalledWith(description.configFilename, 'utf-8')
-			expect(readFileMock).toHaveBeenCalledWith(description.managedConfigFilename, 'utf-8')
-		})
-
-		it('uses empty profile if none exists', async () => {
-			const description = {
-				...descriptionTemplate,
-				profileName: 'nonExistentProfile',
-			}
-			const expected: CLIConfig = {
-				...description,
-				profiles,
-				managedProfiles,
-				mergedProfiles,
-				profile: {},
-			}
-
-			readFileMock.mockResolvedValue('good contents')
-			yamlLoadMock.mockReturnValueOnce(profiles)
-			yamlLoadMock.mockReturnValueOnce(managedProfiles)
-
-			expect(await loadConfig(description)).toStrictEqual(expected)
-
-			expect(readFileMock).toHaveBeenCalledTimes(2)
-			expect(readFileMock).toHaveBeenCalledWith(description.configFilename, 'utf-8')
-			expect(readFileMock).toHaveBeenCalledWith(description.managedConfigFilename, 'utf-8')
+		expect(mergeProfiles(preferred, secondary)).toEqual({
+			profile1: {
+				configItem1: 'preferred value',
+			},
 		})
 	})
 
-	test('setConfigKey writes updated file and updates config', async () => {
+	it('processes complicated example properly', () => {
+		const preferred = {
+			profileInBoth: {
+				onlyInPreferred: 'only in preferred',
+				inBoth: 'preferred value',
+			},
+			profileOnlyInPreferred: {
+				configItem1: 'value 1',
+				configItem2: 'value 2',
+			},
+		} as ProfilesByName
+		const secondary = {
+			profileInBoth: {
+				inBoth: 'overridden value',
+				onlyInSecondary: 'only in secondary',
+			},
+			profileOnlyInSecondary: {
+				configItem1: 'value 1',
+				configItem2: 'value 2',
+			},
+		} as ProfilesByName
+
+		expect(mergeProfiles(preferred, secondary)).toEqual({
+			profileInBoth: {
+				onlyInPreferred: 'only in preferred',
+				inBoth: 'preferred value',
+				onlyInSecondary: 'only in secondary',
+			},
+			profileOnlyInPreferred: {
+				configItem1: 'value 1',
+				configItem2: 'value 2',
+			},
+			profileOnlyInSecondary: {
+				configItem1: 'value 1',
+				configItem2: 'value 2',
+			},
+		})
+	})
+})
+
+const descriptionTemplate: CLIConfigDescription = {
+	configFilename: 'config-filename.yaml',
+	managedConfigFilename: 'managed-config-filename.yaml',
+	profileName: 'chosenProfile',
+}
+
+const profiles: ProfilesByName = {
+	mainConfigProfile: { key: 'value' },
+	chosenProfile: { configKey: 'configured value' },
+}
+const managedProfiles: ProfilesByName = { managedConfigProfile: { key: 'value' } }
+const mergedProfiles: ProfilesByName = {
+	...profiles,
+	...managedProfiles,
+	chosenProfile: { configKey: 'configured value' },
+}
+
+describe('loadConfig', () => {
+	it('merges main and managed configurations', async () => {
 		const description = descriptionTemplate
-		const cliConfig = {
+		const expected: CLIConfig = {
 			...description,
-			profileName: 'updatedProfile',
 			profiles,
 			managedProfiles,
-		} as CLIConfig
+			mergedProfiles,
+			profile: mergedProfiles.chosenProfile,
+		}
 
 		readFileMock.mockResolvedValue('good contents')
 		yamlLoadMock.mockReturnValueOnce(profiles)
 		yamlLoadMock.mockReturnValueOnce(managedProfiles)
 
-		yamlDumpMock.mockReturnValueOnce('yaml output')
+		expect(await loadConfig(description)).toStrictEqual(expected)
 
-		await expect(setConfigKey(cliConfig, 'keyToSet', 'value')).resolves.not.toThrow()
-
-		expect(yamlDumpMock).toHaveBeenCalledTimes(1)
-		expect(yamlDumpMock).toHaveBeenCalledWith({
-			...managedProfiles,
-			updatedProfile: {
-				keyToSet: 'value',
-			},
-		})
-		expect(writeFileMock).toHaveBeenCalledTimes(1)
-		expect(writeFileMock).toHaveBeenCalledWith(description.managedConfigFilename,
-			expect.stringContaining('yaml output'))
+		expect(readFileMock).toHaveBeenCalledTimes(2)
+		expect(readFileMock).toHaveBeenCalledWith(description.configFilename, 'utf-8')
+		expect(readFileMock).toHaveBeenCalledWith(description.managedConfigFilename, 'utf-8')
 	})
 
-	describe('resetManagedConfigKey', () => {
-		const deepCopy = <T> (input: T): T => JSON.parse(JSON.stringify(input))
-		const makeConfig = (profiles: ProfilesByName, managedProfiles: ProfilesByName): CLIConfig => deepCopy({
+	it('uses empty profile if none exists', async () => {
+		const description = {
 			...descriptionTemplate,
-			profileName: 'defaultProfile',
+			profileName: 'nonExistentProfile',
+		}
+		const expected: CLIConfig = {
+			...description,
 			profiles,
 			managedProfiles,
-			mergedProfiles: mergeProfiles(profiles, managedProfiles),
-		} as CLIConfig)
-
-		const profilesWithKeyToRemove: ProfilesByName = {
-			profile1: {
-				keyToRemove: 'remove value',
-			},
-			profile2: {
-				keyToRemove: 'value to remove',
-			},
-		}
-		const profilesWithKeysRemoved: ProfilesByName = {
-			profile1: {},
-			profile2: {},
+			mergedProfiles,
+			profile: {},
 		}
 
-		const predicateMock = jest.fn<(value: unknown) => boolean>()
+		readFileMock.mockResolvedValue('good contents')
+		yamlLoadMock.mockReturnValueOnce(profiles)
+		yamlLoadMock.mockReturnValueOnce(managedProfiles)
 
-		it('does nothing when key not present', async () => {
-			const cliConfig = makeConfig(profiles, managedProfiles)
+		expect(await loadConfig(description)).toStrictEqual(expected)
 
-			await expect(resetManagedConfigKey(cliConfig, 'unusedKey', predicateMock)).resolves.not.toThrow()
+		expect(readFileMock).toHaveBeenCalledTimes(2)
+		expect(readFileMock).toHaveBeenCalledWith(description.configFilename, 'utf-8')
+		expect(readFileMock).toHaveBeenCalledWith(description.managedConfigFilename, 'utf-8')
+	})
+})
 
-			expect(cliConfig).toStrictEqual(makeConfig(profiles, managedProfiles))
-			expect(predicateMock).toHaveBeenCalledTimes(0)
-		})
+test('setConfigKey writes updated file and updates config', async () => {
+	const description = descriptionTemplate
+	const cliConfig = {
+		...description,
+		profileName: 'updatedProfile',
+		profiles,
+		managedProfiles,
+	} as CLIConfig
 
-		it('does not modify user config', async () => {
-			const cliConfig = makeConfig(profilesWithKeyToRemove, managedProfiles)
+	readFileMock.mockResolvedValue('good contents')
+	yamlLoadMock.mockReturnValueOnce(profiles)
+	yamlLoadMock.mockReturnValueOnce(managedProfiles)
 
-			predicateMock.mockReturnValue(true)
-			await expect(resetManagedConfigKey(cliConfig, 'keyToRemove', predicateMock)).resolves.not.toThrow()
+	yamlDumpMock.mockReturnValueOnce('yaml output')
 
-			expect(cliConfig).toStrictEqual(makeConfig(profilesWithKeyToRemove, managedProfiles))
-			expect(predicateMock).toHaveBeenCalledTimes(0)
-		})
+	await expect(setConfigKey(cliConfig, 'keyToSet', 'value')).resolves.not.toThrow()
 
-		it('keeps keys that fail predicate', async () => {
-			const cliConfig = makeConfig(profiles, profilesWithKeyToRemove)
+	expect(yamlDumpMock).toHaveBeenCalledTimes(1)
+	expect(yamlDumpMock).toHaveBeenCalledWith({
+		...managedProfiles,
+		updatedProfile: {
+			keyToSet: 'value',
+		},
+	})
+	expect(writeFileMock).toHaveBeenCalledTimes(1)
+	expect(writeFileMock).toHaveBeenCalledWith(description.managedConfigFilename,
+		expect.stringContaining('yaml output'))
+})
 
-			predicateMock.mockReturnValue(false)
-			await expect(resetManagedConfigKey(cliConfig, 'keyToRemove', predicateMock)).resolves.not.toThrow()
+describe('resetManagedConfigKey', () => {
+	const deepCopy = <T> (input: T): T => JSON.parse(JSON.stringify(input))
+	const makeConfig = (profiles: ProfilesByName, managedProfiles: ProfilesByName): CLIConfig => deepCopy({
+		...descriptionTemplate,
+		profileName: 'defaultProfile',
+		profiles,
+		managedProfiles,
+		mergedProfiles: mergeProfiles(profiles, managedProfiles),
+	} as CLIConfig)
 
-			expect(cliConfig).toStrictEqual(makeConfig(profiles, profilesWithKeyToRemove))
-			expect(predicateMock).toHaveBeenCalledTimes(2)
-		})
+	const profilesWithKeyToRemove: ProfilesByName = {
+		profile1: {
+			keyToRemove: 'remove value',
+		},
+		profile2: {
+			keyToRemove: 'value to remove',
+		},
+	}
+	const profilesWithKeysRemoved: ProfilesByName = {
+		profile1: {},
+		profile2: {},
+	}
 
-		it('removes managed keys when no predicate is specified', async () => {
-			const cliConfig = makeConfig(profiles, profilesWithKeyToRemove)
+	const predicateMock = jest.fn<(value: unknown) => boolean>()
 
-			await expect(resetManagedConfigKey(cliConfig, 'keyToRemove')).resolves.not.toThrow()
+	it('does nothing when key not present', async () => {
+		const cliConfig = makeConfig(profiles, managedProfiles)
 
-			expect(cliConfig).toStrictEqual(makeConfig(profiles, profilesWithKeysRemoved))
-		})
+		await expect(resetManagedConfigKey(cliConfig, 'unusedKey', predicateMock)).resolves.not.toThrow()
 
-		it('removes managed keys that match predicate', async () => {
-			const cliConfig = makeConfig(profiles, profilesWithKeyToRemove)
-
-			predicateMock.mockReturnValue(true)
-			await expect(resetManagedConfigKey(cliConfig, 'keyToRemove', predicateMock)).resolves.not.toThrow()
-
-			expect(cliConfig).toStrictEqual(makeConfig(profiles, profilesWithKeysRemoved))
-			expect(predicateMock).toHaveBeenCalledTimes(2)
-		})
+		expect(cliConfig).toStrictEqual(makeConfig(profiles, managedProfiles))
+		expect(predicateMock).toHaveBeenCalledTimes(0)
 	})
 
-	test('resetManagedConfig', async () => {
-		const managedProfilesWithProfileToReset: ProfilesByName = {
-			...managedProfiles,
-			profileToReset: { not: 'empty' },
-		}
-		const description = descriptionTemplate
-		const cliConfig = {
-			...description,
-			profileName: 'updatedProfile',
-			profiles,
-			managedProfiles: { ...managedProfilesWithProfileToReset },
-		} as CLIConfig
-		yamlDumpMock.mockReturnValueOnce('yaml output')
+	it('does not modify user config', async () => {
+		const cliConfig = makeConfig(profilesWithKeyToRemove, managedProfiles)
 
-		await expect(resetManagedConfig(cliConfig, 'profileToReset')).resolves.not.toThrow()
+		predicateMock.mockReturnValue(true)
+		await expect(resetManagedConfigKey(cliConfig, 'keyToRemove', predicateMock)).resolves.not.toThrow()
 
-		expect(cliConfig.managedProfiles.profileToReset).toBeUndefined()
-		expect(cliConfig.mergedProfiles).toStrictEqual(mergedProfiles)
-
-		expect(yamlDumpMock).toHaveBeenCalledTimes(1)
-		expect(yamlDumpMock).toHaveBeenCalledWith(managedProfiles)
-		expect(writeFileMock).toHaveBeenCalledTimes(1)
-		expect(writeFileMock).toHaveBeenCalledWith(description.managedConfigFilename,
-			expect.stringContaining('yaml output'))
+		expect(cliConfig).toStrictEqual(makeConfig(profilesWithKeyToRemove, managedProfiles))
+		expect(predicateMock).toHaveBeenCalledTimes(0)
 	})
+
+	it('keeps keys that fail predicate', async () => {
+		const cliConfig = makeConfig(profiles, profilesWithKeyToRemove)
+
+		predicateMock.mockReturnValue(false)
+		await expect(resetManagedConfigKey(cliConfig, 'keyToRemove', predicateMock)).resolves.not.toThrow()
+
+		expect(cliConfig).toStrictEqual(makeConfig(profiles, profilesWithKeyToRemove))
+		expect(predicateMock).toHaveBeenCalledTimes(2)
+	})
+
+	it('removes managed keys when no predicate is specified', async () => {
+		const cliConfig = makeConfig(profiles, profilesWithKeyToRemove)
+
+		await expect(resetManagedConfigKey(cliConfig, 'keyToRemove')).resolves.not.toThrow()
+
+		expect(cliConfig).toStrictEqual(makeConfig(profiles, profilesWithKeysRemoved))
+	})
+
+	it('removes managed keys that match predicate', async () => {
+		const cliConfig = makeConfig(profiles, profilesWithKeyToRemove)
+
+		predicateMock.mockReturnValue(true)
+		await expect(resetManagedConfigKey(cliConfig, 'keyToRemove', predicateMock)).resolves.not.toThrow()
+
+		expect(cliConfig).toStrictEqual(makeConfig(profiles, profilesWithKeysRemoved))
+		expect(predicateMock).toHaveBeenCalledTimes(2)
+	})
+})
+
+test('resetManagedConfig', async () => {
+	const managedProfilesWithProfileToReset: ProfilesByName = {
+		...managedProfiles,
+		profileToReset: { not: 'empty' },
+	}
+	const description = descriptionTemplate
+	const cliConfig = {
+		...description,
+		profileName: 'updatedProfile',
+		profiles,
+		managedProfiles: { ...managedProfilesWithProfileToReset },
+	} as CLIConfig
+	yamlDumpMock.mockReturnValueOnce('yaml output')
+
+	await expect(resetManagedConfig(cliConfig, 'profileToReset')).resolves.not.toThrow()
+
+	expect(cliConfig.managedProfiles.profileToReset).toBeUndefined()
+	expect(cliConfig.mergedProfiles).toStrictEqual(mergedProfiles)
+
+	expect(yamlDumpMock).toHaveBeenCalledTimes(1)
+	expect(yamlDumpMock).toHaveBeenCalledWith(managedProfiles)
+	expect(writeFileMock).toHaveBeenCalledTimes(1)
+	expect(writeFileMock).toHaveBeenCalledWith(description.managedConfigFilename,
+		expect.stringContaining('yaml output'))
 })

--- a/src/__tests__/lib/command/select.test.ts
+++ b/src/__tests__/lib/command/select.test.ts
@@ -39,355 +39,353 @@ jest.unstable_mockModule('../../../lib/command/command-util.js', () => ({
 const { indefiniteArticleFor, promptUser, selectFromList } = await import('../../../lib/command/select.js')
 
 
-describe('select', () => {
-	const item1: SimpleType = { str: 'string-id-1', num: 5 }
-	const item2: SimpleType = { str: 'string-id-2', num: 7 }
-	const list = [item1, item2]
-	const singleItemList = [item1]
-	const booleanConfigValueMock = jest.fn()
+const item1: SimpleType = { str: 'string-id-1', num: 5 }
+const item2: SimpleType = { str: 'string-id-2', num: 7 }
+const list = [item1, item2]
+const singleItemList = [item1]
+const booleanConfigValueMock = jest.fn()
 
-	const commandWithProfile = (profile: Profile): SmartThingsCommand<SmartThingsCommandFlags> => ({
-		logger: log4js.getLogger('cli'),
-		cliConfig: {
-			profileName: 'default',
-			mergedProfiles: { default: { profile } } as ProfilesByName,
-			profile,
-		} as CLIConfig,
-		booleanConfigValue: booleanConfigValueMock,
-	} as unknown as SmartThingsCommand<SmartThingsCommandFlags>)
-	const command = commandWithProfile({})
-	const config: SelectFromListConfig<SimpleType> = {
-		primaryKeyName: 'str',
-		sortKeyName: 'num',
+const commandWithProfile = (profile: Profile): SmartThingsCommand<SmartThingsCommandFlags> => ({
+	logger: log4js.getLogger('cli'),
+	cliConfig: {
+		profileName: 'default',
+		mergedProfiles: { default: { profile } } as ProfilesByName,
+		profile,
+	} as CLIConfig,
+	booleanConfigValue: booleanConfigValueMock,
+} as unknown as SmartThingsCommand<SmartThingsCommandFlags>)
+const command = commandWithProfile({})
+const config: SelectFromListConfig<SimpleType> = {
+	primaryKeyName: 'str',
+	sortKeyName: 'num',
+}
+
+const listItemsMock = jest.fn<ListDataFunction<SimpleType>>().mockResolvedValue(list)
+
+const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => { /*no-op*/ })
+
+describe('indefiniteArticleFor', () => {
+	it.each(['apple', 'Animal', 'egret', 'item', 'orange'])('returns "an" for "%s"', word => {
+		expect(indefiniteArticleFor(word)).toBe('an')
+	})
+
+	it.each(['banana', 'Balloon', 'tree'])('returns "a" for "%s"', word => {
+		expect(indefiniteArticleFor(word)).toBe('a')
+	})
+})
+
+describe('promptUser', () => {
+	it('works with defaults', async () => {
+		outputListMock.mockResolvedValueOnce(list)
+		stringGetIdFromUserMock.mockResolvedValue('chosen-id')
+
+		expect(await promptUser(command, config, { listItems: listItemsMock })).toBe('chosen-id')
+
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+		expect(listItemsMock).toHaveBeenCalledWith()
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledWith(config, list, undefined)
+
+		// Anonymous function passed to outputList should return same list as listItems
+		// without calling it again.
+		const anonymousListFunction = outputListMock.mock.calls[0][2]
+		expect(await anonymousListFunction()).toBe(list)
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+	})
+
+	it('autoChoose default to false', async () => {
+		listItemsMock.mockResolvedValueOnce(singleItemList)
+		outputListMock.mockResolvedValueOnce(singleItemList)
+		stringGetIdFromUserMock.mockResolvedValue('chosen-id')
+
+		expect(await promptUser(command, config, { listItems: listItemsMock })).toBe('chosen-id')
+
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+		expect(listItemsMock).toHaveBeenCalledWith()
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledWith(config, singleItemList, undefined)
+	})
+
+	it('chooses single item automatically if autoChoose is on', async () => {
+		listItemsMock.mockResolvedValueOnce(singleItemList)
+
+		expect(await promptUser(command, config, { listItems: listItemsMock, autoChoose: true })).toBe('string-id-1')
+
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+		expect(listItemsMock).toHaveBeenCalledWith()
+		expect(outputListMock).toHaveBeenCalledTimes(0)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('exits when nothing to select from', async () => {
+		const exitSpy = jest.spyOn(process, 'exit')
+		outputListMock.mockResolvedValue([])
+		// fake exiting with a special thrown error
+		exitSpy.mockImplementation(() => { throw Error('should exit') })
+
+		await expect(promptUser(command, config, { listItems: listItemsMock })).rejects.toThrow('should exit')
+
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(0)
+	})
+	it('calls custom getIdFromUser when specified', async () => {
+		outputListMock.mockResolvedValueOnce(list)
+
+		const getIdFromUser = jest.fn<IdRetrievalFunction<string, SimpleType>>().mockResolvedValueOnce('special-id')
+
+		expect(await promptUser(command, config, { listItems: listItemsMock, getIdFromUser })).toBe('special-id')
+
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+		expect(listItemsMock).toHaveBeenCalledWith()
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(0)
+		expect(getIdFromUser).toHaveBeenCalledTimes(1)
+		expect(getIdFromUser).toHaveBeenCalledWith(config, list, undefined)
+	})
+
+	it('builds prompt message automatically from name', async () => {
+		outputListMock.mockResolvedValue(list)
+		const configWithName = { ...config, itemName: 'thingamabob' }
+
+		expect(await promptUser(command, configWithName, { listItems: listItemsMock })).toBe('chosen-id')
+
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledWith(command, configWithName, expect.any(Function), true, true)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledWith(configWithName, list, 'Select a thingamabob.')
+	})
+
+	it('passes custom prompt on', async () => {
+		outputListMock.mockResolvedValue(list)
+
+		expect(await promptUser(command, config, { listItems: listItemsMock, promptMessage: 'custom prompt' }))
+			.toBe('chosen-id')
+
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledWith(config, list, 'custom prompt')
+	})
+})
+
+describe('selectFromList', () => {
+	const getItemMock = jest.fn<LookupDataFunction<string, SimpleType>>()
+	const userMessageMock = jest.fn<(item: SimpleType) => string>()
+	const defaultValue: SelectOptions<SimpleType>['defaultValue'] = {
+		configKey: 'defaultItem',
+		getItem: getItemMock,
+		userMessage: userMessageMock,
 	}
 
-	const listItemsMock = jest.fn<ListDataFunction<SimpleType>>().mockResolvedValue(list)
+	it('returns id when present', async () => {
+		expect(await selectFromList(command, config, { preselectedId: 'sample-id', listItems: listItemsMock }))
+			.toBe('sample-id')
 
-	const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => { /*no-op*/ })
+		expect(listItemsMock).toHaveBeenCalledTimes(0)
+		expect(outputListMock).toHaveBeenCalledTimes(0)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(0)
 
-	describe('indefiniteArticleFor', () => {
-		it.each(['apple', 'Animal', 'egret', 'item', 'orange'])('returns "an" for "%s"', word => {
-			expect(indefiniteArticleFor(word)).toBe('an')
-		})
-
-		it.each(['banana', 'Balloon', 'tree'])('returns "a" for "%s"', word => {
-			expect(indefiniteArticleFor(word)).toBe('a')
-		})
+		expect(booleanConfigValueMock).toHaveBeenCalledTimes(0)
+		expect(promptMock).toHaveBeenCalledTimes(0)
+		expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
+		expect(getItemMock).toHaveBeenCalledTimes(0)
+		expect(userMessageMock).toHaveBeenCalledTimes(0)
+		expect(resetManagedConfigKeyMock).toHaveBeenCalledTimes(0)
 	})
 
-	describe('promptUser', () => {
-		it('works with defaults', async () => {
-			outputListMock.mockResolvedValueOnce(list)
-			stringGetIdFromUserMock.mockResolvedValue('chosen-id')
+	it('uses promptUser when no preselected id included', async () => {
+		expect(await selectFromList(command, config, { listItems: listItemsMock }))
+			.toBe('chosen-id')
 
-			expect(await promptUser(command, config, { listItems: listItemsMock })).toBe('chosen-id')
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
 
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-			expect(listItemsMock).toHaveBeenCalledWith()
-			expect(outputListMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledWith(config, list, undefined)
-
-			// Anonymous function passed to outputList should return same list as listItems
-			// without calling it again.
-			const anonymousListFunction = outputListMock.mock.calls[0][2]
-			expect(await anonymousListFunction()).toBe(list)
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-		})
-
-		it('autoChoose default to false', async () => {
-			listItemsMock.mockResolvedValueOnce(singleItemList)
-			outputListMock.mockResolvedValueOnce(singleItemList)
-			stringGetIdFromUserMock.mockResolvedValue('chosen-id')
-
-			expect(await promptUser(command, config, { listItems: listItemsMock })).toBe('chosen-id')
-
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-			expect(listItemsMock).toHaveBeenCalledWith()
-			expect(outputListMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledWith(config, singleItemList, undefined)
-		})
-
-		it('chooses single item automatically if autoChoose is on', async () => {
-			listItemsMock.mockResolvedValueOnce(singleItemList)
-
-			expect(await promptUser(command, config, { listItems: listItemsMock, autoChoose: true })).toBe('string-id-1')
-
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-			expect(listItemsMock).toHaveBeenCalledWith()
-			expect(outputListMock).toHaveBeenCalledTimes(0)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(0)
-		})
-
-		it('exits when nothing to select from', async () => {
-			const exitSpy = jest.spyOn(process, 'exit')
-			outputListMock.mockResolvedValue([])
-			// fake exiting with a special thrown error
-			exitSpy.mockImplementation(() => { throw Error('should exit') })
-
-			await expect(promptUser(command, config, { listItems: listItemsMock })).rejects.toThrow('should exit')
-
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(0)
-		})
-		it('calls custom getIdFromUser when specified', async () => {
-			outputListMock.mockResolvedValueOnce(list)
-
-			const getIdFromUser = jest.fn<IdRetrievalFunction<string, SimpleType>>().mockResolvedValueOnce('special-id')
-
-			expect(await promptUser(command, config, { listItems: listItemsMock, getIdFromUser })).toBe('special-id')
-
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-			expect(listItemsMock).toHaveBeenCalledWith()
-			expect(outputListMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(0)
-			expect(getIdFromUser).toHaveBeenCalledTimes(1)
-			expect(getIdFromUser).toHaveBeenCalledWith(config, list, undefined)
-		})
-
-		it('builds prompt message automatically from name', async () => {
-			outputListMock.mockResolvedValue(list)
-			const configWithName = { ...config, itemName: 'thingamabob' }
-
-			expect(await promptUser(command, configWithName, { listItems: listItemsMock })).toBe('chosen-id')
-
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledWith(command, configWithName, expect.any(Function), true, true)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledWith(configWithName, list, 'Select a thingamabob.')
-		})
-
-		it('passes custom prompt on', async () => {
-			outputListMock.mockResolvedValue(list)
-
-			expect(await promptUser(command, config, { listItems: listItemsMock, promptMessage: 'custom prompt' }))
-				.toBe('chosen-id')
-
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledWith(command, config, expect.any(Function), true, true)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledWith(config, list, 'custom prompt')
-		})
+		expect(booleanConfigValueMock).toHaveBeenCalledTimes(0)
+		expect(promptMock).toHaveBeenCalledTimes(0)
+		expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
+		expect(getItemMock).toHaveBeenCalledTimes(0)
+		expect(userMessageMock).toHaveBeenCalledTimes(0)
+		expect(resetManagedConfigKeyMock).toHaveBeenCalledTimes(0)
 	})
 
-	describe('selectFromList', () => {
-		const getItemMock = jest.fn<LookupDataFunction<string, SimpleType>>()
-		const userMessageMock = jest.fn<(item: SimpleType) => string>()
-		const defaultValue: SelectOptions<SimpleType>['defaultValue'] = {
-			configKey: 'defaultItem',
-			getItem: getItemMock,
-			userMessage: userMessageMock,
-		}
-
-		it('returns id when present', async () => {
-			expect(await selectFromList(command, config, { preselectedId: 'sample-id', listItems: listItemsMock }))
-				.toBe('sample-id')
-
-			expect(listItemsMock).toHaveBeenCalledTimes(0)
-			expect(outputListMock).toHaveBeenCalledTimes(0)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(0)
-
-			expect(booleanConfigValueMock).toHaveBeenCalledTimes(0)
-			expect(promptMock).toHaveBeenCalledTimes(0)
-			expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
-			expect(getItemMock).toHaveBeenCalledTimes(0)
-			expect(userMessageMock).toHaveBeenCalledTimes(0)
-			expect(resetManagedConfigKeyMock).toHaveBeenCalledTimes(0)
+	it('returns saved default', async () => {
+		const commandWithDefault = commandWithProfile({
+			defaultItem: 'default-item-id',
 		})
+		getItemMock.mockResolvedValueOnce(item1)
+		userMessageMock.mockReturnValueOnce('user message')
 
-		it('uses promptUser when no preselected id included', async () => {
-			expect(await selectFromList(command, config, { listItems: listItemsMock }))
-				.toBe('chosen-id')
+		expect(await selectFromList(commandWithDefault, config, { listItems: listItemsMock, defaultValue }))
+			.toBe('default-item-id')
 
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledTimes(1)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
+		expect(consoleLogSpy).toHaveBeenCalledWith('user message')
 
-			expect(booleanConfigValueMock).toHaveBeenCalledTimes(0)
-			expect(promptMock).toHaveBeenCalledTimes(0)
-			expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
-			expect(getItemMock).toHaveBeenCalledTimes(0)
-			expect(userMessageMock).toHaveBeenCalledTimes(0)
-			expect(resetManagedConfigKeyMock).toHaveBeenCalledTimes(0)
+		expect(listItemsMock).toHaveBeenCalledTimes(0)
+		expect(outputListMock).toHaveBeenCalledTimes(0)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(0)
+
+		expect(booleanConfigValueMock).toHaveBeenCalledTimes(0)
+		expect(promptMock).toHaveBeenCalledTimes(0)
+		expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
+		expect(userMessageMock).toHaveBeenCalledTimes(1)
+		expect(userMessageMock).toHaveBeenCalledWith(item1)
+		expect(resetManagedConfigKeyMock).toHaveBeenCalledTimes(0)
+	})
+
+	it('ignores and clears saved default when no item returned', async () => {
+		const commandWithDefault = commandWithProfile({
+			defaultItem: 'default-item-id',
 		})
+		getItemMock.mockResolvedValueOnce(undefined as unknown as SimpleType)
+		promptMock.mockResolvedValue({ answer: 'No' })
 
-		it('returns saved default', async () => {
-			const commandWithDefault = commandWithProfile({
-				defaultItem: 'default-item-id',
-			})
-			getItemMock.mockResolvedValueOnce(item1)
-			userMessageMock.mockReturnValueOnce('user message')
+		expect(await selectFromList(commandWithDefault, config, { listItems: listItemsMock, defaultValue }))
+			.toBe('chosen-id')
 
-			expect(await selectFromList(commandWithDefault, config, { listItems: listItemsMock, defaultValue }))
-				.toBe('default-item-id')
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
 
-			expect(consoleLogSpy).toHaveBeenCalledWith('user message')
+		expect(booleanConfigValueMock).toHaveBeenCalledTimes(1)
+		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
+		expect(getItemMock).toHaveBeenCalledTimes(1)
+		expect(getItemMock).toHaveBeenCalledWith('default-item-id')
+		expect(userMessageMock).toHaveBeenCalledTimes(0)
+		expect(resetManagedConfigKeyMock).toHaveBeenCalledTimes(1)
+		expect(resetManagedConfigKeyMock).toHaveBeenCalledWith(commandWithDefault.cliConfig, 'defaultItem')
+	})
 
-			expect(listItemsMock).toHaveBeenCalledTimes(0)
-			expect(outputListMock).toHaveBeenCalledTimes(0)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(0)
-
-			expect(booleanConfigValueMock).toHaveBeenCalledTimes(0)
-			expect(promptMock).toHaveBeenCalledTimes(0)
-			expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
-			expect(userMessageMock).toHaveBeenCalledTimes(1)
-			expect(userMessageMock).toHaveBeenCalledWith(item1)
-			expect(resetManagedConfigKeyMock).toHaveBeenCalledTimes(0)
+	it.each([403, 404])('ignores and clears saved default exception with status code %d', async statusCode => {
+		const commandWithDefault = commandWithProfile({
+			defaultItem: 'default-item-id',
 		})
+		getItemMock.mockRejectedValueOnce({ response: { status: statusCode } })
+		promptMock.mockResolvedValue({ answer: 'No' })
 
-		it('ignores and clears saved default when no item returned', async () => {
-			const commandWithDefault = commandWithProfile({
-				defaultItem: 'default-item-id',
-			})
-			getItemMock.mockResolvedValueOnce(undefined as unknown as SimpleType)
-			promptMock.mockResolvedValue({ answer: 'No' })
+		expect(await selectFromList(commandWithDefault, config, { listItems: listItemsMock, defaultValue }))
+			.toBe('chosen-id')
 
-			expect(await selectFromList(commandWithDefault, config, { listItems: listItemsMock, defaultValue }))
-				.toBe('chosen-id')
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
 
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledTimes(1)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
+		expect(booleanConfigValueMock).toHaveBeenCalledTimes(1)
+		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
+		expect(getItemMock).toHaveBeenCalledTimes(1)
+		expect(getItemMock).toHaveBeenCalledWith('default-item-id')
+		expect(userMessageMock).toHaveBeenCalledTimes(0)
+		expect(resetManagedConfigKeyMock).toHaveBeenCalledTimes(1)
+		expect(resetManagedConfigKeyMock).toHaveBeenCalledWith(commandWithDefault.cliConfig, 'defaultItem')
+	})
 
-			expect(booleanConfigValueMock).toHaveBeenCalledTimes(1)
-			expect(promptMock).toHaveBeenCalledTimes(1)
-			expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
-			expect(getItemMock).toHaveBeenCalledTimes(1)
-			expect(getItemMock).toHaveBeenCalledWith('default-item-id')
-			expect(userMessageMock).toHaveBeenCalledTimes(0)
-			expect(resetManagedConfigKeyMock).toHaveBeenCalledTimes(1)
-			expect(resetManagedConfigKeyMock).toHaveBeenCalledWith(commandWithDefault.cliConfig, 'defaultItem')
+	it('rethrows unexpected error from defaultConfig.getItem', async () => {
+		const commandWithDefault = commandWithProfile({
+			defaultItem: 'default-item-id',
 		})
+		getItemMock.mockRejectedValueOnce(Error('unexpected error'))
+		promptMock.mockResolvedValue({ answer: 'No' })
 
-		it.each([403, 404])('ignores and clears saved default exception with status code %d', async statusCode => {
-			const commandWithDefault = commandWithProfile({
-				defaultItem: 'default-item-id',
-			})
-			getItemMock.mockRejectedValueOnce({ response: { status: statusCode } })
-			promptMock.mockResolvedValue({ answer: 'No' })
+		await expect(selectFromList(commandWithDefault, config, { listItems: listItemsMock, defaultValue }))
+			.rejects.toThrow('unexpected error')
 
-			expect(await selectFromList(commandWithDefault, config, { listItems: listItemsMock, defaultValue }))
-				.toBe('chosen-id')
+		expect(listItemsMock).toHaveBeenCalledTimes(0)
+		expect(outputListMock).toHaveBeenCalledTimes(0)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(0)
 
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledTimes(1)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
+		expect(booleanConfigValueMock).toHaveBeenCalledTimes(0)
+		expect(promptMock).toHaveBeenCalledTimes(0)
+		expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
+		expect(getItemMock).toHaveBeenCalledTimes(1)
+		expect(getItemMock).toHaveBeenCalledWith('default-item-id')
+		expect(userMessageMock).toHaveBeenCalledTimes(0)
+		expect(resetManagedConfigKeyMock).toHaveBeenCalledTimes(0)
+	})
 
-			expect(booleanConfigValueMock).toHaveBeenCalledTimes(1)
-			expect(promptMock).toHaveBeenCalledTimes(1)
-			expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
-			expect(getItemMock).toHaveBeenCalledTimes(1)
-			expect(getItemMock).toHaveBeenCalledWith('default-item-id')
-			expect(userMessageMock).toHaveBeenCalledTimes(0)
-			expect(resetManagedConfigKeyMock).toHaveBeenCalledTimes(1)
-			expect(resetManagedConfigKeyMock).toHaveBeenCalledWith(commandWithDefault.cliConfig, 'defaultItem')
-		})
+	it('does not save default when user asked not to', async () => {
+		booleanConfigValueMock.mockReturnValueOnce(false)
+		promptMock.mockResolvedValue({ answer: 'No' })
 
-		it('rethrows unexpected error from defaultConfig.getItem', async () => {
-			const commandWithDefault = commandWithProfile({
-				defaultItem: 'default-item-id',
-			})
-			getItemMock.mockRejectedValueOnce(Error('unexpected error'))
-			promptMock.mockResolvedValue({ answer: 'No' })
+		expect(await selectFromList(command, config,
+			{ listItems: listItemsMock, defaultValue })).toBe('chosen-id')
 
-			await expect(selectFromList(commandWithDefault, config, { listItems: listItemsMock, defaultValue }))
-				.rejects.toThrow('unexpected error')
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
 
-			expect(listItemsMock).toHaveBeenCalledTimes(0)
-			expect(outputListMock).toHaveBeenCalledTimes(0)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(0)
+		expect(booleanConfigValueMock).toHaveBeenCalledTimes(1)
+		expect(booleanConfigValueMock).toHaveBeenCalledWith('defaultItem::neverAskForSaveAgain')
+		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'list', name: 'answer' }))
+		expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
+	})
 
-			expect(booleanConfigValueMock).toHaveBeenCalledTimes(0)
-			expect(promptMock).toHaveBeenCalledTimes(0)
-			expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
-			expect(getItemMock).toHaveBeenCalledTimes(1)
-			expect(getItemMock).toHaveBeenCalledWith('default-item-id')
-			expect(userMessageMock).toHaveBeenCalledTimes(0)
-			expect(resetManagedConfigKeyMock).toHaveBeenCalledTimes(0)
-		})
+	it('does not prompt to save default when default key specified but user said never again', async () => {
+		booleanConfigValueMock.mockReturnValueOnce(true)
 
-		it('does not save default when user asked not to', async () => {
-			booleanConfigValueMock.mockReturnValueOnce(false)
-			promptMock.mockResolvedValue({ answer: 'No' })
+		expect(await selectFromList(command, config,
+			{ listItems: listItemsMock, defaultValue })).toBe('chosen-id')
 
-			expect(await selectFromList(command, config,
-				{ listItems: listItemsMock, defaultValue })).toBe('chosen-id')
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
 
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledTimes(1)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
+		expect(booleanConfigValueMock).toHaveBeenCalledTimes(1)
+		expect(booleanConfigValueMock).toHaveBeenCalledWith('defaultItem::neverAskForSaveAgain')
+		expect(promptMock).toHaveBeenCalledTimes(0)
+		expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
+	})
 
-			expect(booleanConfigValueMock).toHaveBeenCalledTimes(1)
-			expect(booleanConfigValueMock).toHaveBeenCalledWith('defaultItem::neverAskForSaveAgain')
-			expect(promptMock).toHaveBeenCalledTimes(1)
-			expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'list', name: 'answer' }))
-			expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
-		})
+	it('saves selected item as default', async () => {
+		booleanConfigValueMock.mockReturnValueOnce(false)
+		promptMock.mockResolvedValue({ answer: 'yes' })
 
-		it('does not prompt to save default when default key specified but user said never again', async () => {
-			booleanConfigValueMock.mockReturnValueOnce(true)
+		expect(await selectFromList(command, config,
+			{ listItems: listItemsMock, defaultValue })).toBe('chosen-id')
 
-			expect(await selectFromList(command, config,
-				{ listItems: listItemsMock, defaultValue })).toBe('chosen-id')
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
 
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledTimes(1)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
+		expect(booleanConfigValueMock).toHaveBeenCalledTimes(1)
+		expect(booleanConfigValueMock).toHaveBeenCalledWith('defaultItem::neverAskForSaveAgain')
+		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'list', name: 'answer' }))
+		expect(setConfigKeyMock).toHaveBeenCalledTimes(1)
+		expect(setConfigKeyMock).toHaveBeenCalledWith(command.cliConfig, 'defaultItem', 'chosen-id')
+		expect(consoleLogSpy).toHaveBeenCalledWith('chosen-id is now the default.\n' +
+			'You can reset these settings using the config:reset command.')
+	})
 
-			expect(booleanConfigValueMock).toHaveBeenCalledTimes(1)
-			expect(booleanConfigValueMock).toHaveBeenCalledWith('defaultItem::neverAskForSaveAgain')
-			expect(promptMock).toHaveBeenCalledTimes(0)
-			expect(setConfigKeyMock).toHaveBeenCalledTimes(0)
-		})
+	it('saves "never ask again" response"', async () => {
+		booleanConfigValueMock.mockReturnValueOnce(false)
+		promptMock.mockResolvedValue({ answer: 'never' })
 
-		it('saves selected item as default', async () => {
-			booleanConfigValueMock.mockReturnValueOnce(false)
-			promptMock.mockResolvedValue({ answer: 'yes' })
+		expect(await selectFromList(command, config,
+			{ listItems: listItemsMock, defaultValue })).toBe('chosen-id')
 
-			expect(await selectFromList(command, config,
-				{ listItems: listItemsMock, defaultValue })).toBe('chosen-id')
+		expect(listItemsMock).toHaveBeenCalledTimes(1)
+		expect(outputListMock).toHaveBeenCalledTimes(1)
+		expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
 
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledTimes(1)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
-
-			expect(booleanConfigValueMock).toHaveBeenCalledTimes(1)
-			expect(booleanConfigValueMock).toHaveBeenCalledWith('defaultItem::neverAskForSaveAgain')
-			expect(promptMock).toHaveBeenCalledTimes(1)
-			expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'list', name: 'answer' }))
-			expect(setConfigKeyMock).toHaveBeenCalledTimes(1)
-			expect(setConfigKeyMock).toHaveBeenCalledWith(command.cliConfig, 'defaultItem', 'chosen-id')
-			expect(consoleLogSpy).toHaveBeenCalledWith('chosen-id is now the default.\n' +
-				'You can reset these settings using the config:reset command.')
-		})
-
-		it('saves "never ask again" response"', async () => {
-			booleanConfigValueMock.mockReturnValueOnce(false)
-			promptMock.mockResolvedValue({ answer: 'never' })
-
-			expect(await selectFromList(command, config,
-				{ listItems: listItemsMock, defaultValue })).toBe('chosen-id')
-
-			expect(listItemsMock).toHaveBeenCalledTimes(1)
-			expect(outputListMock).toHaveBeenCalledTimes(1)
-			expect(stringGetIdFromUserMock).toHaveBeenCalledTimes(1)
-
-			expect(booleanConfigValueMock).toHaveBeenCalledTimes(1)
-			expect(booleanConfigValueMock).toHaveBeenCalledWith('defaultItem::neverAskForSaveAgain')
-			expect(promptMock).toHaveBeenCalledTimes(1)
-			expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'list', name: 'answer' }))
-			expect(setConfigKeyMock).toHaveBeenCalledTimes(1)
-			expect(setConfigKeyMock).toHaveBeenCalledWith(command.cliConfig, 'defaultItem::neverAskForSaveAgain', true)
-			expect(consoleLogSpy).toHaveBeenCalledWith('You will not be asked again.\n' +
-				'You can reset these settings using the config:reset command.')
-		})
+		expect(booleanConfigValueMock).toHaveBeenCalledTimes(1)
+		expect(booleanConfigValueMock).toHaveBeenCalledWith('defaultItem::neverAskForSaveAgain')
+		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'list', name: 'answer' }))
+		expect(setConfigKeyMock).toHaveBeenCalledTimes(1)
+		expect(setConfigKeyMock).toHaveBeenCalledWith(command.cliConfig, 'defaultItem::neverAskForSaveAgain', true)
+		expect(consoleLogSpy).toHaveBeenCalledWith('You will not be asked again.\n' +
+			'You can reset these settings using the config:reset command.')
 	})
 })

--- a/src/__tests__/lib/file-util.test.ts
+++ b/src/__tests__/lib/file-util.test.ts
@@ -30,203 +30,201 @@ jest.unstable_mockModule('js-yaml', () => ({
 const { fileExists, findYAMLFilename, isDir, isFile, readYAMLFile, requireDir } = await import('../../lib/file-util.js')
 
 
-describe('file-util', () => {
-	describe('fileExists', () => {
-		it('returns true when file exists', async () => {
-			statMock.mockResolvedValue({} as fs.Stats)
+describe('fileExists', () => {
+	it('returns true when file exists', async () => {
+		statMock.mockResolvedValue({} as fs.Stats)
 
-			expect(await fileExists('file-path')).toBe(true)
+		expect(await fileExists('file-path')).toBe(true)
 
-			expect(statMock).toHaveBeenCalledTimes(1)
-			expect(statMock).toHaveBeenCalledWith('file-path')
-		})
-
-		it('returns false when file does not exist', async () => {
-			statMock.mockRejectedValueOnce({ code: 'ENOENT' })
-
-			expect(await fileExists('file-path')).toBe(false)
-
-			expect(statMock).toHaveBeenCalledTimes(1)
-			expect(statMock).toHaveBeenCalledWith('file-path')
-		})
-
-		it('passes on unexpected exceptions', async () => {
-			statMock.mockRejectedValueOnce(Error('unexpected-error'))
-
-			await expect(fileExists('file-path')).rejects.toThrow('unexpected-error')
-
-			expect(statMock).toHaveBeenCalledTimes(1)
-			expect(statMock).toHaveBeenCalledWith('file-path')
-		})
+		expect(statMock).toHaveBeenCalledTimes(1)
+		expect(statMock).toHaveBeenCalledWith('file-path')
 	})
 
-	describe('isFile', () => {
-		it('returns false if does not exist', async () => {
-			statMock.mockRejectedValueOnce({ code: 'ENOENT' })
+	it('returns false when file does not exist', async () => {
+		statMock.mockRejectedValueOnce({ code: 'ENOENT' })
 
-			expect(await isFile('non-existent.stl')).toBe(false)
+		expect(await fileExists('file-path')).toBe(false)
 
-			expect(statMock).toHaveBeenCalledTimes(1)
-			expect(statMock).toHaveBeenCalledWith('non-existent.stl')
-		})
-
-		it('returns false if exists but is not a file', async () => {
-			const statsIsFileMock = jest.fn().mockReturnValue(false)
-			statMock.mockResolvedValue({ isFile: statsIsFileMock } as unknown as fs.Stats)
-
-			expect(await isFile('directory')).toBe(false)
-
-			expect(statMock).toHaveBeenCalledTimes(2)
-			expect(statMock).toHaveBeenCalledWith('directory')
-			expect(statsIsFileMock).toHaveBeenCalledTimes(1)
-			expect(statsIsFileMock).toHaveBeenCalledWith()
-		})
-
-		it('returns true if exists and is a file', async () => {
-			const statsIsFileMock = jest.fn().mockReturnValue(true)
-			statMock.mockResolvedValue({ isFile: statsIsFileMock } as unknown as fs.Stats)
-
-			expect(await isFile('file')).toBe(true)
-
-			expect(statMock).toHaveBeenCalledTimes(2)
-			expect(statMock).toHaveBeenCalledWith('file')
-			expect(statsIsFileMock).toHaveBeenCalledTimes(1)
-			expect(statsIsFileMock).toHaveBeenCalledWith()
-		})
+		expect(statMock).toHaveBeenCalledTimes(1)
+		expect(statMock).toHaveBeenCalledWith('file-path')
 	})
 
-	describe('isDir', () => {
-		it('returns false if does not exist', async () => {
-			statMock.mockRejectedValueOnce({ code: 'ENOENT' })
+	it('passes on unexpected exceptions', async () => {
+		statMock.mockRejectedValueOnce(Error('unexpected-error'))
 
-			expect(await isDir('non-existent')).toBe(false)
+		await expect(fileExists('file-path')).rejects.toThrow('unexpected-error')
 
-			expect(statMock).toHaveBeenCalledTimes(1)
-			expect(statMock).toHaveBeenCalledWith('non-existent')
-		})
+		expect(statMock).toHaveBeenCalledTimes(1)
+		expect(statMock).toHaveBeenCalledWith('file-path')
+	})
+})
 
-		it('returns false if exists but is not a directory', async () => {
-			statMock.mockResolvedValue({} as fs.Stats)
-			const statsIsDirectoryMock = jest.fn().mockReturnValue(false)
-			statMock.mockResolvedValue({ isDirectory: statsIsDirectoryMock } as unknown as fs.Stats)
+describe('isFile', () => {
+	it('returns false if does not exist', async () => {
+		statMock.mockRejectedValueOnce({ code: 'ENOENT' })
 
-			expect(await isDir('file')).toBe(false)
+		expect(await isFile('non-existent.stl')).toBe(false)
 
-			expect(statMock).toHaveBeenCalledTimes(2)
-			expect(statMock).toHaveBeenCalledWith('file')
-		})
-
-		it('returns true if exists and is a directory', async () => {
-			const statsIsDirectoryMock = jest.fn().mockReturnValue(true)
-			statMock.mockResolvedValue({ isDirectory: statsIsDirectoryMock } as unknown as fs.Stats)
-
-			expect(await isDir('directory')).toBe(true)
-
-			expect(statMock).toHaveBeenCalledTimes(2)
-			expect(statMock).toHaveBeenCalledWith('directory')
-			expect(statsIsDirectoryMock).toHaveBeenCalledTimes(1)
-			expect(statsIsDirectoryMock).toHaveBeenCalledWith()
-		})
+		expect(statMock).toHaveBeenCalledTimes(1)
+		expect(statMock).toHaveBeenCalledWith('non-existent.stl')
 	})
 
-	describe('findYAMLFilename', () => {
-		it('returns filename with yaml extension if that is found', async () => {
-			const statsIsFileMock = jest.fn().mockReturnValue(true)
-			statMock.mockResolvedValue({ isFile: statsIsFileMock } as unknown as fs.Stats)
+	it('returns false if exists but is not a file', async () => {
+		const statsIsFileMock = jest.fn().mockReturnValue(false)
+		statMock.mockResolvedValue({ isFile: statsIsFileMock } as unknown as fs.Stats)
 
-			expect(await findYAMLFilename('filename')).toBe('filename.yaml')
+		expect(await isFile('directory')).toBe(false)
 
-			expect(statMock).toBeCalledTimes(2)
-			expect(statMock).toBeCalledWith('filename.yaml')
-			expect(statsIsFileMock).toBeCalledTimes(1)
-			expect(statsIsFileMock).toBeCalledWith()
-		})
-
-		it('returns filename with yml extension if that is found', async () => {
-			// mimic `isFileSpy.mockResolvedValueOnce(false)` once
-			statMock.mockRejectedValueOnce({ code: 'ENOENT' })
-
-			// mimic `isFileSpy.mockResolvedValueOnce(true)` once
-			statMock.mockResolvedValueOnce({} as unknown as fs.Stats)
-			const statsIsFileMock = jest.fn().mockReturnValue(true)
-			statMock.mockResolvedValueOnce({ isFile: statsIsFileMock } as unknown as fs.Stats)
-
-			expect(await findYAMLFilename('filename')).toBe('filename.yml')
-
-			expect(statMock).toBeCalledTimes(3)
-			expect(statMock).toBeCalledWith('filename.yaml')
-			expect(statMock).toBeCalledWith('filename.yml')
-		})
-
-		it('returns false when no matching file found', async () => {
-			statMock.mockRejectedValue({ code: 'ENOENT' })
-
-			expect(await findYAMLFilename('filename')).toBe(false)
-
-			expect(statMock).toBeCalledTimes(2)
-			expect(statMock).toBeCalledWith('filename.yaml')
-			expect(statMock).toBeCalledWith('filename.yml')
-		})
+		expect(statMock).toHaveBeenCalledTimes(2)
+		expect(statMock).toHaveBeenCalledWith('directory')
+		expect(statsIsFileMock).toHaveBeenCalledTimes(1)
+		expect(statsIsFileMock).toHaveBeenCalledWith()
 	})
 
-	describe('requireDir', () => {
-		it('returns directory when it exists and is a directory', async () => {
-			// mimic `isDirSpy.mockResolvedValue(true)`
-			const statsIsDirectoryMock = jest.fn().mockReturnValue(true)
-			statMock.mockResolvedValue({ isDirectory: statsIsDirectoryMock } as unknown as fs.Stats)
+	it('returns true if exists and is a file', async () => {
+		const statsIsFileMock = jest.fn().mockReturnValue(true)
+		statMock.mockResolvedValue({ isFile: statsIsFileMock } as unknown as fs.Stats)
 
-			expect(await requireDir('my-dir')).toBe('my-dir')
+		expect(await isFile('file')).toBe(true)
 
-			expect(statMock).toBeCalledTimes(2)
-			expect(statMock).toBeCalledWith('my-dir')
-		})
+		expect(statMock).toHaveBeenCalledTimes(2)
+		expect(statMock).toHaveBeenCalledWith('file')
+		expect(statsIsFileMock).toHaveBeenCalledTimes(1)
+		expect(statsIsFileMock).toHaveBeenCalledWith()
+	})
+})
 
-		it('throws exception when directory does not exist', async () => {
-			// mimic `isDirSpy.mockResolvedValue(false)`
-			statMock.mockRejectedValueOnce({ code: 'ENOENT' })
+describe('isDir', () => {
+	it('returns false if does not exist', async () => {
+		statMock.mockRejectedValueOnce({ code: 'ENOENT' })
 
-			await expect(requireDir('not-a-dir')).rejects.toThrow('missing required directory: not-a-dir')
+		expect(await isDir('non-existent')).toBe(false)
 
-			expect(statMock).toBeCalledTimes(1)
-			expect(statMock).toBeCalledWith('not-a-dir')
-		})
+		expect(statMock).toHaveBeenCalledTimes(1)
+		expect(statMock).toHaveBeenCalledWith('non-existent')
 	})
 
-	describe('readYAMLFile', () => {
-		it('returns processed file', () => {
-			const yamlFile: YAMLFileData = { key: 'value' }
-			readFileSyncMock.mockReturnValueOnce('file contents')
-			yamlLoadMock.mockReturnValueOnce(yamlFile)
+	it('returns false if exists but is not a directory', async () => {
+		statMock.mockResolvedValue({} as fs.Stats)
+		const statsIsDirectoryMock = jest.fn().mockReturnValue(false)
+		statMock.mockResolvedValue({ isDirectory: statsIsDirectoryMock } as unknown as fs.Stats)
 
-			expect(readYAMLFile('filename')).toBe(yamlFile)
+		expect(await isDir('file')).toBe(false)
 
-			expect(readFileSyncMock).toHaveBeenCalledTimes(1)
-			expect(readFileSyncMock).toHaveBeenCalledWith('filename', 'utf-8')
-			expect(yamlLoadMock).toHaveBeenCalledTimes(1)
-			expect(yamlLoadMock).toHaveBeenCalledWith('file contents')
-		})
+		expect(statMock).toHaveBeenCalledTimes(2)
+		expect(statMock).toHaveBeenCalledWith('file')
+	})
 
-		it('passes error message into user-facing error', () => {
-			readFileSyncMock.mockImplementation(() => { throw Error('read failure') })
+	it('returns true if exists and is a directory', async () => {
+		const statsIsDirectoryMock = jest.fn().mockReturnValue(true)
+		statMock.mockResolvedValue({ isDirectory: statsIsDirectoryMock } as unknown as fs.Stats)
 
-			expect(() => readYAMLFile('filename'))
-				.toThrow('error "read failure" reading filename')
+		expect(await isDir('directory')).toBe(true)
 
-			expect(readFileSyncMock).toHaveBeenCalledTimes(1)
-			expect(readFileSyncMock).toHaveBeenCalledWith('filename', 'utf-8')
-		})
+		expect(statMock).toHaveBeenCalledTimes(2)
+		expect(statMock).toHaveBeenCalledWith('directory')
+		expect(statsIsDirectoryMock).toHaveBeenCalledTimes(1)
+		expect(statsIsDirectoryMock).toHaveBeenCalledWith()
+	})
+})
 
-		it.each`
-			invalidYaml | errorMessage
-			${{}}       | ${'error "invalid file" reading filename'}
-			${null}     | ${'error "empty file" reading filename'}
-			${''}       | ${'error "invalid file" reading filename'}
-			${0}        | ${'error "invalid file" reading filename'}
-		`('throws $errorMessage when reading $invalidYaml', ({ invalidYaml, errorMessage }) => {
-			readFileSyncMock.mockReturnValueOnce('file contents')
-			yamlLoadMock.mockReturnValueOnce(invalidYaml)
+describe('findYAMLFilename', () => {
+	it('returns filename with yaml extension if that is found', async () => {
+		const statsIsFileMock = jest.fn().mockReturnValue(true)
+		statMock.mockResolvedValue({ isFile: statsIsFileMock } as unknown as fs.Stats)
 
-			expect(() => readYAMLFile('filename')).toThrow(errorMessage)
-		})
+		expect(await findYAMLFilename('filename')).toBe('filename.yaml')
+
+		expect(statMock).toBeCalledTimes(2)
+		expect(statMock).toBeCalledWith('filename.yaml')
+		expect(statsIsFileMock).toBeCalledTimes(1)
+		expect(statsIsFileMock).toBeCalledWith()
+	})
+
+	it('returns filename with yml extension if that is found', async () => {
+		// mimic `isFileSpy.mockResolvedValueOnce(false)` once
+		statMock.mockRejectedValueOnce({ code: 'ENOENT' })
+
+		// mimic `isFileSpy.mockResolvedValueOnce(true)` once
+		statMock.mockResolvedValueOnce({} as unknown as fs.Stats)
+		const statsIsFileMock = jest.fn().mockReturnValue(true)
+		statMock.mockResolvedValueOnce({ isFile: statsIsFileMock } as unknown as fs.Stats)
+
+		expect(await findYAMLFilename('filename')).toBe('filename.yml')
+
+		expect(statMock).toBeCalledTimes(3)
+		expect(statMock).toBeCalledWith('filename.yaml')
+		expect(statMock).toBeCalledWith('filename.yml')
+	})
+
+	it('returns false when no matching file found', async () => {
+		statMock.mockRejectedValue({ code: 'ENOENT' })
+
+		expect(await findYAMLFilename('filename')).toBe(false)
+
+		expect(statMock).toBeCalledTimes(2)
+		expect(statMock).toBeCalledWith('filename.yaml')
+		expect(statMock).toBeCalledWith('filename.yml')
+	})
+})
+
+describe('requireDir', () => {
+	it('returns directory when it exists and is a directory', async () => {
+		// mimic `isDirSpy.mockResolvedValue(true)`
+		const statsIsDirectoryMock = jest.fn().mockReturnValue(true)
+		statMock.mockResolvedValue({ isDirectory: statsIsDirectoryMock } as unknown as fs.Stats)
+
+		expect(await requireDir('my-dir')).toBe('my-dir')
+
+		expect(statMock).toBeCalledTimes(2)
+		expect(statMock).toBeCalledWith('my-dir')
+	})
+
+	it('throws exception when directory does not exist', async () => {
+		// mimic `isDirSpy.mockResolvedValue(false)`
+		statMock.mockRejectedValueOnce({ code: 'ENOENT' })
+
+		await expect(requireDir('not-a-dir')).rejects.toThrow('missing required directory: not-a-dir')
+
+		expect(statMock).toBeCalledTimes(1)
+		expect(statMock).toBeCalledWith('not-a-dir')
+	})
+})
+
+describe('readYAMLFile', () => {
+	it('returns processed file', () => {
+		const yamlFile: YAMLFileData = { key: 'value' }
+		readFileSyncMock.mockReturnValueOnce('file contents')
+		yamlLoadMock.mockReturnValueOnce(yamlFile)
+
+		expect(readYAMLFile('filename')).toBe(yamlFile)
+
+		expect(readFileSyncMock).toHaveBeenCalledTimes(1)
+		expect(readFileSyncMock).toHaveBeenCalledWith('filename', 'utf-8')
+		expect(yamlLoadMock).toHaveBeenCalledTimes(1)
+		expect(yamlLoadMock).toHaveBeenCalledWith('file contents')
+	})
+
+	it('passes error message into user-facing error', () => {
+		readFileSyncMock.mockImplementation(() => { throw Error('read failure') })
+
+		expect(() => readYAMLFile('filename'))
+			.toThrow('error "read failure" reading filename')
+
+		expect(readFileSyncMock).toHaveBeenCalledTimes(1)
+		expect(readFileSyncMock).toHaveBeenCalledWith('filename', 'utf-8')
+	})
+
+	it.each`
+		invalidYaml | errorMessage
+		${{}}       | ${'error "invalid file" reading filename'}
+		${null}     | ${'error "empty file" reading filename'}
+		${''}       | ${'error "invalid file" reading filename'}
+		${0}        | ${'error "invalid file" reading filename'}
+	`('throws $errorMessage when reading $invalidYaml', ({ invalidYaml, errorMessage }) => {
+		readFileSyncMock.mockReturnValueOnce('file contents')
+		yamlLoadMock.mockReturnValueOnce(invalidYaml)
+
+		expect(() => readYAMLFile('filename')).toThrow(errorMessage)
 	})
 })


### PR DESCRIPTION
Removed redundant top-level describe we had been using in many tests.

(I skipped tests for commands since they will be almost complete rewrites anyway with yargs.)