### PR TITLE
refactor: move config helpers to config

### DIFF
--- a/src/__tests__/lib/command/api-command.test.ts
+++ b/src/__tests__/lib/command/api-command.test.ts
@@ -2,14 +2,26 @@ import { jest } from '@jest/globals'
 
 import { osLocale } from 'os-locale'
 
-import { Authenticator, Logger, RESTClientConfig, SmartThingsClient, WarningFromHeader } from '@smartthings/core-sdk'
+import {
+	Authenticator,
+	Logger,
+	RESTClientConfig,
+	SmartThingsClient,
+	WarningFromHeader,
+} from '@smartthings/core-sdk'
 
-import { SmartThingsCommand, SmartThingsCommandFlags, smartThingsCommand, smartThingsCommandBuilder } from '../../../lib/command/smartthings-command.js'
+import {
+	SmartThingsCommand,
+	SmartThingsCommandFlags,
+	smartThingsCommand,
+	smartThingsCommandBuilder,
+} from '../../../lib/command/smartthings-command.js'
 import { newBearerTokenAuthenticator, newSmartThingsClient } from '../../../lib/command/util/st-client-wrapper.js'
 import { coreSDKLoggerFromLog4JSLogger } from '../../../lib/log-utils.js'
 import { defaultClientIdProvider, loginAuthenticator } from '../../../lib/login-authenticator.js'
 import { TableGenerator } from '../../../lib/table-generator.js'
 import { buildArgvMock } from '../../test-lib/builder-mock.js'
+import { CLIConfig } from '../../../lib/cli-config.js'
 
 
 const { errorMock, loggerMock } = await import('../../test-lib/logger-mock.js')
@@ -31,15 +43,19 @@ jest.unstable_mockModule('../../../lib/log-utils.js', async () => ({
 	coreSDKLoggerFromLog4JSLogger: coreSDKLoggerFromLog4JSLoggerMock,
 }))
 
-const stringConfigValueMock = jest.fn<SmartThingsCommand['stringConfigValue']>()
+const stringConfigValueMock = jest.fn<CLIConfig['stringConfigValue']>()
+const cliConfigMock = {
+	stringConfigValue: stringConfigValueMock,
+}
+
 const buildTableFromListMock = jest.fn<TableGenerator['buildTableFromList']>()
 buildTableFromListMock.mockReturnValue('table built from list')
 const stCommandMock = {
 	configDir: 'test-config-dir',
+	cliConfig: cliConfigMock,
 	profileName: 'profile-from-parent',
 	profile: {},
 	logger: loggerMock,
-	stringConfigValue: stringConfigValueMock,
 	tableGenerator: {
 		buildTableFromList: buildTableFromListMock,
 	},

--- a/src/__tests__/lib/command/api-organization-command.test.ts
+++ b/src/__tests__/lib/command/api-organization-command.test.ts
@@ -1,16 +1,19 @@
 import { jest } from '@jest/globals'
 
+import { CLIConfig } from '../../../lib/cli-config.js'
 import { APICommand, apiCommand, apiCommandBuilder } from '../../../lib/command/api-command.js'
-import { SmartThingsCommand, SmartThingsCommandFlags } from '../../../lib/command/smartthings-command.js'
-import { buildArgvMock } from '../../test-lib/builder-mock.js'
 import { APIOrganizationCommandFlags } from '../../../lib/command/api-organization-command.js'
+import { SmartThingsCommandFlags } from '../../../lib/command/smartthings-command.js'
+import { buildArgvMock } from '../../test-lib/builder-mock.js'
 
 
-const stringConfigValueMock = jest.fn<SmartThingsCommand['stringConfigValue']>()
+const stringConfigValueMock = jest.fn<CLIConfig['stringConfigValue']>()
 const apiCommandResultMock = {
 	configDir: 'test-config-dir',
+	cliConfig: {
+		stringConfigValue: stringConfigValueMock,
+	},
 	profileName: 'profile-from-parent',
-	stringConfigValue: stringConfigValueMock,
 } as unknown as APICommand
 const apiCommandBuilderMock = jest.fn<typeof apiCommandBuilder>()
 const apiCommandMock = jest.fn<typeof apiCommand>()

--- a/src/__tests__/lib/command/select.test.ts
+++ b/src/__tests__/lib/command/select.test.ts
@@ -43,7 +43,7 @@ const item1: SimpleType = { str: 'string-id-1', num: 5 }
 const item2: SimpleType = { str: 'string-id-2', num: 7 }
 const list = [item1, item2]
 const singleItemList = [item1]
-const booleanConfigValueMock = jest.fn()
+const booleanConfigValueMock = jest.fn<CLIConfig['booleanConfigValue']>()
 
 const commandWithProfile = (profile: Profile): SmartThingsCommand<SmartThingsCommandFlags> => ({
 	logger: log4js.getLogger('cli'),
@@ -51,8 +51,8 @@ const commandWithProfile = (profile: Profile): SmartThingsCommand<SmartThingsCom
 		profileName: 'default',
 		mergedProfiles: { default: { profile } } as ProfilesByName,
 		profile,
-	} as CLIConfig,
-	booleanConfigValue: booleanConfigValueMock,
+		booleanConfigValue: booleanConfigValueMock,
+	} as unknown as CLIConfig,
 } as unknown as SmartThingsCommand<SmartThingsCommandFlags>)
 const command = commandWithProfile({})
 const config: SelectFromListConfig<SimpleType> = {

--- a/src/__tests__/lib/command/smartthings-command.test.ts
+++ b/src/__tests__/lib/command/smartthings-command.test.ts
@@ -9,7 +9,7 @@ import { buildArgvMock } from '../../test-lib/builder-mock.js'
 import { SmartThingsCommandFlags } from '../../../lib/command/smartthings-command.js'
 
 
-const { configureMock, getLoggerMock } = await import('../../test-lib/logger-mock.js')
+const { configureMock, getLoggerMock, loggerMock } = await import('../../test-lib/logger-mock.js')
 
 const loadConfigMock = jest.fn<typeof loadConfig>()
 jest.unstable_mockModule('../../../lib/cli-config.js', () => ({
@@ -46,9 +46,15 @@ describe('smartThingsCommand', () => {
 	buildDefaultLog4jsConfigMock.mockReturnValue(defaultLogConfig)
 	const logConfig = { config: 'final' } as unknown as log4js.Configuration
 	loadLog4jsConfigMock.mockReturnValue(logConfig)
-	const cliConfig = { profile: {} } as CLIConfig
+	const booleanConfigValueMock = jest.fn<CLIConfig['booleanConfigValue']>()
+		.mockReturnValue(true)
+	const cliConfig = {
+		profile: {},
+		booleanConfigValue: booleanConfigValueMock,
+	} as unknown as CLIConfig
 	loadConfigMock.mockResolvedValue(cliConfig)
 
+	// TODO: write more complete tests here!
 	it('works', async () => {
 		const flags = { profile: 'default' }
 		const result = await smartThingsCommand(flags)
@@ -68,120 +74,8 @@ describe('smartThingsCommand', () => {
 			configFilename: expect.stringContaining('/.config/@smartthings/cli/config.yaml'),
 			managedConfigFilename: expect.stringContaining('/.config/@smartthings/cli/config-managed.yaml'),
 			profileName: 'default',
-		})
+		}, loggerMock)
 		expect(defaultTableGeneratorMock).toHaveBeenCalledTimes(1)
 		expect(defaultTableGeneratorMock).toHaveBeenCalledWith({ groupRows: true })
 	})
-
-	// TODO: these will eventually go in cli-config.test.ts
-	/*
-	describe('stringConfigValue', () => {
-		it('returns undefined when not set', async () => {
-			await smartThingsCommand.init()
-
-			expect('configKey' in smartThingsCommand.profile).toBeFalse()
-			expect(smartThingsCommand.stringConfigValue('configKey')).toBeUndefined()
-		})
-
-		it('returns config value when defined', async () => {
-			const profile: Profile = { configKey: 'config value' }
-			loadConfigMock.mockResolvedValueOnce({ profile } as CLIConfig)
-
-			await smartThingsCommand.init()
-
-			expect(smartThingsCommand.profile.configKey).toEqual('config value')
-			expect(smartThingsCommand.stringConfigValue('configKey')).toBe('config value')
-		})
-
-		it('returns undefined when configured value is not a string', async () => {
-			const profile: Profile = { configKey: ['value1', 'value2'] }
-			loadConfigMock.mockResolvedValueOnce({ profile } as CLIConfig)
-
-			await smartThingsCommand.init()
-
-			expect(smartThingsCommand.profile.configKey).toEqual(['value1', 'value2'])
-			expect(smartThingsCommand.stringConfigValue('configKey')).toBeUndefined()
-		})
-
-		it('returns default value when not set', async () => {
-			await smartThingsCommand.init()
-
-			expect('configKey' in smartThingsCommand.profile).toBeFalse()
-			expect(smartThingsCommand.stringConfigValue('configKey', 'default value'))
-				.toBe('default value')
-		})
-
-		it('returns default value when configured value is not a string', async () => {
-			const profile: Profile = { configKey: ['value1', 'value2'] }
-			loadConfigMock.mockResolvedValueOnce({ profile } as CLIConfig)
-
-			await smartThingsCommand.init()
-
-			expect(smartThingsCommand.profile.configKey).toEqual(['value1', 'value2'])
-			expect(smartThingsCommand.stringConfigValue('configKey', 'default value'))
-				.toBe('default value')
-		})
-	})
-
-	describe('stringArrayConfigValue', () => {
-		it('returns [] when not set', async () => {
-			await smartThingsCommand.init()
-
-			expect('configKey' in smartThingsCommand.profile).toBeFalse()
-			expect(smartThingsCommand.stringArrayConfigValue('configKey')).toEqual([])
-		})
-
-		it('returns string config value as single-item array', async () => {
-			const profile: Profile = { configKey: 'config value' }
-			loadConfigMock.mockResolvedValueOnce({ profile } as CLIConfig)
-
-			await smartThingsCommand.init()
-
-			expect(smartThingsCommand.profile.configKey).toEqual('config value')
-			expect(smartThingsCommand.stringArrayConfigValue('configKey')).toEqual(['config value'])
-		})
-
-		it('returns array config value when configured', async () => {
-			const items = ['config value 1', 'config value 2']
-			const profile: Profile = { configKey: items }
-			loadConfigMock.mockResolvedValueOnce({ profile } as CLIConfig)
-
-			await smartThingsCommand.init()
-
-			expect(smartThingsCommand.profile.configKey).toEqual(items)
-			expect(smartThingsCommand.stringArrayConfigValue('configKey')).toEqual(items)
-		})
-
-		it('returns default value when not set', async () => {
-			await smartThingsCommand.init()
-
-			expect('configKey' in smartThingsCommand.profile).toBeFalse()
-			expect(smartThingsCommand.stringArrayConfigValue('configKey', ['default value']))
-				.toEqual(['default value'])
-		})
-
-		it('returns default value when configured value is not a string or array', async () => {
-			const profile: Profile = { configKey: 5 }
-			loadConfigMock.mockResolvedValueOnce({ profile } as CLIConfig)
-
-			await smartThingsCommand.init()
-
-			expect(smartThingsCommand.profile.configKey).toEqual(5)
-			expect(smartThingsCommand.stringArrayConfigValue('configKey', ['default value']))
-				.toEqual(['default value'])
-		})
-
-		it('returns default value when configured value is array but not of strings', async () => {
-			const items = [5, { thing: 'one' }]
-			const profile: Profile = { configKey: items }
-			loadConfigMock.mockResolvedValueOnce({ profile } as CLIConfig)
-
-			await smartThingsCommand.init()
-
-			expect(smartThingsCommand.profile.configKey).toEqual(items)
-			expect(smartThingsCommand.stringArrayConfigValue('configKey', ['default value']))
-				.toEqual(['default value'])
-		})
-	})
-	*/
 })

--- a/src/__tests__/lib/io-util.test.ts
+++ b/src/__tests__/lib/io-util.test.ts
@@ -72,11 +72,9 @@ describe('readDataFromStdin', () => {
 	})
 })
 
-describe('stdinIsTTY', () => {
-	it('returns true inside a test', function () {
-		Object.defineProperty(process.stdin, 'isTTY', { value: true })
-		expect(stdinIsTTY()).toBe(true)
-	})
+test('stdinIsTTY', () => {
+	Object.defineProperty(process.stdin, 'isTTY', { value: true })
+	expect(stdinIsTTY()).toBe(true)
 })
 
 describe('yamlExists', () => {

--- a/src/__tests__/lib/log-utils.test.ts
+++ b/src/__tests__/lib/log-utils.test.ts
@@ -80,7 +80,7 @@ describe('loadLog4jsConfig', () => {
 		yamlExistsMock.mockReturnValueOnce(false)
 
 		expect(loadLog4jsConfig('filename', defaultConfig)).toStrictEqual(defaultConfig)
-		expect(yamlExistsMock).toBeCalledWith('filename')
+		expect(yamlExistsMock).toHaveBeenCalledWith('filename')
 	})
 
 	it('returns valid config if found', () => {
@@ -108,7 +108,8 @@ describe('loadLog4jsConfig', () => {
 		readFileSyncMock.mockReturnValueOnce('bad file contents')
 		yamlLoadMock.mockReturnValueOnce(invalidConfig)
 
-		expect(() => loadLog4jsConfig('filename', defaultConfig)).toThrow('invalid or unreadable logging config file format')
+		expect(() => loadLog4jsConfig('filename', defaultConfig))
+			.toThrow('invalid or unreadable logging config file format')
 
 		expect(readFileSyncMock).toHaveBeenCalledTimes(1)
 		expect(yamlLoadMock).toHaveBeenCalledTimes(1)

--- a/src/__tests__/lib/util.test.ts
+++ b/src/__tests__/lib/util.test.ts
@@ -1,4 +1,4 @@
-import { clipToMaximum, sanitize, stringFromUnknown } from '../../lib/util.js'
+import { clipToMaximum, delay, sanitize, stringFromUnknown } from '../../lib/util.js'
 
 
 describe('stringFromUnknown', () => {
@@ -41,4 +41,10 @@ describe('sanitize', () => {
 	`('converts $input to $result', ({ input, result }) => {
 		expect(sanitize(input)).toBe(result)
 	})
+})
+
+test('delay', async () => {
+	const beforeDate = new Date().getTime()
+	await delay(3)
+	expect(new Date().getTime()).toBeGreaterThanOrEqual(beforeDate + 2)
 })

--- a/src/lib/command/api-command.ts
+++ b/src/lib/command/api-command.ts
@@ -49,7 +49,7 @@ export const apiCommand = async <T extends APICommandFlags>(flags: T, addAdditio
 	const stCommand = await smartThingsCommand(flags)
 
 	// The `|| undefined` at then end of this line is to normalize falsy values to `undefined`.
-	const token = (flags.token ?? stCommand.stringConfigValue('token')) || undefined
+	const token = (flags.token ?? stCommand.cliConfig.stringConfigValue('token')) || undefined
 
 	const calculateClientIdProvider = (): ClientIdProvider => {
 		const configClientIdProvider = stCommand.profile.clientIdProvider

--- a/src/lib/command/api-organization-command.ts
+++ b/src/lib/command/api-organization-command.ts
@@ -25,7 +25,7 @@ export const apiOrganizationCommand = async <T extends APIOrganizationCommandFla
 		if (flags.organization) {
 			headers['X-ST-Organization'] = flags.organization
 		} else {
-			const configOrganization = stCommand.stringConfigValue('organization')
+			const configOrganization = stCommand.cliConfig.stringConfigValue('organization')
 			if (configOrganization) {
 				headers['X-ST-Organization'] = configOrganization
 			}

--- a/src/lib/command/select.ts
+++ b/src/lib/command/select.ts
@@ -158,7 +158,7 @@ export async function selectFromList<L extends object, ID = string>(command: Sma
 	const userSelected = await promptUser(command, config, options)
 
 	const neverAgainKey = `${options.defaultValue?.configKey ?? ''}::neverAskForSaveAgain`
-	if (options.defaultValue && !command.booleanConfigValue(neverAgainKey)) {
+	if (options.defaultValue && !command.cliConfig.booleanConfigValue(neverAgainKey)) {
 		const answer = (await inquirer.prompt({
 			type: 'list',
 			name: 'answer',


### PR DESCRIPTION
* move config helper functions from `smartthings-command.ts` to `cli-config.ts`
* updated unit tests appropriately
* updated uses of these helper functions and their unit tests
* added a couple more unit tests
