### PR TITLE
fix: fix bug with editing webook URL for webhook endpoint app

### DIFF
--- a/.changeset/sweet-dryers-help.md
+++ b/.changeset/sweet-dryers-help.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+fixed bug preventing editing of webhook URLs in Schema apps

--- a/packages/cli/src/__tests__/lib/commands/schema-util.test.ts
+++ b/packages/cli/src/__tests__/lib/commands/schema-util.test.ts
@@ -220,6 +220,7 @@ test.each`
 
 describe('buildInputDefinition', () => {
 	const mockARNInputDef = {} as InputDefinition<string | undefined>
+	const mockWebHookUrlDef = {} as InputDefinition<string | undefined>
 	const chinaCommandMock = { profile: { clientIdProvider: { baseURL: 'base-url.cn' } } } as unknown as SmartThingsCommandInterface
 	const appLinksDefMock = { name: 'Generated App Links Def' } as InputDefinition<ViperAppLinks>
 	const generatedDef = { name: 'Final Generated Def' } as InputDefinition<InputData>
@@ -322,6 +323,16 @@ describe('buildInputDefinition', () => {
 
 		expect(optionalDefMock).toHaveBeenCalledTimes(2)
 		expect(optionalDefMock).toHaveBeenCalledWith(appLinksDefMock, expect.any(Function), { initiallyActive: true })
+	})
+
+	it('passes initial value on to webHookUrlDef', async () => {
+		const webHookUrlDefSpy = jest.spyOn(schemaUtil, 'webHookUrlDef').mockImplementation(() => mockWebHookUrlDef)
+
+		const initialValue = { appName: 'My Schema App' } as SchemaAppRequest
+		expect(buildInputDefinition(commandMock, initialValue)).toBe(generatedDef)
+
+		expect(webHookUrlDefSpy).toHaveBeenCalledTimes(1)
+		expect(webHookUrlDefSpy).toHaveBeenCalledWith(false, initialValue)
 	})
 })
 

--- a/packages/cli/src/lib/commands/schema-util.ts
+++ b/packages/cli/src/lib/commands/schema-util.ts
@@ -108,7 +108,7 @@ export const buildInputDefinition = (command: SmartThingsCommandInterface, initi
 		lambdaArnEU: arnDef('Lambda ARN for EU region', inChina, initialValue),
 		lambdaArnCN: arnDef('Lambda ARN for CN region', inChina, initialValue, { forChina: true }),
 		lambdaArnAP: arnDef('Lambda ARN for AP region', inChina, initialValue),
-		webhookUrl: webHookUrlDef(inChina),
+		webhookUrl: webHookUrlDef(inChina, initialValue),
 		includeAppLinks: booleanDef('Enable app-to-app linking?', { default: false }),
 		viperAppLinks: optionalDef(appLinksDef,
 			(context?: unknown[]) => (context?.[0] as Pick<InputData, 'includeAppLinks'>)?.includeAppLinks,


### PR DESCRIPTION
The function `webHookUrlDef` function builds the input definition for the webhook URL. It needs the initial value of the app when used to edit a pre-existing app but it wasn't being passed in.