### PR TITLE
fix: allow port number in callback URLs of API_ONLY apps

### DIFF
--- a/.changeset/bright-books-fail.md
+++ b/.changeset/bright-books-fail.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli-lib": patch
+---
+
+Allow port number in callback URLs of API_ONLY apps.

--- a/packages/lib/src/__tests__/validate-util.test.ts
+++ b/packages/lib/src/__tests__/validate-util.test.ts
@@ -170,6 +170,8 @@ describe('localhostOrHTTPSValidate', () => {
 		'https://www.adafruit.com/category/168',
 		'http://localhost/path/to/fun',
 		'http://127.0.0.1',
+		'http://localhost:3000',
+		'http://127.0.0.1:3000/callback',
 	])('accepts "%s" when https is required', (input) => {
 		expect(localhostOrHTTPSValidate(input)).toBe(true)
 	})

--- a/packages/lib/src/validate-util.ts
+++ b/packages/lib/src/validate-util.ts
@@ -99,7 +99,7 @@ const urlValidateFn = (options?: URLValidateFnOptions): ValidateFunction => {
 			if (options?.httpsRequired) {
 				if (options.allowLocalhostHTTP) {
 					return url.protocol === 'https:' ||
-						url.protocol === 'http:' && allowedHTTPHosts.includes(url.host) ||
+						url.protocol === 'http:' && allowedHTTPHosts.includes(url.hostname) ||
 						'https is required except for localhost'
 				}
 				return url.protocol === 'https:' || 'https protocol is required'


### PR DESCRIPTION
<!-- Describe your pull request. -->

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
