### PR TITLE
chore: update upload-artifact github action

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -97,7 +97,7 @@ jobs:
         run: tar -cvf dist_bin.tar packages/cli/dist_bin/
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: dist_bin
           path: dist_bin.tar
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           name: dist_bin
 
@@ -162,7 +162,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           name: dist_bin
 
@@ -243,7 +243,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           name: dist_bin
 


### PR DESCRIPTION
I just merged a [dependabot pull request](https://github.com/SmartThingsCommunity/smartthings-cli/pull/618) that bumped the download-artifact github action from 3 to 4.

It turns out there is a [breaking change](https://github.com/actions/download-artifact?tab=readme-ov-file#breaking-changes) with v4 that it won't allow downloads of artifacts uploaded with <v4 of upload-artifacts. This pull request updates upload-artifacts.

I also noticed there is another dot release for download-artifacts to I updated that as well.