### PR TITLE
chore: remove reference to DefinitelyTyped log4js types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
 				"@types/jest": "^29.5.5",
 				"@types/js-yaml": "^4.0.6",
 				"@types/lodash.at": "^4.6.7",
-				"@types/log4js": "^2.3.5",
 				"@types/node": "^20.8.4",
 				"@types/picomatch": "^2.3.1",
 				"@types/qs": "^6.9.8",
@@ -4458,16 +4457,6 @@
 			"dev": true,
 			"dependencies": {
 				"@types/lodash": "*"
-			}
-		},
-		"node_modules/@types/log4js": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/@types/log4js/-/log4js-2.3.5.tgz",
-			"integrity": "sha512-SwF8LkSHqHy9A8GQ67NAYJiGl8zzP4Qtx65Wa+IOxDGdMHxKeoQZjg7m2M1erIT6VK0DYHpu2aTbdLkdkuMHjw==",
-			"deprecated": "This is a stub types definition for log4js (https://github.com/nomiddlename/log4js-node). log4js provides its own type definitions, so you don't need @types/log4js installed!",
-			"dev": true,
-			"dependencies": {
-				"log4js": "*"
 			}
 		},
 		"node_modules/@types/mime": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
 		"@types/jest": "^29.5.5",
 		"@types/js-yaml": "^4.0.6",
 		"@types/lodash.at": "^4.6.7",
-		"@types/log4js": "^2.3.5",
 		"@types/node": "^20.8.4",
 		"@types/picomatch": "^2.3.1",
 		"@types/qs": "^6.9.8",


### PR DESCRIPTION
log4js now has its types directly in its own repo and the DefinitelyTyped ones are gone. This removes the DefinitelyTyped ones from our package.json.