### PR TITLE
refactor: consolidate all choose function stuff in util-utils.ts

### DIFF
--- a/src/__tests__/lib/command/command-util.test.ts
+++ b/src/__tests__/lib/command/command-util.test.ts
@@ -2,7 +2,6 @@ import { jest } from '@jest/globals'
 
 import inquirer from 'inquirer'
 
-import { ChooseOptions } from '../../../lib/command/command-util.js'
 import { sort } from '../../../lib/command/output.js'
 import { ListDataFunction, Sorting } from '../../../lib/command/basic-io.js'
 import { SimpleType } from '../../test-lib/simple-type.js'
@@ -22,8 +21,6 @@ jest.unstable_mockModule('../../../lib/command/output.js', () => ({
 
 
 const {
-	chooseOptionsDefaults,
-	chooseOptionsWithDefaults,
 	convertToId,
 	isIndexArgument,
 	itemName,
@@ -103,8 +100,7 @@ describe('stringTranslateToId', () => {
 		expect(computedId).toBe('string-id-a')
 
 		expect(listFunction).toHaveBeenCalledTimes(1)
-		expect(sortMock).toHaveBeenCalledTimes(1)
-		expect(sortMock).toHaveBeenCalledWith(list, 'num')
+		expect(sortMock).toHaveBeenCalledExactlyOnceWith(list, 'num')
 	})
 
 	it('throws an error when item not found', async () => {
@@ -115,8 +111,7 @@ describe('stringTranslateToId', () => {
 			.rejects.toThrow('invalid index 4 (enter an id or index between 1 and 3 inclusive)')
 
 		expect(listFunction).toHaveBeenCalledTimes(1)
-		expect(sortMock).toHaveBeenCalledTimes(1)
-		expect(sortMock).toHaveBeenCalledWith(list, 'num')
+		expect(sortMock).toHaveBeenCalledExactlyOnceWith(list, 'num')
 	})
 
 	it('throws an error for missing primary key', async () => {
@@ -127,8 +122,7 @@ describe('stringTranslateToId', () => {
 			.rejects.toThrow('did not find key str in data')
 
 		expect(listFunction).toHaveBeenCalledTimes(1)
-		expect(sortMock).toHaveBeenCalledTimes(1)
-		expect(sortMock).toHaveBeenCalledWith(list, 'num')
+		expect(sortMock).toHaveBeenCalledExactlyOnceWith(list, 'num')
 	})
 
 	it('throws an error for invalid type for primary key', async () => {
@@ -139,8 +133,7 @@ describe('stringTranslateToId', () => {
 			.rejects.toThrow('invalid type number for primary key str in {"str":3,"num":5}')
 
 		expect(listFunction).toHaveBeenCalledTimes(1)
-		expect(sortMock).toHaveBeenCalledTimes(1)
-		expect(sortMock).toHaveBeenCalledWith(list, 'num')
+		expect(sortMock).toHaveBeenCalledExactlyOnceWith(list, 'num')
 	})
 })
 
@@ -175,8 +168,7 @@ describe('stringGetIdFromUser', () => {
 
 		expect(chosenId).toBe('string-id-a')
 
-		expect(promptMock).toHaveBeenCalledTimes(1)
-		expect(promptMock).toHaveBeenCalledWith({
+		expect(promptMock).toHaveBeenCalledExactlyOnceWith({
 			type: 'input', name: 'itemIdOrIndex',
 			message: 'Enter id or index', validate: expect.anything(),
 		})
@@ -192,8 +184,7 @@ describe('stringGetIdFromUser', () => {
 
 		expect(chosenId).toBe('string-id-a')
 
-		expect(promptMock).toHaveBeenCalledTimes(1)
-		expect(promptMock).toHaveBeenCalledWith({
+		expect(promptMock).toHaveBeenCalledExactlyOnceWith({
 			type: 'input', name: 'itemIdOrIndex',
 			message: 'Enter id or index', validate: expect.anything(),
 		})
@@ -215,39 +206,12 @@ describe('stringGetIdFromUser', () => {
 
 		expect(chosenId).toBe('string-id-a')
 
-		expect(promptMock).toHaveBeenCalledTimes(1)
-		expect(promptMock).toHaveBeenCalledWith({
+		expect(promptMock).toHaveBeenCalledExactlyOnceWith({
 			type: 'input', name: 'itemIdOrIndex',
 			message: 'give me an id', validate: expect.anything(),
 		})
 		const validateFunction = (promptMock.mock.calls[0][0] as { validate: (input: string) => true | string }).validate
 
 		expect(validateFunction('string-id-a')).toBe(true)
-	})
-})
-
-describe('chooseOptionsWithDefaults', () => {
-	it('uses defaults with undefined input', () => {
-		expect(chooseOptionsWithDefaults(undefined)).toStrictEqual(chooseOptionsDefaults())
-	})
-
-	it('uses defaults with empty input', () => {
-		expect(chooseOptionsWithDefaults({})).toStrictEqual(chooseOptionsDefaults())
-	})
-
-	it('input overrides default', () => {
-		const optionsDifferentThanDefault = {
-			allowIndex: true,
-			verbose: true,
-			useConfigDefault: true,
-			autoChoose: true,
-		}
-		expect(chooseOptionsWithDefaults(optionsDifferentThanDefault))
-			.toEqual(optionsDifferentThanDefault)
-	})
-
-	it('passes on other values unchanged', () => {
-		expect(chooseOptionsWithDefaults({ someOtherKey: 'some other value' } as Partial<ChooseOptions<{ someOtherKey: string }>>))
-			.toEqual(expect.objectContaining({ someOtherKey: 'some other value' }))
 	})
 })

--- a/src/lib/command/command-util.ts
+++ b/src/lib/command/command-util.ts
@@ -97,27 +97,3 @@ export async function stringGetIdFromUser<L extends object>(fieldInfo: Sorting<L
 	}
 	return inputId
 }
-
-/**
- * Note that not all functions that use this interface support all options. Check the
- * `chooseThing` (e.g. `chooseDevice`) method itself.
- */
-export type ChooseOptions<T extends object> = {
-	allowIndex: boolean
-	verbose: boolean
-	useConfigDefault: boolean
-	listItems?: ListDataFunction<T>
-	autoChoose?: boolean
-}
-
-export const chooseOptionsDefaults = <T extends object>(): ChooseOptions<T> => ({
-	allowIndex: false,
-	verbose: false,
-	useConfigDefault: false,
-	autoChoose: false,
-})
-
-export const chooseOptionsWithDefaults = <T extends object>(options: Partial<ChooseOptions<T>> | undefined): ChooseOptions<T> => ({
-	...chooseOptionsDefaults(),
-	...options,
-})

--- a/src/lib/command/util/apps-util.ts
+++ b/src/lib/command/util/apps-util.ts
@@ -10,7 +10,7 @@ import {
 import { arrayDef, checkboxDef, stringDef } from '../../item-input/index.js'
 import { TableFieldDefinition, TableGenerator } from '../../table-generator.js'
 import { localhostOrHTTPSValidate } from '../../validate-util.js'
-import { createChooseFn } from './util-util.js'
+import { ChooseFunction, createChooseFn } from './util-util.js'
 
 
 export const isWebhookSmartApp = (app: AppResponse): boolean => !!app.webhookSmartApp
@@ -45,7 +45,7 @@ export const tableFieldDefinitions: TableFieldDefinition<AppResponse>[] = [
 
 export const oauthTableFieldDefinitions: TableFieldDefinition<AppOAuthRequest>[] = ['clientName', 'scope', 'redirectUris']
 
-export const chooseApp = createChooseFn(
+export const chooseAppFn = (): ChooseFunction<PagedApp> => createChooseFn(
 	{
 		itemName: 'app',
 		primaryKeyName: 'appId',
@@ -53,6 +53,8 @@ export const chooseApp = createChooseFn(
 	},
 	(client: SmartThingsClient) => client.apps.list(),
 )
+
+export const chooseApp = chooseAppFn()
 
 export const buildTableOutput = (tableGenerator: TableGenerator, appSettings: AppSettingsResponse): string => {
 	if (!appSettings.settings || Object.keys(appSettings.settings).length === 0) {

--- a/src/lib/command/util/locations-util.ts
+++ b/src/lib/command/util/locations-util.ts
@@ -1,7 +1,7 @@
-import { Location, SmartThingsClient } from '@smartthings/core-sdk'
+import { Location, LocationItem, SmartThingsClient } from '@smartthings/core-sdk'
 
 import { TableFieldDefinition } from '../../table-generator.js'
-import { createChooseFn } from './util-util.js'
+import { ChooseFunction, createChooseFn } from './util-util.js'
 
 
 export const tableFieldDefinitions: TableFieldDefinition<Location>[] = [
@@ -9,7 +9,7 @@ export const tableFieldDefinitions: TableFieldDefinition<Location>[] = [
 	'latitude', 'longitude', 'regionRadius', 'temperatureScale', 'locale',
 ]
 
-export const chooseLocation = createChooseFn(
+export const chooseLocationFn = (): ChooseFunction<LocationItem> => createChooseFn(
 	{
 		itemName: 'location',
 		primaryKeyName: 'locationId',
@@ -17,3 +17,5 @@ export const chooseLocation = createChooseFn(
 	},
 	(client: SmartThingsClient) => client.locations.list(),
 )
+
+export const chooseLocation = chooseLocationFn()

--- a/src/lib/command/util/util-util.ts
+++ b/src/lib/command/util/util-util.ts
@@ -1,13 +1,38 @@
 import { SmartThingsClient } from '@smartthings/core-sdk'
 
 import { APICommand } from '../api-command.js'
-import { ChooseOptions, chooseOptionsWithDefaults, stringTranslateToId } from '../command-util.js'
+import { ListDataFunction } from '../basic-io.js'
+import { stringTranslateToId } from '../command-util.js'
 import { SelectFromListConfig, SelectFromListFlags, selectFromList } from '../select.js'
 
 
+/**
+ * Note that not all functions that use this interface support all options. Check the
+ * `chooseThing` (e.g. `chooseDevice`) method itself.
+ */
+export type ChooseOptions<T extends object> = {
+	allowIndex: boolean
+	verbose: boolean
+	useConfigDefault: boolean
+	listItems?: ListDataFunction<T>
+	autoChoose?: boolean
+}
+
+export const chooseOptionsDefaults = <T extends object>(): ChooseOptions<T> => ({
+	allowIndex: false,
+	verbose: false,
+	useConfigDefault: false,
+	autoChoose: false,
+})
+
+export const chooseOptionsWithDefaults = <T extends object>(options: Partial<ChooseOptions<T>> | undefined): ChooseOptions<T> => ({
+	...chooseOptionsDefaults(),
+	...options,
+})
+
 export type ChooseFunction<T extends object> = (
 	command: APICommand<SelectFromListFlags>,
-	locationFromArg?: string,
+	itemIdOrNameFromArg?: string,
 	options?: Partial<ChooseOptions<T>>) => Promise<string>
 
 export const createChooseFn = <T extends object>(
@@ -16,15 +41,15 @@ export const createChooseFn = <T extends object>(
 ): ChooseFunction<T> =>
 	async (
 			command: APICommand<SelectFromListFlags>,
-			locationFromArg?: string,
+			itemIdOrNameFromArg?: string,
 			options?: Partial<ChooseOptions<T>>): Promise<string> => {
 		const opts = chooseOptionsWithDefaults(options)
 
 		const listItemsWrapper = (): Promise<T[]> => listItems(command.client)
 
 		const preselectedId = opts.allowIndex
-			? await stringTranslateToId(config, locationFromArg, listItemsWrapper)
-			: locationFromArg
+			? await stringTranslateToId(config, itemIdOrNameFromArg, listItemsWrapper)
+			: itemIdOrNameFromArg
 
 		return selectFromList(command, config, {
 			preselectedId,


### PR DESCRIPTION
Moved all the supporting types and variables for `createChooseFn` into the same file as `createChooseFn`. Not sure why I didn't do this when I created `createChooseFn`. Also updated affected unit tests.