### PR TITLE
fix: schema apps in "review" state cannot be updated

### DIFF
--- a/.changeset/late-feet-retire.md
+++ b/.changeset/late-feet-retire.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+Schema apps that are in review cannot be updated.

--- a/packages/cli/src/commands/schema/update.ts
+++ b/packages/cli/src/commands/schema/update.ts
@@ -55,7 +55,9 @@ export default class SchemaUpdateCommand extends APIOrganizationCommand<typeof S
 
 		const { schemaApp: original, organizationWasUpdated } =
 			await getSchemaAppEnsuringOrganization(this, id, this.flags)
-		if (original.certificationStatus === 'wwst' || original.certificationStatus === 'cst') {
+		if (original.certificationStatus === 'wwst' ||
+				original.certificationStatus === 'cst' ||
+				original.certificationStatus === 'review') {
 			const cancelMsgBase =
 				'Schema apps that have already been certified cannot be updated via the CLI'
 			const cancelMsg = organizationWasUpdated


### PR DESCRIPTION
Schema apps that have a "review" `certificationStatus` cannot be updated.