### PR TITLE
refactor: add canned mock of exports from api-command

### DIFF
--- a/src/__tests__/commands/apps.test.ts
+++ b/src/__tests__/commands/apps.test.ts
@@ -4,25 +4,18 @@ import { ArgumentsCamelCase, Argv, Options } from 'yargs'
 
 import { AppClassification, AppResponse, AppType, AppsEndpoint, PagedApp, SmartThingsClient } from '@smartthings/core-sdk'
 
-import { APICommand, APICommandFlags, apiCommand, apiCommandBuilder, apiDocsURL } from '../../lib/command/api-command.js'
+import { APICommand, APICommandFlags } from '../../lib/command/api-command.js'
 import { outputItemOrList, outputItemOrListBuilder } from '../../lib/command/listing-io.js'
 import { CommandArgs } from '../../commands/apps.js'
 import { ListDataFunction } from '../../lib/command/io-defs.js'
 import { BuildOutputFormatterFlags } from '../../lib/command/output-builder.js'
 import { SmartThingsCommandFlags } from '../../lib/command/smartthings-command.js'
 import { shortARNorURL, verboseApps } from '../../lib/command/util/apps-util.js'
+import { apiCommandMocks } from '../test-lib/api-command-mock.js'
 import { buildArgvMock, buildArgvMockStub } from '../test-lib/builder-mock.js'
 
 
-
-const apiCommandMock = jest.fn<typeof apiCommand>()
-const apiCommandBuilderMock = jest.fn<typeof apiCommandBuilder>()
-const apiDocsURLMock = jest.fn<typeof apiDocsURL>()
-jest.unstable_mockModule('../../lib/command/api-command.js', () => ({
-	apiCommand: apiCommandMock,
-	apiCommandBuilder: apiCommandBuilderMock,
-	apiDocsURL: apiDocsURLMock,
-}))
+const { apiCommandMock, apiCommandBuilderMock } = apiCommandMocks('../..')
 
 const outputItemOrListMock = jest.fn<typeof outputItemOrList<PagedApp | AppResponse>>()
 const outputItemOrListBuilderMock = jest.fn<typeof outputItemOrListBuilder>()

--- a/src/__tests__/commands/devices/capability-status.test.ts
+++ b/src/__tests__/commands/devices/capability-status.test.ts
@@ -10,12 +10,7 @@ import type {
 } from '@smartthings/core-sdk'
 
 import type { CommandArgs } from '../../../commands/devices/capability-status.js'
-import type {
-	APICommand,
-	apiCommand,
-	apiCommandBuilder,
-	apiDocsURL,
-} from '../../../lib/command/api-command.js'
+import type { APICommand } from '../../../lib/command/api-command.js'
 import type { stringTranslateToId } from '../../../lib/command/command-util.js'
 import type {
 	CustomCommonOutputProducer,
@@ -40,16 +35,10 @@ import {
 	tableToStringMock,
 } from '../../test-lib/table-mock.js'
 import type { fatalError } from '../../../lib/util.js'
+import { apiCommandMocks } from '../../test-lib/api-command-mock.js'
 
 
-const apiCommandMock = jest.fn<typeof apiCommand>()
-const apiCommandBuilderMock = jest.fn<typeof apiCommandBuilder>()
-const apiDocsURLMock = jest.fn<typeof apiDocsURL>()
-jest.unstable_mockModule('../../../lib/command/api-command.js', () => ({
-	apiCommand: apiCommandMock,
-	apiCommandBuilder: apiCommandBuilderMock,
-	apiDocsURL: apiDocsURLMock,
-}))
+const { apiCommandMock, apiCommandBuilderMock } = apiCommandMocks('../../..')
 
 const stringTranslateToIdMock = jest.fn<typeof stringTranslateToId>()
 jest.unstable_mockModule('../../../lib/command/command-util.js', () => ({

--- a/src/__tests__/commands/devices/preferences.test.ts
+++ b/src/__tests__/commands/devices/preferences.test.ts
@@ -4,7 +4,7 @@ import type { ArgumentsCamelCase, Argv } from 'yargs'
 
 import type { Device, DevicePreferenceResponse, DevicesEndpoint } from '@smartthings/core-sdk'
 
-import type { APICommand, apiCommand, apiCommandBuilder } from '../../../lib/command/api-command.js'
+import type { APICommand } from '../../../lib/command/api-command.js'
 import type {
 	CustomCommonOutputProducer,
 	formatAndWriteItem,
@@ -14,6 +14,7 @@ import type { CommandArgs } from '../../../commands/apps.js'
 import type { BuildOutputFormatterFlags } from '../.././../lib/command/output-builder.js'
 import type { SmartThingsCommandFlags } from '../../../lib/command/smartthings-command.js'
 import type { ChooseFunction } from '../../../lib/command/util/util-util.js'
+import { apiCommandMocks } from '../../test-lib/api-command-mock.js'
 import { buildArgvMock, buildArgvMockStub } from '../../test-lib/builder-mock.js'
 import {
 	mockedTableOutput,
@@ -24,12 +25,7 @@ import {
 } from '../../test-lib/table-mock.js'
 
 
-const apiCommandMock = jest.fn<typeof apiCommand>()
-const apiCommandBuilderMock = jest.fn<typeof apiCommandBuilder>()
-jest.unstable_mockModule('../../../lib/command/api-command.js', () => ({
-	apiCommand: apiCommandMock,
-	apiCommandBuilder: apiCommandBuilderMock,
-}))
+const { apiCommandMock, apiCommandBuilderMock } = apiCommandMocks('../../..')
 
 const chooseDeviceMock = jest.fn<ChooseFunction<Device>>()
 jest.unstable_mockModule('../../../lib/command/util/devices-util.js', () => ({

--- a/src/__tests__/commands/locations.test.ts
+++ b/src/__tests__/commands/locations.test.ts
@@ -1,24 +1,17 @@
 import { jest } from '@jest/globals'
 
-import { ArgumentsCamelCase, Argv } from 'yargs'
+import type { ArgumentsCamelCase, Argv } from 'yargs'
 
-import { Location, LocationsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
+import type { Location, LocationsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
 
-import { APICommand, APICommandFlags, apiCommand, apiCommandBuilder, apiDocsURL } from '../../lib/command/api-command.js'
-import { outputItemOrList, outputItemOrListBuilder } from '../../lib/command/listing-io.js'
-import { CommandArgs } from '../../commands/locations.js'
+import type { APICommand, APICommandFlags } from '../../lib/command/api-command.js'
+import type { outputItemOrList, outputItemOrListBuilder } from '../../lib/command/listing-io.js'
+import type { CommandArgs } from '../../commands/locations.js'
+import { apiCommandMocks } from '../test-lib/api-command-mock.js'
 import { buildArgvMock, buildArgvMockStub } from '../test-lib/builder-mock.js'
 
 
-
-const apiCommandMock = jest.fn<typeof apiCommand>()
-const apiCommandBuilderMock = jest.fn<typeof apiCommandBuilder>()
-const apiDocsURLMock = jest.fn<typeof apiDocsURL>()
-jest.unstable_mockModule('../../lib/command/api-command.js', () => ({
-	apiCommand: apiCommandMock,
-	apiCommandBuilder: apiCommandBuilderMock,
-	apiDocsURL: apiDocsURLMock,
-}))
+const { apiCommandMock, apiCommandBuilderMock } = apiCommandMocks('../..')
 
 const outputItemOrListMock = jest.fn<typeof outputItemOrList>()
 const outputItemOrListBuilderMock = jest.fn<typeof outputItemOrListBuilder>()
@@ -26,7 +19,6 @@ jest.unstable_mockModule('../../lib/command/listing-io.js', () => ({
 	outputItemOrList: outputItemOrListMock,
 	outputItemOrListBuilder: outputItemOrListBuilderMock,
 }))
-
 
 
 const { default: cmd } = await import('../../commands/locations.js')

--- a/src/__tests__/commands/locations/create.test.ts
+++ b/src/__tests__/commands/locations/create.test.ts
@@ -5,15 +5,10 @@ import { ArgumentsCamelCase, Argv } from 'yargs'
 import { Location, LocationCreate, LocationsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
 
 import { tableFieldDefinitions } from '../../../lib/command/util/locations-util.js'
-import {
-	APICommand,
-	APICommandFlags,
-	apiCommand,
-	apiCommandBuilder,
-	apiDocsURL,
-} from '../../../lib/command/api-command.js'
+import { APICommand, APICommandFlags } from '../../../lib/command/api-command.js'
 import { inputAndOutputItem, inputAndOutputItemBuilder } from '../../../lib/command/input-and-output-item.js'
 import { CommandArgs } from '../../../commands/locations/create.js'
+import { apiCommandMocks } from '../../test-lib/api-command-mock.js'
 import { buildArgvMock, buildArgvMockStub } from '../../test-lib/builder-mock.js'
 
 
@@ -21,14 +16,7 @@ jest.unstable_mockModule('../../../lib/command/util/locations-util.js', () => ({
 	tableFieldDefinitions,
 }))
 
-const apiCommandMock = jest.fn<typeof apiCommand>()
-const apiCommandBuilderMock = jest.fn<typeof apiCommandBuilder>()
-const apiDocsURLMock = jest.fn<typeof apiDocsURL>()
-jest.unstable_mockModule('../../../lib/command/api-command.js', () => ({
-	apiCommand: apiCommandMock,
-	apiCommandBuilder: apiCommandBuilderMock,
-	apiDocsURL: apiDocsURLMock,
-}))
+const { apiCommandMock, apiCommandBuilderMock } = apiCommandMocks('../../..')
 
 const inputAndOutputItemMock = jest.fn<typeof inputAndOutputItem>()
 const inputAndOutputItemBuilderMock = jest.fn<typeof inputAndOutputItemBuilder>()

--- a/src/__tests__/commands/locations/delete.test.ts
+++ b/src/__tests__/commands/locations/delete.test.ts
@@ -5,19 +5,13 @@ import { ArgumentsCamelCase, Argv } from 'yargs'
 import { LocationsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
 
 import { CommandArgs } from '../../../commands/locations/delete.js'
-import { APICommand, APICommandFlags, apiCommand, apiCommandBuilder, apiDocsURL } from '../../../lib/command/api-command.js'
+import { APICommand, APICommandFlags } from '../../../lib/command/api-command.js'
 import { chooseLocation } from '../../../lib/command/util/locations-util.js'
+import { apiCommandMocks } from '../../test-lib/api-command-mock.js'
 import { buildArgvMock } from '../../test-lib/builder-mock.js'
 
 
-const apiCommandMock = jest.fn<typeof apiCommand>()
-const apiCommandBuilderMock = jest.fn<typeof apiCommandBuilder>()
-const apiDocsURLMock = jest.fn<typeof apiDocsURL>()
-jest.unstable_mockModule('../../../lib/command/api-command.js', () => ({
-	apiCommand: apiCommandMock,
-	apiCommandBuilder: apiCommandBuilderMock,
-	apiDocsURL: apiDocsURLMock,
-}))
+const { apiCommandMock, apiCommandBuilderMock } = apiCommandMocks('../../..')
 
 const chooseLocationMock = jest.fn<typeof chooseLocation>()
 jest.unstable_mockModule('../../../lib/command/util/locations-util.js', () => ({

--- a/src/__tests__/commands/locations/update.test.ts
+++ b/src/__tests__/commands/locations/update.test.ts
@@ -5,9 +5,10 @@ import { ArgumentsCamelCase, Argv } from 'yargs'
 import { Location, LocationUpdate, LocationsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
 
 import { chooseLocation, tableFieldDefinitions } from '../../../lib/command/util/locations-util.js'
-import { APICommand, APICommandFlags, apiCommand, apiCommandBuilder, apiDocsURL } from '../../../lib/command/api-command.js'
+import { APICommand, APICommandFlags } from '../../../lib/command/api-command.js'
 import { inputAndOutputItem, inputAndOutputItemBuilder } from '../../../lib/command/input-and-output-item.js'
 import { CommandArgs } from '../../../commands/locations/update.js'
+import { apiCommandMocks } from '../../test-lib/api-command-mock.js'
 import { buildArgvMock, buildArgvMockStub } from '../../test-lib/builder-mock.js'
 
 
@@ -17,14 +18,7 @@ jest.unstable_mockModule('../../../lib/command/util/locations-util.js', () => ({
 	tableFieldDefinitions,
 }))
 
-const apiCommandMock = jest.fn<typeof apiCommand>()
-const apiCommandBuilderMock = jest.fn<typeof apiCommandBuilder>()
-const apiDocsURLMock = jest.fn<typeof apiDocsURL>()
-jest.unstable_mockModule('../../../lib/command/api-command.js', () => ({
-	apiCommand: apiCommandMock,
-	apiCommandBuilder: apiCommandBuilderMock,
-	apiDocsURL: apiDocsURLMock,
-}))
+const { apiCommandMock, apiCommandBuilderMock } = apiCommandMocks('../../..')
 
 const inputAndOutputItemMock = jest.fn<typeof inputAndOutputItem>()
 const inputAndOutputItemBuilderMock = jest.fn<typeof inputAndOutputItemBuilder>()

--- a/src/__tests__/lib/command/api-organization-command.test.ts
+++ b/src/__tests__/lib/command/api-organization-command.test.ts
@@ -1,9 +1,10 @@
 import { jest } from '@jest/globals'
 
 import { CLIConfig } from '../../../lib/cli-config.js'
-import { APICommand, apiCommand, apiCommandBuilder } from '../../../lib/command/api-command.js'
+import { APICommand } from '../../../lib/command/api-command.js'
 import { APIOrganizationCommandFlags } from '../../../lib/command/api-organization-command.js'
 import { SmartThingsCommandFlags } from '../../../lib/command/smartthings-command.js'
+import { apiCommandMocks } from '../../test-lib/api-command-mock.js'
 import { buildArgvMock } from '../../test-lib/builder-mock.js'
 
 
@@ -15,13 +16,9 @@ const apiCommandResultMock = {
 	},
 	profileName: 'profile-from-parent',
 } as unknown as APICommand
-const apiCommandBuilderMock = jest.fn<typeof apiCommandBuilder>()
-const apiCommandMock = jest.fn<typeof apiCommand>()
+
+const { apiCommandMock, apiCommandBuilderMock } = apiCommandMocks('../../..')
 apiCommandMock.mockResolvedValue(apiCommandResultMock)
-jest.unstable_mockModule('../../../lib/command/api-command.js', () => ({
-	apiCommandBuilder: apiCommandBuilderMock,
-	apiCommand: apiCommandMock,
-}))
 
 const {
 	apiOrganizationCommand,

--- a/src/__tests__/test-lib/api-command-mock.ts
+++ b/src/__tests__/test-lib/api-command-mock.ts
@@ -1,0 +1,39 @@
+import { jest } from '@jest/globals'
+
+import type { Argv } from 'yargs'
+
+import {
+	userAgent,
+	type APICommandFlags,
+	type apiCommand,
+	type apiDocsURL,
+	type itemInputHelpText,
+} from '../../lib/command/api-command.js'
+import { buildArgvMockStub, type BuilderFunctionMock } from './builder-mock.js'
+
+
+export const apiCommandMocks = <T extends APICommandFlags = APICommandFlags>(prefix: string): {
+	apiDocsURLMock: jest.Mock<typeof apiDocsURL>
+	itemInputHelpTextMock: jest.Mock<typeof itemInputHelpText>
+	apiCommandMock: jest.Mock<typeof apiCommand>
+	apiCommandBuilderMock: BuilderFunctionMock<Argv<T>>
+} => {
+	const apiDocsURLMock = jest.fn<typeof apiDocsURL>()
+	const itemInputHelpTextMock = jest.fn<typeof itemInputHelpText>()
+	const apiCommandBuilderMock = buildArgvMockStub<T>()
+	const apiCommandMock = jest.fn<typeof apiCommand>()
+	jest.unstable_mockModule(`${prefix}/lib/command/api-command.js`, () => ({
+		userAgent,
+		apiDocsURL: apiDocsURLMock,
+		itemInputHelpText: itemInputHelpTextMock,
+		apiCommandBuilder: apiCommandBuilderMock,
+		apiCommand: apiCommandMock,
+	}))
+
+	return {
+		apiDocsURLMock,
+		itemInputHelpTextMock,
+		apiCommandBuilderMock,
+		apiCommandMock,
+	}
+}


### PR DESCRIPTION
This an example of an attempt at making the unit tests a little less repetitive.