### PR TITLE
refactor: standarzie on fatalError for handling expected fatal errors

### DIFF
--- a/src/__tests__/commands/locations/create.test.ts
+++ b/src/__tests__/commands/locations/create.test.ts
@@ -12,10 +12,6 @@ import { apiCommandMocks } from '../../test-lib/api-command-mock.js'
 import { buildArgvMock, buildArgvMockStub } from '../../test-lib/builder-mock.js'
 
 
-jest.unstable_mockModule('../../../lib/command/util/locations-util.js', () => ({
-	tableFieldDefinitions,
-}))
-
 const { apiCommandMock, apiCommandBuilderMock, apiDocsURLMock } = apiCommandMocks('../../..')
 
 const inputAndOutputItemMock = jest.fn<typeof inputAndOutputItem>()

--- a/src/__tests__/lib/command/output-list.test.ts
+++ b/src/__tests__/lib/command/output-list.test.ts
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals'
 
 import type { GetDataFunction } from '../../../lib/command/io-defs.js'
 import type { OutputListConfig, OutputListFlags } from '../../../lib/command/output-list.js'
-import type { formatAndWriteItem, formatAndWriteList } from '../../../lib/command/format.js'
+import type { formatAndWriteList } from '../../../lib/command/format.js'
 import type {
 	buildInputProcessor,
 	inputProcessorBuilder,
@@ -16,10 +16,8 @@ import type {
 import type { SimpleType } from '../../test-lib/simple-type.js'
 
 
-const formatAndWriteItemMock = jest.fn<typeof formatAndWriteItem>()
 const formatAndWriteListMock = jest.fn<typeof formatAndWriteList>()
 jest.unstable_mockModule('../../../lib/command/format.js', () => ({
-	formatAndWriteItem: formatAndWriteItemMock,
 	formatAndWriteList: formatAndWriteListMock,
 }))
 

--- a/src/__tests__/lib/command/util/apps-util.test.ts
+++ b/src/__tests__/lib/command/util/apps-util.test.ts
@@ -34,8 +34,7 @@ jest.unstable_mockModule('../../../../lib/aws-util.js', () => ({
 	addPermission: addPermissionMock,
 }))
 
-const fatalErrorMock = jest.fn<typeof fatalError>()
-	.mockImplementation(() => { throw Error('fatal error') })
+const fatalErrorMock = jest.fn<typeof fatalError>().mockReturnValue('never return' as never)
 jest.unstable_mockModule('../../../../lib/util.js', () => ({
 	fatalError: fatalErrorMock,
 }))
@@ -293,8 +292,7 @@ describe('shortARNorURL', () => {
 
 describe('authorizeApp', () => {
 	it('errors for non-lambda apps', async () => {
-		await expect(authorizeApp({} as AppUpdateRequest, 'principal', 'statement'))
-			.rejects.toThrow('fatal error')
+		expect(await authorizeApp({} as AppUpdateRequest, 'principal', 'statement')).toBe('never return')
 
 		expect(fatalErrorMock).toHaveBeenCalledExactlyOnceWith(
 			'Authorization is only applicable to Lambda SmartApps.',

--- a/src/__tests__/lib/command/util/devices-util.test.ts
+++ b/src/__tests__/lib/command/util/devices-util.test.ts
@@ -14,11 +14,17 @@ import { TableCommonListOutputProducer } from '../../../../lib/command/format.js
 import { BuildOutputFormatterFlags } from '../../../../lib/command/output-builder.js'
 import type { createChooseFn, ChooseFunction } from '../../../../lib/command/util/util-util.js'
 import { ValueTableFieldDefinition } from '../../../../lib/table-generator.js'
+import { fatalError } from '../../../../lib/util.js'
 
 
 const stringTranslateToIdMock = jest.fn<typeof stringTranslateToId>()
 jest.unstable_mockModule('../../../../lib/command/command-util.js', () => ({
 	stringTranslateToId: stringTranslateToIdMock,
+}))
+
+const fatalErrorMock = jest.fn<typeof fatalError>().mockReturnValue('never return' as never)
+jest.unstable_mockModule('../../../../lib/util.js', () => ({
+	fatalError: fatalErrorMock,
 }))
 
 const createChooseFnMock = jest.fn<typeof createChooseFn<Device>>()
@@ -149,10 +155,11 @@ describe('chooseComponentFn', () => {
 	)
 
 	it.each(devicesWithNoComponents)(
-		'throws for device with no components by not defaulting to main %#',
+		'display fatal error message for device with no components when not defaulting to main %#',
 		device => {
-			expect(() => chooseComponentFn(device, { defaultToMain: false }))
-				.toThrow('No components found')
+			expect(chooseComponentFn(device, { defaultToMain: false })).toBe('never return')
+
+			expect(fatalErrorMock).toHaveBeenCalledExactlyOnceWith('No components found')
 		},
 	)
 })

--- a/src/__tests__/lib/command/util/schema-util.test.ts
+++ b/src/__tests__/lib/command/util/schema-util.test.ts
@@ -47,9 +47,7 @@ jest.unstable_mockModule('../../../../lib/io-util.js', () => ({
 }))
 
 const clipToMaximumMock = jest.fn<typeof clipToMaximum>().mockReturnValue('clipped result')
-const fatalErrorMock = jest.fn<typeof fatalError>()
-	// simulate never returning with an error
-	.mockImplementation(() => { throw Error('fatal error') })
+const fatalErrorMock = jest.fn<typeof fatalError>().mockReturnValue('never return' as never)
 jest.unstable_mockModule('../../../../lib/util.js', () => ({
 	clipToMaximum: clipToMaximumMock,
 	fatalError: fatalErrorMock,
@@ -480,8 +478,8 @@ describe('getSchemaAppEnsuringOrganization', () => {
 				stdoutIsTTYMock.mockReturnValueOnce(stdoutIsTTYReturn)
 			}
 
-			await expect(getSchemaAppEnsuringOrganization(commandMock, 'sans-organization', flags))
-				.rejects.toThrow('fatal error')
+			expect(await getSchemaAppEnsuringOrganization(commandMock, 'sans-organization', flags))
+				.toBe('never return')
 
 			expect(apiSchemaListMock).toHaveBeenCalledExactlyOnceWith()
 			expect(fatalErrorMock).toHaveBeenCalledExactlyOnceWith(

--- a/src/lib/cli-config.ts
+++ b/src/lib/cli-config.ts
@@ -4,6 +4,7 @@ import { Logger } from 'log4js'
 import yaml from 'js-yaml'
 
 import { yamlExists } from './io-util.js'
+import { fatalError } from './util.js'
 
 
 export const seeConfigDocs = 'see https://github.com/SmartThingsCommunity/smartthings-cli/blob/main/packages/cli/doc/configuration.md for more information'
@@ -83,11 +84,11 @@ export const loadConfigFile = async (filename: string): Promise<ProfilesByName> 
 				}
 			}
 			if (errors.length) {
-				throw Error(`${errors.join('\n')}\n${seeConfigDocs}`)
+				return fatalError(`${errors.join('\n')}\n${seeConfigDocs}`)
 			}
 			return config
 		} else {
-			throw Error('invalid config file format\n' + seeConfigDocs)
+			return fatalError('invalid config file format\n' + seeConfigDocs)
 		}
 	}
 	return {}

--- a/src/lib/command/input-item.ts
+++ b/src/lib/command/input-item.ts
@@ -5,6 +5,7 @@ import {
 	type InputProcessorFlags,
 } from './input-builder.js'
 import { type IOFormat } from '../io-util.js'
+import { fatalError } from '../util.js'
 
 
 export type InputItemFlags = InputProcessorFlags
@@ -18,7 +19,6 @@ export async function inputItem<I extends object>(flags: InputItemFlags,
 		const item = await inputProcessor.read()
 		return [item, inputProcessor.ioFormat]
 	} else {
-		// TODO: standardize error handling
-		throw Error('input is required either via file specified with --input option or from stdin')
+		return fatalError('input is required either via file specified with --input option or from stdin')
 	}
 }

--- a/src/lib/command/output-list.ts
+++ b/src/lib/command/output-list.ts
@@ -1,8 +1,8 @@
 import { formatAndWriteList, type FormatAndWriteListConfig } from './format.js'
-import { GetDataFunction } from './io-defs.js'
+import { type GetDataFunction } from './io-defs.js'
 import { sort } from './output.js'
 import { buildOutputFormatterBuilder, type BuildOutputFormatterFlags } from './output-builder.js'
-import { SmartThingsCommand } from './smartthings-command.js'
+import { type SmartThingsCommand } from './smartthings-command.js'
 
 
 export type OutputListFlags = BuildOutputFormatterFlags

--- a/src/lib/command/util/capabilities-util.ts
+++ b/src/lib/command/util/capabilities-util.ts
@@ -5,7 +5,7 @@ import {
 	type SmartThingsClient,
 } from '@smartthings/core-sdk'
 
-import { asTextBulletedList } from '../../util.js'
+import { asTextBulletedList, fatalError } from '../../util.js'
 import { type ListDataFunction } from '../io-defs.js'
 import { sort } from '../output.js'
 
@@ -95,7 +95,7 @@ export const translateToId = async (
 
 	const items = sort(await listFunction(), sortKeyName)
 	if (index < 1 || index > items.length) {
-		throw Error(`invalid index ${index} (enter an id or index between 1 and ${items.length}` +
+		return fatalError(`invalid index ${index} (enter an id or index between 1 and ${items.length}` +
 			'inclusive)')
 	}
 	const matchingItem: CapabilitySummaryWithNamespace = items[index - 1]

--- a/src/lib/command/util/devices-util.ts
+++ b/src/lib/command/util/devices-util.ts
@@ -6,6 +6,7 @@ import {
 	type SmartThingsClient,
 } from '@smartthings/core-sdk'
 
+import { fatalError } from '../../util.js'
 import { type ChooseFunction, createChooseFn } from './util-util.js'
 
 
@@ -41,7 +42,7 @@ export const chooseComponentFn = (
 		if (defaultToMain) {
 			return async () => 'main'
 		} else {
-			throw Error('No components found')
+			return fatalError('No components found')
 		}
 	}
 

--- a/src/lib/command/util/scenes-util.ts
+++ b/src/lib/command/util/scenes-util.ts
@@ -1,7 +1,7 @@
 import { type SceneSummary } from '@smartthings/core-sdk'
 
-import { TableFieldDefinition } from '../../table-generator.js'
-import { ChooseFunction, createChooseFn } from './util-util.js'
+import { type TableFieldDefinition } from '../../table-generator.js'
+import { type ChooseFunction, createChooseFn } from './util-util.js'
 
 
 export const tableFieldDefinitions: TableFieldDefinition<SceneSummary>[] = [

--- a/src/lib/command/util/schema-util.ts
+++ b/src/lib/command/util/schema-util.ts
@@ -164,7 +164,7 @@ export const getSchemaAppEnsuringOrganization = async (
 	const appFromList = apps.find(app => app.endpointAppId === schemaAppId)
 	if (appFromList && !appFromList.organizationId) {
 		if (flags.json || flags.yaml || flags.output || flags.input || !stdinIsTTY()  || !stdoutIsTTY()) {
-			fatalError(
+			return fatalError(
 				'Schema app does not have an organization associated with it.\n' +
 					`Please run "smartthings schema ${schemaAppId}" and choose an organization when prompted.`,
 			)

--- a/src/lib/file-util.ts
+++ b/src/lib/file-util.ts
@@ -2,6 +2,8 @@ import fs from 'fs'
 
 import yaml from 'js-yaml'
 
+import { fatalError } from './util.js'
+
 
 export const fileExists = async (path: string): Promise<boolean> => {
 	try {
@@ -45,8 +47,7 @@ export const requireDir = async (dirName: string): Promise<string> => {
 	if (await isDir(dirName)) {
 		return dirName
 	}
-	// TODO: fix for yargs
-	throw Error(`missing required directory: ${dirName}`)
+	return fatalError(`missing required directory: ${dirName}`)
 }
 
 export type YAMLFileData = {
@@ -68,12 +69,11 @@ export const readYAMLFile = (filename: string): YAMLFileData => {
 		}
 
 		if (data == null) {
-			throw Error('empty file')
+			return fatalError(`empty file ${filename}`)
 		}
 
-		throw Error('invalid file')
+		return fatalError(`invalid file ${filename}`)
 	} catch (error) {
-		// TODO: fix for yargs
-		throw Error(`error "${error.message}" reading ${filename}`)
+		return fatalError(`error "${error.message}" reading ${filename}`)
 	}
 }

--- a/src/lib/io-util.ts
+++ b/src/lib/io-util.ts
@@ -3,6 +3,8 @@ import fs from 'fs'
 import path from 'path'
 import yaml from 'js-yaml'
 
+import { fatalError } from './util.js'
+
 
 export type IOFormat =
 	| 'yaml'
@@ -25,10 +27,10 @@ export function formatFromFilename(filename: string): IOFormat {
 export function parseJSONOrYAML<T>(rawInputData: string, source: string): T {
 	const data = yaml.load(rawInputData)
 	if (!data) {
-		throw Error(`did not get any data from ${source}`)
+		return fatalError(`did not get any data from ${source}`)
 	}
 	if (typeof data === 'string') {
-		throw Error(`got simple string from ${source}`)
+		return fatalError(`got simple string from ${source}`)
 	}
 	return data as unknown as T
 }
@@ -75,7 +77,7 @@ export function yamlExists(filepath: string): boolean {
 	const parsedPath = path.parse(filepath)
 
 	if (parsedPath.ext !== '.yaml') {
-		throw Error(`Invalid file extension: ${parsedPath.ext}`)
+		return fatalError(`Invalid file extension: ${parsedPath.ext}`)
 	}
 
 	if (!fs.existsSync(filepath)) {

--- a/src/lib/item-input/object.ts
+++ b/src/lib/item-input/object.ts
@@ -43,7 +43,9 @@ export type ObjectDefOptions<T> = {
 	validateFinal?: (item: T, context?: unknown[]) => true | string
 }
 
-const defaultSummarizeForEditFn = (name: string) => (): string => { throw Error(`missing implementation of summarizeForEdit for objectDef ${name}`) }
+const defaultSummarizeForEditFn = (name: string) => (): string => {
+	throw Error(`missing implementation of summarizeForEdit for objectDef ${name}`)
+}
 export type ObjectItemTypeData<T> = {
 	type: 'object'
 	inputDefsByProperty: InputDefsByProperty<T>

--- a/src/lib/log-utils.ts
+++ b/src/lib/log-utils.ts
@@ -5,6 +5,7 @@ import { Configuration as Log4jsConfig, Logger, FileAppender, StandardErrorAppen
 import { Logger as CoreSDKLogger } from '@smartthings/core-sdk'
 
 import { yamlExists } from './io-util.js'
+import { fatalError } from './util.js'
 
 
 const defaultLogFileSize = 1_000_000 // bytes
@@ -57,7 +58,7 @@ export function loadLog4jsConfig(configFilename: string, defaultConfig: Log4jsCo
 		return parsedConfig
 	}
 
-	throw new Error(`invalid or unreadable logging config file format; see ${loggingDocsURL}`)
+	return fatalError(`invalid or unreadable logging config file format; see ${loggingDocsURL}`)
 }
 
 /**


### PR DESCRIPTION
* standardize on using `fatalError` for handling fatal error messages the user can be expected to encounter
* updated unit tests (in some cases I modernized them a bit as well but I stopped doing this at some point)
* some bad unit tests were cleaned up a bit in the process (the tests for `input-and-output-item.ts` were particularly messed up
* changed mocking of `fatalError` to return the string `never return` instead of throwing an exception