### PR TITLE
build: remove qemu dummy package reference

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -67,8 +67,8 @@ jobs:
     steps:
       - name: Install and Setup QEMU
         run: |
-          sudo apt-get update
-          sudo apt-get install qemu binfmt-support qemu-user-static
+          sudo apt update
+          sudo apt install binfmt-support qemu-user-static
 
       # see https://github.com/vercel/pkg/issues/1251#issuecomment-1024832725
       - name: Download and Install ldid Codesign Utility


### PR DESCRIPTION
<!-- Describe your pull request. -->

The `qemu` umbrella package was split into component packages a long time ago, but the package name itself remained in older registries and just didn't do anything.  Now that the workflow is running on the `ubuntu-24.04` image instead of an older version of Ubuntu, that name is no longer in the registry and trying to install it causes an error. 

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [ ] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
