### PR TITLE
build: fix Windows installation location to x64 folder

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -258,7 +258,7 @@ jobs:
         run: Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\WiX Toolset v3.11\bin"
 
       - name: Compile WiX file
-        run: candle.exe smartthings.wxs -ext WixUIExtension
+        run: candle.exe smartthings.wxs -ext WixUIExtension -arch x64
         working-directory: packages\cli\wix
         env:
           SMARTTHINGS_SEMVER: ${{ steps.safe-semver.outputs.version }}

--- a/packages/cli/wix/smartthings.wxs
+++ b/packages/cli/wix/smartthings.wxs
@@ -22,7 +22,7 @@
 
 		<!-- https://github.com/kurtanr/WiXInstallerExamples/tree/main/00_HelloWorldInstaller#directory -->
 		<Directory Id="TARGETDIR" Name="SourceDir">
-			<Directory Id="ProgramFilesFolder">
+			<Directory Id="ProgramFiles64Folder">
 				<Directory Id="INSTALLDIR" Name="SmartThings" />
 			</Directory>
 		</Directory>


### PR DESCRIPTION
<!-- Describe your pull request. -->

- Correct the Windows installation folder from the 32-bit folder to the 64-bit folder
- Add a switch to tell the toolset this is a 64-bit build rather than the default 32-bit build.

Changing the folder reference should fix the installation location issue.  I'm not sure the `-arch` switch is necessary for this build I don't think it will hurt, and there may be other incorrect 32-bit things that the installer is doing that no one's noticed yet.

<!--- Put an `x` in all the boxes that apply: -->

- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [ ] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] I have added tests to cover my changes
