### PR TITLE
refactor: use env-paths library to determine file locations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@smartthings/core-sdk": "^8.4.0",
 				"axios": "1.7.7",
 				"chalk": "^5.3.0",
+				"env-paths": "^3.0.0",
 				"eventsource": "^2.0.2",
 				"express": "^4.21.0",
 				"get-port-please": "^3.1.2",
@@ -6256,6 +6257,16 @@
 				"typescript": ">=4"
 			}
 		},
+		"node_modules/cosmiconfig/node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/crc-32": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -6992,13 +7003,15 @@
 			}
 		},
 		"node_modules/env-paths": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-			"dev": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+			"integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=6"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/error-ex": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"@smartthings/core-sdk": "^8.4.0",
 		"axios": "1.7.7",
 		"chalk": "^5.3.0",
+		"env-paths": "^3.0.0",
 		"eventsource": "^2.0.2",
 		"express": "^4.21.0",
 		"get-port-please": "^3.1.2",

--- a/src/__tests__/lib/command/api-command.test.ts
+++ b/src/__tests__/lib/command/api-command.test.ts
@@ -52,6 +52,8 @@ const buildTableFromListMock = jest.fn<TableGenerator['buildTableFromList']>()
 buildTableFromListMock.mockReturnValue('table built from list')
 const stCommandMock = {
 	configDir: 'test-config-dir',
+	dataDir: 'test-data-dir',
+	logDir: 'test-log-dir',
 	cliConfig: cliConfigMock,
 	profileName: 'profile-from-parent',
 	profile: {},
@@ -142,6 +144,8 @@ describe('apiCommand', () => {
 		const result = await apiCommand(flags)
 
 		expect(result.configDir).toBe('test-config-dir')
+		expect(result.dataDir).toBe('test-data-dir')
+		expect(result.logDir).toBe('test-log-dir')
 		expect(result.profile).toBe(stCommandMock.profile)
 
 		expect(smartThingsCommandMock).toHaveBeenCalledTimes(1)
@@ -160,7 +164,7 @@ describe('apiCommand', () => {
 			expect(newBearerTokenAuthenticatorMock).toHaveBeenCalledTimes(0)
 			expect(loginAuthenticatorMock).toHaveBeenCalledTimes(1)
 			expect(loginAuthenticatorMock).toHaveBeenCalledWith(
-				'test-config-dir/credentials.json',
+				'test-data-dir/credentials.json',
 				'profile-from-parent',
 				defaultClientIdProvider, userAgent)
 		})
@@ -208,7 +212,7 @@ describe('apiCommand', () => {
 			expect(newBearerTokenAuthenticatorMock).toHaveBeenCalledTimes(0)
 			expect(loginAuthenticatorMock).toHaveBeenCalledTimes(1)
 			expect(loginAuthenticatorMock).toHaveBeenCalledWith(
-				'test-config-dir/credentials.json',
+				'test-data-dir/credentials.json',
 				'profile-from-parent',
 				defaultClientIdProvider, userAgent)
 		})

--- a/src/__tests__/lib/yargs-transition-temp.test.ts
+++ b/src/__tests__/lib/yargs-transition-temp.test.ts
@@ -1,0 +1,264 @@
+import { jest } from '@jest/globals'
+
+import { copyFile } from 'node:fs/promises'
+import type { homedir, platform, tmpdir } from 'node:os'
+import type { join } from 'node:path'
+
+import { ensureDir, isFile } from '../../lib/file-util.js'
+
+
+const copyFileMock = jest.fn<typeof copyFile>()
+jest.unstable_mockModule('node:fs/promises', () => ({
+	copyFile: copyFileMock,
+}))
+
+const homedirMock = jest.fn<typeof homedir>().mockReturnValue('home-dir-func')
+const platformMock = jest.fn<typeof platform>()
+const tmpdirMock = jest.fn<typeof tmpdir>().mockReturnValue('tmp-dir-func')
+jest.unstable_mockModule('node:os', () => ({
+	homedir: homedirMock,
+	platform: platformMock,
+	tmpdir: tmpdirMock,
+}))
+
+const joinMock = jest.fn<typeof join>().mockImplementation((...paths: string[]) => paths.join('|'))
+jest.unstable_mockModule('node:path', () => ({
+	join: joinMock,
+}))
+
+const ensureDirMock = jest.fn<typeof ensureDir>()
+const isFileMock = jest.fn<typeof isFile>()
+jest.unstable_mockModule('../../lib/file-util.js', () => ({
+	ensureDir: ensureDirMock,
+	isFile: isFileMock,
+}))
+
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { /*no-op*/ })
+const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => { /*no-op*/ })
+
+
+const {
+	oldDirs,
+	copyIfExists,
+} = await import('../../lib/yargs-transition-temp.js')
+
+
+const origEnv = process.env
+
+beforeEach(() => {
+	process.env = { ...origEnv }
+})
+
+afterEach(() => {
+	process.env = origEnv
+})
+
+describe('oldDirs', () => {
+	type MockEnvironment = {
+		platform: NodeJS.Platform
+		env: NodeJS.ProcessEnv
+		homeDirReturnsEmpty?: boolean // defaults to true
+
+		oldConfigDir: string
+		oldCacheDir: string
+	}
+
+	/* eslint-disable @typescript-eslint/naming-convention */
+	const mockEnvironments: MockEnvironment[] = [
+		{
+			platform: 'win32',
+			env: {
+				HOMEDRIVE: 'home-drive-env',
+				HOMEPATH: 'home-path-env',
+				USERPROFILE: 'user-profile-env',
+			},
+			oldConfigDir: 'home-drive-env|home-path-env|.config|@smartthings/cli',
+			oldCacheDir: 'home-drive-env|home-path-env|.cache|@smartthings/cli',
+		},
+		{
+			platform: 'win32',
+			env: {
+				USERPROFILE: 'user-profile-env',
+			},
+			oldConfigDir: 'user-profile-env|.config|@smartthings/cli',
+			oldCacheDir: 'user-profile-env|.cache|@smartthings/cli',
+		},
+		{
+			platform: 'win32',
+			env: {
+				HOMEDRIVE: 'home-drive-env',
+				HOMEPATH: 'home-path-env',
+				USERPROFILE: 'user-profile-env',
+				HOME: 'home-env',
+			},
+			oldConfigDir: 'home-env|.config|@smartthings/cli',
+			oldCacheDir: 'home-env|.cache|@smartthings/cli',
+		},
+		{
+			platform: 'win32',
+			env: {
+				HOMEDRIVE: 'home-drive-env',
+				HOMEPATH: 'home-path-env',
+				USERPROFILE: 'user-profile-env',
+				HOME: 'home-env',
+				XDG_CONFIG_HOME: 'xdg-config-home-env',
+				XDG_CACHE_HOME: 'xdg-cache-home-env',
+			},
+			oldConfigDir: 'xdg-config-home-env|@smartthings/cli',
+			oldCacheDir: 'xdg-cache-home-env|@smartthings/cli',
+		},
+		{
+			platform: 'darwin',
+			env: {
+				HOMEDRIVE: 'home-drive-env',
+				HOMEPATH: 'home-path-env',
+				USERPROFILE: 'user-profile-env',
+				HOME: 'home-env',
+			},
+			oldConfigDir: 'home-env|.config|@smartthings/cli',
+			oldCacheDir: 'home-env|Library|Caches|@smartthings/cli',
+		},
+		{
+			platform: 'linux',
+			env: {
+			},
+			oldConfigDir: 'home-dir-func|.config|@smartthings/cli',
+			oldCacheDir: 'home-dir-func|.cache|@smartthings/cli',
+		},
+		{
+			platform: 'linux',
+			env: {
+			},
+			homeDirReturnsEmpty: false,
+			oldConfigDir: 'tmp-dir-func|.config|@smartthings/cli',
+			oldCacheDir: 'tmp-dir-func|.cache|@smartthings/cli',
+		},
+	]
+	/* eslint-enable @typescript-eslint/naming-convention */
+
+	it.each(mockEnvironments)('', ({ platform, env, oldConfigDir, oldCacheDir, homeDirReturnsEmpty }) => {
+		platformMock.mockReturnValue(platform)
+		process.env = env
+		if (homeDirReturnsEmpty === false) {
+			homedirMock.mockReturnValueOnce('')
+		}
+
+		expect(oldDirs()).toStrictEqual({ oldConfigDir, oldCacheDir })
+	})
+})
+
+describe('copyIfExists', () => {
+	it('copies with no log message when given no description', async () => {
+		joinMock.mockReturnValueOnce('old-filename')
+		joinMock.mockReturnValueOnce('new-filename')
+
+		isFileMock.mockResolvedValueOnce(true)
+		isFileMock.mockResolvedValueOnce(false)
+
+		await expect(copyIfExists({
+			filename: 'filename',
+			oldDir: 'old-dir',
+			newDir: 'new-dir',
+			verboseLogging: false,
+		})).resolves.not.toThrow()
+
+		expect(joinMock).toHaveBeenCalledTimes(2)
+		expect(joinMock).toHaveBeenCalledWith('old-dir', 'filename')
+		expect(joinMock).toHaveBeenCalledWith('new-dir', 'filename')
+		expect(isFileMock).toHaveBeenCalledTimes(2)
+		expect(isFileMock).toHaveBeenCalledWith('old-filename')
+		expect(isFileMock).toHaveBeenCalledWith('new-filename')
+		expect(ensureDirMock).toHaveBeenCalledExactlyOnceWith('new-dir')
+		expect(copyFileMock).toHaveBeenCalledExactlyOnceWith('old-filename', 'new-filename')
+
+		expect(consoleErrorSpy).not.toHaveBeenCalledWith(expect.stringContaining('found old file old-filename'))
+		expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining('and copied it to'))
+	})
+
+	it('copies with log message when given description', async () => {
+		joinMock.mockReturnValueOnce('old-filename')
+		joinMock.mockReturnValueOnce('new-filename')
+
+		isFileMock.mockResolvedValueOnce(true)
+		isFileMock.mockResolvedValueOnce(false)
+
+		await expect(copyIfExists({
+			filename: 'filename',
+			oldDir: 'old-dir',
+			newDir: 'new-dir',
+			description: 'interesting',
+			verboseLogging: true,
+		})).resolves.not.toThrow()
+
+		expect(isFileMock).toHaveBeenCalledTimes(2)
+		expect(isFileMock).toHaveBeenCalledWith('old-filename')
+		expect(isFileMock).toHaveBeenCalledWith('new-filename')
+		expect(ensureDirMock).toHaveBeenCalledExactlyOnceWith('new-dir')
+		expect(copyFileMock).toHaveBeenCalledExactlyOnceWith('old-filename', 'new-filename')
+		expect(consoleErrorSpy).toHaveBeenCalledWith('found old file filename in old-dir; copying to new-dir')
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			'found old interesting file old-filename and copied it to new-filename\n' +
+				'from version 2.0, the CLI will use new-filename for interesting')
+
+	})
+
+	it('does nothing if old file does not exist', async () => {
+		joinMock.mockReturnValueOnce('old-filename')
+		joinMock.mockReturnValueOnce('new-filename')
+
+		isFileMock.mockResolvedValueOnce(false)
+		isFileMock.mockResolvedValueOnce(false)
+
+		await expect(copyIfExists({
+			filename: 'filename',
+			oldDir: 'old-dir',
+			newDir: 'new-dir',
+			verboseLogging: false,
+		})).resolves.not.toThrow()
+
+		expect(ensureDirMock).not.toHaveBeenCalled()
+		expect(copyFileMock).not.toHaveBeenCalled()
+		expect(consoleErrorSpy).not.toHaveBeenCalledWith(expect.stringContaining('found old file old-filename'))
+		expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining('and copied it to'))
+	})
+
+	it('does nothing new file already exists', async () => {
+		joinMock.mockReturnValueOnce('old-filename')
+		joinMock.mockReturnValueOnce('new-filename')
+
+		isFileMock.mockResolvedValueOnce(true)
+		isFileMock.mockResolvedValueOnce(true)
+
+		await expect(copyIfExists({
+			filename: 'filename',
+			oldDir: 'old-dir',
+			newDir: 'new-dir',
+			verboseLogging: true,
+		})).resolves.not.toThrow()
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'not copying filename from old-dir to new-dir; oldExists=true; newExists=true',
+		)
+
+		expect(ensureDirMock).not.toHaveBeenCalled()
+		expect(copyFileMock).not.toHaveBeenCalled()
+		expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining('and copied it to'))
+	})
+
+	it('does nothing if directory unchanged', async () => {
+		await expect(copyIfExists({
+			filename: 'filename',
+			oldDir: 'old-dir-same-as-new',
+			newDir: 'old-dir-same-as-new',
+			verboseLogging: true,
+		})).resolves.not.toThrow()
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'old and new directories (old-dir-same-as-new) are the same for filename',
+		)
+
+		expect(ensureDirMock).not.toHaveBeenCalled()
+		expect(copyFileMock).not.toHaveBeenCalled()
+		expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining('and copied it to'))
+	})
+})

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path'
+
 import yaml from 'js-yaml'
 import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 
@@ -87,6 +89,8 @@ const handler = async (argv: ArgumentsCamelCase<CommandArgs>): Promise<void> => 
 	} else {
 		const outputFormat = calculateOutputFormat(argv)
 		if (outputFormat === 'common') {
+			console.log('The CLI configuration file on your machine is:\n' +
+				`    ${join(command.configDir, 'config.yaml')}\n`)
 			await outputList(command, outputListConfig, listConfigs, true)
 		} else {
 			const outputFormatter = buildOutputFormatter(command.flags, command.cliConfig)

--- a/src/lib/command/api-command.ts
+++ b/src/lib/command/api-command.ts
@@ -88,7 +88,7 @@ export const apiCommand = async <T extends APICommandFlags>(flags: T, addAdditio
 
 	const authenticator = token
 		? newBearerTokenAuthenticator(token)
-		: loginAuthenticator(`${stCommand.configDir}/credentials.json`, stCommand.profileName, clientIdProvider, userAgent)
+		: loginAuthenticator(`${stCommand.dataDir}/credentials.json`, stCommand.profileName, clientIdProvider, userAgent)
 
 	const warningLogger = (warnings: WarningFromHeader[] | string): void => {
 		const message = 'Warnings from API:\n' + (typeof(warnings) === 'string'

--- a/src/lib/command/smartthings-command.ts
+++ b/src/lib/command/smartthings-command.ts
@@ -1,14 +1,18 @@
+import envPaths from 'env-paths'
 import log4js from 'log4js'
 import { type Argv } from 'yargs'
 
 import { type CLIConfig, loadConfig, type Profile } from '../cli-config.js'
+import { ensureDir } from '../file-util.js'
 import { buildDefaultLog4jsConfig, loadLog4jsConfig } from '../log-utils.js'
-import { BuildOutputFormatterFlags } from './output-builder.js'
 import { defaultTableGenerator, type TableGenerator } from '../table-generator.js'
+import { copyIfExists, oldDirs } from '../yargs-transition-temp.js'
+import type { BuildOutputFormatterFlags } from './output-builder.js'
 
 
 export type SmartThingsCommandFlags = {
 	profile: string
+	verboseDirectoryLogging?: boolean
 }
 
 export const smartThingsCommandBuilder = <T extends object = object>(
@@ -21,37 +25,102 @@ export const smartThingsCommandBuilder = <T extends object = object>(
 			type: 'string',
 			default: 'default',
 		})
+		// This option is temporary and will be removed when removing automatic copy
+		// of old configuration files. (See also yargs-transition-temp.ts.)
+		.option('verbose-directory-logging', {
+			describe: 'log information about config, data, and logging directories to stderr',
+			type: 'boolean',
+			default: false,
+			hidden: true,
+		})
+
+type Dirs = {
+	configDir: string
+	dataDir: string
+	logDir: string
+}
 
 /**
  * An interface version of SmartThingsCommand to make its contract easier to mix with other
  * interfaces and to limit what we need to mock for tests.
  */
-export type SmartThingsCommand<T extends SmartThingsCommandFlags = SmartThingsCommandFlags> = {
-	flags: T
+export type SmartThingsCommand<T extends SmartThingsCommandFlags = SmartThingsCommandFlags> =
+	& Dirs
+	& {
+		flags: T
 
-	configDir: string
-	cacheDir: string
+		/**
+		 * The full configuration set, including both user-configured and cli-managed configuration
+		 * values and all profiles. Most often you will just want to use `profile` instead.
+		 */
+		cliConfig: CLIConfig
 
-	/**
-	 * The full configuration set, including both user-configured and cli-managed configuration
-	 * values and all profiles. Most often you will just want to use `profile` instead.
-	 */
-	cliConfig: CLIConfig
+		/**
+		 * The name of the in-use profile.
+		 */
+		profileName: string
 
-	/**
-	 * The name of the in-use profile.
-	 */
-	profileName: string
+		/**
+		 * The configuration set for the selected profile.
+		 */
+		profile: Profile
 
-	/**
-	 * The configuration set for the selected profile.
-	 */
-	profile: Profile
+		// TODO: move to output-builder.ts
+		tableGenerator: TableGenerator
 
-	// TODO: move to output-builder.ts
-	tableGenerator: TableGenerator
+		logger: log4js.Logger
+	}
 
-	logger: log4js.Logger
+/**
+ * Get config directories and copy old config files if they exist and there are no new ones.
+ */
+export const getConfigDirsCheckingForOldConfig = async (
+		options: { verboseLogging: boolean },
+): Promise<Dirs> => {
+	const { oldConfigDir, oldCacheDir } = oldDirs()
+	if (options.verboseLogging) {
+		console.error(`old config dir = ${oldConfigDir}`)
+		console.error(`old cache dir = ${oldCacheDir}`)
+	}
+	// The documentation says not to use `suffix` "unless you really have to" but the directories
+	// get suffixed with `-nodejs` without using it. This would be fine for the data directory,
+	// but for the config and log directories that users might use, it seems rather ugly.
+	const { config: configDir, data: dataDir, log: logDir } = envPaths('@smartthings/cli', { suffix: '' })
+	if (options.verboseLogging) {
+		console.error(`config dir = ${configDir}`)
+		console.error(`data dir = ${dataDir}`)
+		console.error(`log dir = ${logDir}`)
+	}
+	await ensureDir(configDir)
+
+	await copyIfExists({
+		...options,
+		filename: 'config.yaml',
+		oldDir: oldConfigDir,
+		newDir: configDir,
+		description: 'configuration',
+	})
+	await copyIfExists({
+		...options,
+		filename: 'logging.yaml',
+		oldDir: oldConfigDir,
+		newDir: configDir,
+		description: 'logging configuration',
+	})
+	await copyIfExists({
+		...options,
+		filename: 'credentials.json',
+		oldDir: oldConfigDir,
+		newDir: dataDir,
+	})
+	await copyIfExists({
+		...options,
+		filename: 'config-managed.yaml',
+		oldDir: oldCacheDir,
+		newDir: dataDir,
+	})
+
+	return { configDir, dataDir, logDir }
 }
 
 /**
@@ -60,11 +129,11 @@ export type SmartThingsCommand<T extends SmartThingsCommandFlags = SmartThingsCo
 export const smartThingsCommand = async <T extends SmartThingsCommandFlags>(
 	flags: T,
 ): Promise<SmartThingsCommand<T>> => {
-	// TODO: need to be platform-independent
-	const configDir = `${process.env['HOME']}/.config/@smartthings/cli`
-	const cacheDir = `${process.env['HOME']}/Library/Caches/@smartthings/cli`
+	const { configDir, dataDir, logDir } = await getConfigDirsCheckingForOldConfig(
+		{ verboseLogging: !!flags.verboseDirectoryLogging },
+	)
 
-	const defaultLogConfig = buildDefaultLog4jsConfig(`${cacheDir}/smartthings.log`)
+	const defaultLogConfig = buildDefaultLog4jsConfig(`${logDir}/smartthings.log`)
 	const logConfig = loadLog4jsConfig(`${configDir}/logging.yaml`, defaultLogConfig)
 
 	log4js.configure(logConfig)
@@ -75,7 +144,7 @@ export const smartThingsCommand = async <T extends SmartThingsCommandFlags>(
 
 	const cliConfig = await loadConfig({
 		configFilename: `${configDir}/config.yaml`,
-		managedConfigFilename: `${cacheDir}/config-managed.yaml`,
+		managedConfigFilename: `${dataDir}/config-managed.yaml`,
 		profileName,
 	}, logger)
 
@@ -89,7 +158,8 @@ export const smartThingsCommand = async <T extends SmartThingsCommandFlags>(
 	return {
 		flags,
 		configDir,
-		cacheDir,
+		dataDir,
+		logDir,
 		cliConfig,
 		profileName,
 		profile,

--- a/src/lib/yargs-transition-temp.ts
+++ b/src/lib/yargs-transition-temp.ts
@@ -1,0 +1,75 @@
+import { copyFile } from 'node:fs/promises'
+import { homedir, platform, tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { ensureDir, isFile } from './file-util.js'
+
+
+// This file includes functions for finding old configuration files from before the yargs transition
+// and copying them if needed.
+//
+// It is intended that we will delete this file one year after the release of the yargs version
+// of the CLI.
+
+
+// Code temporarily copied from @oclif/core, version 1.16.3, that determines config and cache
+// directories (with some things hard-coded to our values and WSL support removed).
+// We are now using the `envPaths` library but want to support users by copying their configs.
+// This is planned to be removed 1 year after the transition to yargs has been released.
+export const oldDirs = (): { oldConfigDir: string; oldCacheDir: string } => {
+	const onWindows = platform() === 'win32'
+	const windowsHome  = (process.env.HOMEDRIVE && process.env.HOMEPATH &&
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		join(process.env.HOMEDRIVE!, process.env.HOMEPATH!)) || process.env.USERPROFILE
+	const home = process.env.HOME || (onWindows && windowsHome) || homedir() || tmpdir()
+	const dirname = '@smartthings/cli'
+	const macosCacheDir = (): string | undefined =>
+		(platform() === 'darwin' && join(home, 'Library', 'Caches', dirname)) || undefined
+
+	const dir = (category: 'cache' | 'config'): string => {
+		const base = process.env[`XDG_${category.toUpperCase()}_HOME`] ||
+			(onWindows && process.env.LOCALAPPDATA) || join(home, '.' + category)
+		return join(base, dirname)
+	}
+
+	return { oldConfigDir: dir('config'), oldCacheDir: macosCacheDir() || dir('cache') }
+}
+
+export const copyIfExists = async (
+		options: {
+			filename: string
+			oldDir: string
+			newDir: string
+			description?: string // when omitted, user is not notified (omit for CLI-managed files)
+			verboseLogging: boolean
+		},
+): Promise<void> => {
+	const { filename, oldDir, newDir, description, verboseLogging } = options
+	if (oldDir === newDir) {
+		// in some situations, the directory might not change
+		if (verboseLogging) {
+			console.error(`old and new directories (${oldDir}) are the same for ${filename}`)
+		}
+		return
+	}
+	const oldFilename = join(oldDir, filename)
+	const newFilename = join(newDir, filename)
+	const oldExists = await isFile(oldFilename)
+	const newExists = await isFile(newFilename)
+	if (oldExists && !newExists) {
+		if (verboseLogging) {
+			console.error(`found old file ${filename} in ${oldDir}; copying to ${newDir}`)
+		}
+		await ensureDir(newDir)
+		await copyFile(oldFilename, newFilename)
+		if (description) {
+			console.warn(`found old ${description} file ${oldFilename} and copied it to ${newFilename}\n` +
+				`from version 2.0, the CLI will use ${newFilename} for ${description}`)
+		}
+	} else if (verboseLogging) {
+		console.error(
+			`not copying ${filename} from ${oldDir} to ${newDir}; ` +
+			`oldExists=${oldExists}; newExists=${newExists}`,
+		)
+	}
+}

--- a/temporary-notes.md
+++ b/temporary-notes.md
@@ -2,3 +2,6 @@ Collected notes to eventually include in the yargs release notes.
 
 * capability version command line arguments have been changed from (in yargs-speak) positionals to
   flags (options in yargs-speak)
+* config file location is now determined by https://www.npmjs.com/package/env-paths[envPaths] library
+  rather than oclif. A reasonable attempt has been made at finding the old config and copying it for
+  the user. The `config` command now displays the name of the configuration file in its default output.


### PR DESCRIPTION
* made use of `env-path` node library to determine where to locate:
    * config files (files power users might edit)
    * default log file location
    * data files (non-user files managed completely by the CLI)
* temporarily included code to find old files and copy them; the plan is to leave this in for at least a year after the yargs release
* the `config` command now tells the user where the config file is found
* updated and added unit tests 