### PR TITLE
refactor: split devices-util up to match new util structure

### DIFF
--- a/src/__tests__/commands/devices/capability-status.test.ts
+++ b/src/__tests__/commands/devices/capability-status.test.ts
@@ -21,10 +21,8 @@ import type {
 import type { BuildOutputFormatterFlags } from '../.././../lib/command/output-builder.js'
 import type { selectFromList } from '../../../lib/command/select.js'
 import type { SmartThingsCommandFlags } from '../../../lib/command/smartthings-command.js'
-import {
-	chooseComponentFn,
-	prettyPrintAttribute,
-} from '../../../lib/command/util/devices-util.js'
+import type { prettyPrintAttribute } from '../../../lib/command/util/devices.js'
+import type { chooseComponentFn } from '../../../lib/command/util/devices-choose.js'
 import type { ChooseFunction } from '../../../lib/command/util/util-util.js'
 import { buildArgvMock, buildArgvMockStub } from '../../test-lib/builder-mock.js'
 import {
@@ -50,15 +48,18 @@ jest.unstable_mockModule('../../../lib/command/select.js', () => ({
 	selectFromList: selectFromListMock,
 }))
 
+const prettyPrintAttributeMock = jest.fn<typeof prettyPrintAttribute>()
+jest.unstable_mockModule('../../../lib/command/util/devices.js', () => ({
+	prettyPrintAttribute: prettyPrintAttributeMock,
+}))
+
 const chooseComponentMock = jest.fn<ChooseFunction<Component>>()
 const chooseComponentFnMock = jest.fn<typeof chooseComponentFn>()
 	.mockReturnValue(chooseComponentMock)
 const chooseDeviceMock = jest.fn<ChooseFunction<Device>>().mockResolvedValue('chosen-device-id')
-const prettyPrintAttributeMock = jest.fn<typeof prettyPrintAttribute>()
-jest.unstable_mockModule('../../../lib/command/util/devices-util.js', () => ({
+jest.unstable_mockModule('../../../lib/command/util/devices-choose.js', () => ({
 	chooseComponentFn: chooseComponentFnMock,
 	chooseDevice: chooseDeviceMock,
-	prettyPrintAttribute: prettyPrintAttributeMock,
 }))
 
 const formatAndWriteItemMock = jest.fn<typeof formatAndWriteItem<CapabilityStatus>>()

--- a/src/__tests__/commands/devices/delete.test.ts
+++ b/src/__tests__/commands/devices/delete.test.ts
@@ -6,7 +6,7 @@ import type { DevicesEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
 
 import type { CommandArgs } from '../../../commands/devices/delete.js'
 import type { APICommand, APICommandFlags } from '../../../lib/command/api-command.js'
-import type { chooseDevice } from '../../../lib/command/util/devices-util.js'
+import type { chooseDevice } from '../../../lib/command/util/devices-choose.js'
 import { apiCommandMocks } from '../../test-lib/api-command-mock.js'
 import { buildArgvMock } from '../../test-lib/builder-mock.js'
 
@@ -14,7 +14,7 @@ import { buildArgvMock } from '../../test-lib/builder-mock.js'
 const { apiCommandMock, apiCommandBuilderMock, apiDocsURLMock } = apiCommandMocks('../../..')
 
 const chooseDeviceMock = jest.fn<typeof chooseDevice>()
-jest.unstable_mockModule('../../../lib/command/util/devices-util.js', () => ({
+jest.unstable_mockModule('../../../lib/command/util/devices-choose.js', () => ({
 	chooseDevice: chooseDeviceMock,
 }))
 

--- a/src/__tests__/commands/devices/preferences.test.ts
+++ b/src/__tests__/commands/devices/preferences.test.ts
@@ -28,7 +28,7 @@ import {
 const { apiCommandMock, apiCommandBuilderMock } = apiCommandMocks('../../..')
 
 const chooseDeviceMock = jest.fn<ChooseFunction<Device>>()
-jest.unstable_mockModule('../../../lib/command/util/devices-util.js', () => ({
+jest.unstable_mockModule('../../../lib/command/util/devices-choose.js', () => ({
 	chooseDevice: chooseDeviceMock,
 }))
 

--- a/src/__tests__/commands/locations/delete.test.ts
+++ b/src/__tests__/commands/locations/delete.test.ts
@@ -1,12 +1,12 @@
 import { jest } from '@jest/globals'
 
-import { ArgumentsCamelCase, Argv } from 'yargs'
+import type { ArgumentsCamelCase, Argv } from 'yargs'
 
-import { LocationsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
+import type { LocationsEndpoint, SmartThingsClient } from '@smartthings/core-sdk'
 
-import { CommandArgs } from '../../../commands/locations/delete.js'
-import { APICommand, APICommandFlags } from '../../../lib/command/api-command.js'
-import { chooseLocation } from '../../../lib/command/util/locations-util.js'
+import type { CommandArgs } from '../../../commands/locations/delete.js'
+import type { APICommand, APICommandFlags } from '../../../lib/command/api-command.js'
+import type { chooseLocation } from '../../../lib/command/util/locations-util.js'
 import { apiCommandMocks } from '../../test-lib/api-command-mock.js'
 import { buildArgvMock } from '../../test-lib/builder-mock.js'
 
@@ -63,12 +63,9 @@ test('handler', async () => {
 
 	await expect(cmd.handler(inputArgv)).resolves.not.toThrow()
 
-	expect(apiCommandMock).toHaveBeenCalledTimes(1)
-	expect(apiCommandMock).toHaveBeenCalledWith(inputArgv)
-	expect(chooseLocationMock).toHaveBeenCalledTimes(1)
-	expect(chooseLocationMock).toHaveBeenCalledWith(command, 'command-line-id')
-	expect(apiLocationsDeleteMock).toHaveBeenCalledTimes(1)
-	expect(apiLocationsDeleteMock).toHaveBeenCalledWith('chosen-location-id')
+	expect(apiCommandMock).toHaveBeenCalledExactlyOnceWith(inputArgv)
+	expect(chooseLocationMock).toHaveBeenCalledExactlyOnceWith(command, 'command-line-id')
+	expect(apiLocationsDeleteMock).toHaveBeenCalledExactlyOnceWith('chosen-location-id')
 
 	expect(consoleLogSpy).toHaveBeenLastCalledWith('Location chosen-location-id deleted.')
 })

--- a/src/__tests__/lib/command/util/devices-choose.test.ts
+++ b/src/__tests__/lib/command/util/devices-choose.test.ts
@@ -1,7 +1,6 @@
 import { jest } from '@jest/globals'
 
 import type {
-	AttributeState,
 	Component,
 	Device,
 	DeviceListOptions,
@@ -36,8 +35,7 @@ jest.unstable_mockModule('../../../../lib/command/util/util-util.js', () => ({
 const {
 	chooseComponentFn,
 	chooseDeviceFn,
-	prettyPrintAttribute,
-} = await import('../../../../lib/command/util/devices-util.js')
+} = await import('../../../../lib/command/util/devices-choose.js')
 
 describe('chooseDeviceFn', () => {
 	const chooseDeviceMock = jest.fn<ChooseFunction<Device>>()
@@ -162,29 +160,4 @@ describe('chooseComponentFn', () => {
 			expect(fatalErrorMock).toHaveBeenCalledExactlyOnceWith('No components found')
 		},
 	)
-})
-
-const complicatedAttribute: AttributeState = {
-	value: {
-		name: 'Entity name',
-		id: 'entity-id',
-		description: 'It is very big and huge and long so the serialized JSON is over 50 characters.',
-		version: 1,
-		precision: 120.375,
-	},
-}
-const prettyPrintedComplicatedAttribute = JSON.stringify(complicatedAttribute.value, null, 2)
-
-test.each([
-	{ attribute: { value: null }, expected: '' },
-	{ attribute: { value: undefined }, expected: '' },
-	{ attribute: {}, expected: '' },
-	{ attribute: { value: 100 }, expected: '100' },
-	{ attribute: { value: 128, unit: 'yobibytes' }, expected: '128 yobibytes' },
-	{ attribute: { value: 21.5 }, expected: '21.5' },
-	{ attribute: { value: 'active' }, expected: '"active"' },
-	{ attribute: { value: { x: 1, y: 2 } }, expected: '{"x":1,"y":2}' },
-	{ attribute: complicatedAttribute, expected: prettyPrintedComplicatedAttribute },
-])('prettyPrintAttribute returns $expected when given $attribute', ({ attribute, expected }) => {
-	expect(prettyPrintAttribute(attribute)).toBe(expected)
 })

--- a/src/__tests__/lib/command/util/devices.test.ts
+++ b/src/__tests__/lib/command/util/devices.test.ts
@@ -1,0 +1,32 @@
+import { type AttributeState } from '@smartthings/core-sdk'
+
+
+const complicatedAttribute: AttributeState = {
+	value: {
+		name: 'Entity name',
+		id: 'entity-id',
+		description: 'It is very big and huge and long so the serialized JSON is over 50 characters.',
+		version: 1,
+		precision: 120.375,
+	},
+}
+const prettyPrintedComplicatedAttribute = JSON.stringify(complicatedAttribute.value, null, 2)
+
+const {
+	prettyPrintAttribute,
+} = await import('../../../../lib/command/util/devices.js')
+
+
+test.each([
+	{ attribute: { value: null }, expected: '' },
+	{ attribute: { value: undefined }, expected: '' },
+	{ attribute: {}, expected: '' },
+	{ attribute: { value: 100 }, expected: '100' },
+	{ attribute: { value: 128, unit: 'yobibytes' }, expected: '128 yobibytes' },
+	{ attribute: { value: 21.5 }, expected: '21.5' },
+	{ attribute: { value: 'active' }, expected: '"active"' },
+	{ attribute: { value: { x: 1, y: 2 } }, expected: '{"x":1,"y":2}' },
+	{ attribute: complicatedAttribute, expected: prettyPrintedComplicatedAttribute },
+])('prettyPrintAttribute returns $expected when given $attribute', ({ attribute, expected }) => {
+	expect(prettyPrintAttribute(attribute)).toBe(expected)
+})

--- a/src/commands/devices/capability-status.ts
+++ b/src/commands/devices/capability-status.ts
@@ -15,11 +15,8 @@ import {
 	type FormatAndWriteItemFlags,
 } from '../../lib/command/format.js'
 import { selectFromList, type SelectFromListConfig } from '../../lib/command/select.js'
-import {
-	chooseComponentFn,
-	chooseDevice,
-	prettyPrintAttribute,
-} from '../../lib/command/util/devices-util.js'
+import { prettyPrintAttribute } from '../../lib/command/util/devices.js'
+import { chooseComponentFn, chooseDevice } from '../../lib/command/util/devices-choose.js'
 import { type TableGenerator } from '../../lib/table-generator.js'
 import { fatalError } from '../../lib/util.js'
 

--- a/src/commands/devices/commands.ts
+++ b/src/commands/devices/commands.ts
@@ -4,7 +4,7 @@ import { Command } from '@smartthings/core-sdk'
 
 import { apiCommand, apiCommandBuilder, type APICommandFlags, apiDocsURL } from '../../lib/command/api-command.js'
 import { inputItem, inputItemBuilder, type InputItemFlags } from '../../lib/command/input-item.js'
-import { chooseDevice } from '../../lib/command/util/devices-util.js'
+import { chooseDevice } from '../../lib/command/util/devices-choose.js'
 import { commandLineInputProcessor, userInputProcessor } from '../../lib/command/input-processor.js'
 import { getInputFromUser, parseDeviceCommand } from '../../lib/command/util/devices-commands.js'
 

--- a/src/commands/devices/delete.ts
+++ b/src/commands/devices/delete.ts
@@ -6,7 +6,7 @@ import {
 	apiCommandBuilder,
 	apiDocsURL,
 } from '../../lib/command/api-command.js'
-import { chooseDevice } from '../../lib/command/util/devices-util.js'
+import { chooseDevice } from '../../lib/command/util/devices-choose.js'
 
 
 export type CommandArgs = APICommandFlags & {

--- a/src/commands/devices/preferences.ts
+++ b/src/commands/devices/preferences.ts
@@ -3,7 +3,7 @@ import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 import { type DevicePreferenceResponse } from '@smartthings/core-sdk'
 
 import { type APICommandFlags, apiCommand, apiCommandBuilder } from '../../lib/command/api-command.js'
-import { chooseDevice } from '../../lib/command/util/devices-util.js'
+import { chooseDevice } from '../../lib/command/util/devices-choose.js'
 import { type FormatAndWriteItemFlags, formatAndWriteItem, formatAndWriteItemBuilder } from '../../lib/command/format.js'
 import { type TableGenerator } from '../../lib/table-generator.js'
 

--- a/src/lib/command/util/devices-choose.ts
+++ b/src/lib/command/util/devices-choose.ts
@@ -1,5 +1,4 @@
 import {
-	type AttributeState,
 	type Component,
 	type Device,
 	type DeviceListOptions,
@@ -60,24 +59,4 @@ export const chooseComponentFn = (
 		},
 		async () => components,
 	)
-}
-
-/**
- * Return a JSON-formatted value for a capability attribute with the unit appended if there is one.
- *
- * Since strings and numbers are valid JSON, if value is a string, this will return a quoted
- * string or just the number for a number.
- */
-export const prettyPrintAttribute = (attribute: AttributeState): string => {
-	const { unit, value } = attribute
-	if (value == null) {
-		return ''
-	}
-
-	let result = JSON.stringify(value)
-	if (result.length > 50) {
-		result = JSON.stringify(value, null, 2)
-	}
-
-	return `${result}${unit ? ' ' + unit : ''}`
 }

--- a/src/lib/command/util/devices-table.ts
+++ b/src/lib/command/util/devices-table.ts
@@ -2,7 +2,7 @@ import { type Device, type DeviceHealth } from '@smartthings/core-sdk'
 
 import { type WithNamedRoom } from '../../api-helpers.js'
 import { type TableGenerator } from '../../table-generator.js'
-import { prettyPrintAttribute } from './devices-util.js'
+import { prettyPrintAttribute } from './devices.js'
 
 
 export const buildEmbeddedStatusTableOutput = (tableGenerator: TableGenerator, data: Device): string => {

--- a/src/lib/command/util/devices.ts
+++ b/src/lib/command/util/devices.ts
@@ -1,0 +1,22 @@
+import { type AttributeState } from '@smartthings/core-sdk'
+
+
+/**
+ * Return a JSON-formatted value for a capability attribute with the unit appended if there is one.
+ *
+ * Since strings and numbers are valid JSON, if value is a string, this will return a quoted
+ * string or just the number for a number.
+ */
+export const prettyPrintAttribute = (attribute: AttributeState): string => {
+	const { unit, value } = attribute
+	if (value == null) {
+		return ''
+	}
+
+	let result = JSON.stringify(value)
+	if (result.length > 50) {
+		result = JSON.stringify(value, null, 2)
+	}
+
+	return `${result}${unit ? ' ' + unit : ''}`
+}


### PR DESCRIPTION
This pull request splits the devices-util module up:

  * choose functionality moved to `devices-choose`
  * table definitions moved to `devices-table`
  * dropped `-util` from name since this is already nested under a `util` directory
  * updated calling code and tests