### PR TITLE
feat: include label when asking user for an organization

### DIFF
--- a/.changeset/lazy-lies-boil.md
+++ b/.changeset/lazy-lies-boil.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+include label as well as name when prompting user for an organization

--- a/packages/cli/src/lib/commands/organization-util.ts
+++ b/packages/cli/src/lib/commands/organization-util.ts
@@ -20,6 +20,7 @@ export const chooseOrganization = async (
 		itemName: 'organization',
 		primaryKeyName: 'organizationId',
 		sortKeyName: 'name',
+		listTableFieldDefinitions: ['name', 'label', 'organizationId'],
 	}
 	const listItems = (): Promise<OrganizationResponse[]> => command.client.organizations.list()
 	const preselectedId = opts.allowIndex

--- a/packages/cli/src/lib/commands/schema-util.ts
+++ b/packages/cli/src/lib/commands/schema-util.ts
@@ -99,7 +99,7 @@ export const organizationDef = (organizations: OrganizationResponse[]): InputDef
 
 	const choices = organizations
 		.map(organization => ({
-			name: organization.name,
+			name: organization.label ? `${organization.name} (${organization.label})` : organization.name,
 			value: organization.organizationId,
 		}))
 


### PR DESCRIPTION
Include label in addition to name when prompting the user for an organization. (There are two places we do this.) We should probably run them both through `chooseOrganization` but I'll leave that change for another day.