### PR TITLE
fix: allow 0 for integer values in `askForOptionalInteger`

### DIFF
--- a/.changeset/metal-terms-eat.md
+++ b/.changeset/metal-terms-eat.md
@@ -1,0 +1,6 @@
+---
+"@smartthings/cli-lib": patch
+"@smartthings/cli": patch
+---
+
+fixed bug where prompts for optional integers were treating 0 as if no value was entered

--- a/packages/lib/src/__tests__/user-query.test.ts
+++ b/packages/lib/src/__tests__/user-query.test.ts
@@ -203,6 +203,14 @@ describe('askForOptionalInteger', () => {
 		expect(promptMock).toHaveBeenCalledTimes(1)
 	})
 
+	it('returns "0" entered as 0', async () => {
+		promptMock.mockResolvedValue({ value: '0' })
+
+		expect(await askForOptionalInteger('prompt message')).toBe(0)
+
+		expect(promptMock).toHaveBeenCalledTimes(1)
+	})
+
 	it('passes validate to inquirer', async () => {
 		promptMock.mockResolvedValue({ value: '' })
 

--- a/packages/lib/src/user-query.ts
+++ b/packages/lib/src/user-query.ts
@@ -124,7 +124,7 @@ export const askForOptionalInteger = async (message: string, options?: AskForInt
 		...options,
 		validate: options?.validate ? allowEmptyFn(options.validate) : undefined,
 	}
-	return await promptForInteger(message, updatedOptions) || undefined
+	return await promptForInteger(message, updatedOptions)
 }
 
 /**


### PR DESCRIPTION
Fixed a bug where entering the number 0 in a prompt for an optional integer was treating it as if nothing were entered.