### PR TITLE
refactor: update user-query functions to use new inquirer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/client-lambda": "^3.817.0",
+				"@inquirer/prompts": "^7.5.3",
 				"@smartthings/core-sdk": "^8.4.1",
 				"axios": "1.9.0",
 				"chalk": "^5.4.1",
@@ -2305,13 +2306,320 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/@inquirer/checkbox": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.8.tgz",
+			"integrity": "sha512-d/QAsnwuHX2OPolxvYcgSj7A9DO9H6gVOy2DvBTx+P2LH2iRTo/RSGV3iwCzW024nP9hw98KIuDmdyhZQj1UQg==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/figures": "^1.0.12",
+				"@inquirer/type": "^3.0.7",
+				"ansi-escapes": "^4.3.2",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/confirm": {
+			"version": "5.1.12",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.12.tgz",
+			"integrity": "sha512-dpq+ielV9/bqgXRUbNH//KsY6WEw9DrGPmipkpmgC1Y46cwuBTNx7PXFWTjc3MQ+urcc0QxoVHcMI0FW4Ok0hg==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/type": "^3.0.7"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/core": {
+			"version": "10.1.13",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.13.tgz",
+			"integrity": "sha512-1viSxebkYN2nJULlzCxES6G9/stgHSepZ9LqqfdIGPHj5OHhiBUXVS0a6R0bEC2A+VL4D9w6QB66ebCr6HGllA==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/figures": "^1.0.12",
+				"@inquirer/type": "^3.0.7",
+				"ansi-escapes": "^4.3.2",
+				"cli-width": "^4.1.0",
+				"mute-stream": "^2.0.0",
+				"signal-exit": "^4.1.0",
+				"wrap-ansi": "^6.2.0",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@inquirer/editor": {
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.13.tgz",
+			"integrity": "sha512-WbicD9SUQt/K8O5Vyk9iC2ojq5RHoCLK6itpp2fHsWe44VxxcA9z3GTWlvjSTGmMQpZr+lbVmrxdHcumJoLbMA==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/type": "^3.0.7",
+				"external-editor": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/expand": {
+			"version": "4.0.15",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.15.tgz",
+			"integrity": "sha512-4Y+pbr/U9Qcvf+N/goHzPEXiHH8680lM3Dr3Y9h9FFw4gHS+zVpbj8LfbKWIb/jayIB4aSO4pWiBTrBYWkvi5A==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/type": "^3.0.7",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@inquirer/figures": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.6.tgz",
-			"integrity": "sha512-yfZzps3Cso2UbM7WlxKwZQh2Hs6plrbjs1QnzQDZhK2DgyCo6D8AaHps9olkNcUFlcYERMqU3uJSp1gmy3s/qQ==",
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
+			"integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/input": {
+			"version": "4.1.12",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.12.tgz",
+			"integrity": "sha512-xJ6PFZpDjC+tC1P8ImGprgcsrzQRsUh9aH3IZixm1lAZFK49UGHxM3ltFfuInN2kPYNfyoPRh+tU4ftsjPLKqQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/type": "^3.0.7"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/number": {
+			"version": "3.0.15",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.15.tgz",
+			"integrity": "sha512-xWg+iYfqdhRiM55MvqiTCleHzszpoigUpN5+t1OMcRkJrUrw7va3AzXaxvS+Ak7Gny0j2mFSTv2JJj8sMtbV2g==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/type": "^3.0.7"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/password": {
+			"version": "4.0.15",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.15.tgz",
+			"integrity": "sha512-75CT2p43DGEnfGTaqFpbDC2p2EEMrq0S+IRrf9iJvYreMy5mAWj087+mdKyLHapUEPLjN10mNvABpGbk8Wdraw==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/type": "^3.0.7",
+				"ansi-escapes": "^4.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/prompts": {
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.5.3.tgz",
+			"integrity": "sha512-8YL0WiV7J86hVAxrh3fE5mDCzcTDe1670unmJRz6ArDgN+DBK1a0+rbnNWp4DUB5rPMwqD5ZP6YHl9KK1mbZRg==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/checkbox": "^4.1.8",
+				"@inquirer/confirm": "^5.1.12",
+				"@inquirer/editor": "^4.2.13",
+				"@inquirer/expand": "^4.0.15",
+				"@inquirer/input": "^4.1.12",
+				"@inquirer/number": "^3.0.15",
+				"@inquirer/password": "^4.0.15",
+				"@inquirer/rawlist": "^4.1.3",
+				"@inquirer/search": "^3.0.15",
+				"@inquirer/select": "^4.2.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/rawlist": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.3.tgz",
+			"integrity": "sha512-7XrV//6kwYumNDSsvJIPeAqa8+p7GJh7H5kRuxirct2cgOcSWwwNGoXDRgpNFbY/MG2vQ4ccIWCi8+IXXyFMZA==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/type": "^3.0.7",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/search": {
+			"version": "3.0.15",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.15.tgz",
+			"integrity": "sha512-YBMwPxYBrADqyvP4nNItpwkBnGGglAvCLVW8u4pRmmvOsHUtCAUIMbUrLX5B3tFL1/WsLGdQ2HNzkqswMs5Uaw==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/figures": "^1.0.12",
+				"@inquirer/type": "^3.0.7",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/select": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.3.tgz",
+			"integrity": "sha512-OAGhXU0Cvh0PhLz9xTF/kx6g6x+sP+PcyTiLvCrewI99P3BBeexD+VbuwkNDvqGkk3y2h5ZiWLeRP7BFlhkUDg==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.13",
+				"@inquirer/figures": "^1.0.12",
+				"@inquirer/type": "^3.0.7",
+				"ansi-escapes": "^4.3.2",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/type": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.7.tgz",
+			"integrity": "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@isaacs/cliui": {
@@ -4175,9 +4483,9 @@
 			"dev": true
 		},
 		"node_modules/@types/inquirer": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-9.0.7.tgz",
-			"integrity": "sha512-Q0zyBupO6NxGRZut/JdmqYKOnN95Eg5V8Csg3PGKkP+FnvsUZx1jAyK7fztIszxxMuoBA6E3KXWvdZVXIpx60g==",
+			"version": "9.0.8",
+			"resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-9.0.8.tgz",
+			"integrity": "sha512-CgPD5kFGWsb8HJ5K7rfWlifao87m4ph8uioU7OTncJevmE/VLIqAAjfQtko578JZg7/f69K4FgqYym3gNr7DeA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4268,7 +4576,7 @@
 			"version": "22.15.24",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.24.tgz",
 			"integrity": "sha512-w9CZGm9RDjzTh/D+hFwlBJ3ziUaVw7oufKA3vOFSOZlzmW9AkZnfjPb+DLnrV6qtgL/LNmP0/2zBNCFHL3F0ng==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
@@ -4328,6 +4636,7 @@
 			"resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
 			"integrity": "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -9286,6 +9595,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/inquirer/node_modules/mute-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+			"integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
 		"node_modules/inquirer/node_modules/ora": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
@@ -12531,12 +12849,12 @@
 			}
 		},
 		"node_modules/mute-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-			"integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+			"integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/napi-build-utils": {
@@ -14298,6 +14616,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
 			"integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -15847,7 +16166,7 @@
 			"version": "6.21.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
 			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/unherit": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 	},
 	"dependencies": {
 		"@aws-sdk/client-lambda": "^3.817.0",
+		"@inquirer/prompts": "^7.5.3",
 		"@smartthings/core-sdk": "^8.4.1",
 		"axios": "1.9.0",
 		"chalk": "^5.4.1",

--- a/src/__tests__/commands/config/reset.test.ts
+++ b/src/__tests__/commands/config/reset.test.ts
@@ -4,7 +4,7 @@ import type { ArgumentsCamelCase, Argv } from 'yargs'
 
 import type { CommandArgs } from '../../../commands/config/reset.js'
 import type { resetManagedConfig } from '../../../lib/cli-config.js'
-import type { askForBoolean } from '../../../lib/user-query.js'
+import type { booleanInput } from '../../../lib/user-query.js'
 import type {
 	SmartThingsCommand,
 	smartThingsCommand,
@@ -19,9 +19,9 @@ jest.unstable_mockModule('../../../lib/cli-config.js', () => ({
 	resetManagedConfig: resetManagedConfigMock,
 }))
 
-const askForBooleanMock = jest.fn<typeof askForBoolean>()
+const booleanInputMock = jest.fn<typeof booleanInput>()
 jest.unstable_mockModule('../../../lib/user-query.js', () => ({
-	askForBoolean: askForBooleanMock,
+	booleanInput: booleanInputMock,
 }))
 
 const smartThingsCommandMock = jest.fn<typeof smartThingsCommand>()
@@ -71,12 +71,12 @@ describe('handler', () => {
 
 	it('resets specified profile', async () => {
 		const [inputArgv, command] = mockSmartThingsCommand('hub1')
-		askForBooleanMock.mockResolvedValueOnce(true)
+		booleanInputMock.mockResolvedValueOnce(true)
 
 		await expect(cmd.handler(inputArgv)).resolves.not.toThrow()
 
 		expect(smartThingsCommandMock).toHaveBeenCalledExactlyOnceWith(inputArgv)
-		expect(askForBooleanMock).toHaveBeenCalledExactlyOnceWith(
+		expect(booleanInputMock).toHaveBeenCalledExactlyOnceWith(
 			expect.stringMatching(/Are you sure .* questions for the profile hub1\?/),
 			{ default: false },
 		)
@@ -86,12 +86,12 @@ describe('handler', () => {
 
 	it('leaves profile name out of message for default profile', async () => {
 		const [inputArgv] = mockSmartThingsCommand('default')
-		askForBooleanMock.mockResolvedValueOnce(true)
+		booleanInputMock.mockResolvedValueOnce(true)
 
 		await expect(cmd.handler(inputArgv)).resolves.not.toThrow()
 
 		expect(smartThingsCommandMock).toHaveBeenCalledExactlyOnceWith(inputArgv)
-		expect(askForBooleanMock).toHaveBeenCalledExactlyOnceWith(
+		expect(booleanInputMock).toHaveBeenCalledExactlyOnceWith(
 			expect.stringMatching(/Are you sure .* questions\?/),
 			{ default: false },
 		)
@@ -99,12 +99,12 @@ describe('handler', () => {
 
 	it('does not reset when canceled', async () => {
 		const [inputArgv] = mockSmartThingsCommand('default')
-		askForBooleanMock.mockResolvedValueOnce(false)
+		booleanInputMock.mockResolvedValueOnce(false)
 
 		await expect(cmd.handler(inputArgv)).resolves.not.toThrow()
 
 		expect(smartThingsCommandMock).toHaveBeenCalledExactlyOnceWith(inputArgv)
-		expect(askForBooleanMock).toHaveBeenCalledExactlyOnceWith(
+		expect(booleanInputMock).toHaveBeenCalledExactlyOnceWith(
 			expect.stringMatching(/Are you sure .* questions\?/),
 			{ default: false },
 		)

--- a/src/__tests__/commands/installedapps/rename.test.ts
+++ b/src/__tests__/commands/installedapps/rename.test.ts
@@ -1,13 +1,13 @@
 import { jest } from '@jest/globals'
 
-import inquirer from 'inquirer'
 import type { ArgumentsCamelCase, Argv } from 'yargs'
 
 import type { InstalledApp, InstalledAppsEndpoint } from '@smartthings/core-sdk'
 
 import type { CommandArgs } from '../../../commands/installedapps/rename.js'
-import type { APICommand } from '../../../lib/command/api-command.js'
 import type { WithNamedLocation } from '../../../lib/api-helpers.js'
+import type { stringInput } from '../../../lib/user-query.js'
+import type { APICommand } from '../../../lib/command/api-command.js'
 import type { formatAndWriteItem, formatAndWriteItemBuilder } from '../../../lib/command/format.js'
 import type { BuildOutputFormatterFlags } from '../.././../lib/command/output-builder.js'
 import type { SmartThingsCommandFlags } from '../../../lib/command/smartthings-command.js'
@@ -18,11 +18,9 @@ import { apiCommandMocks } from '../../test-lib/api-command-mock.js'
 import { buildArgvMock, buildArgvMockStub } from '../../test-lib/builder-mock.js'
 
 
-const promptMock = jest.fn<typeof inquirer.prompt>()
-jest.unstable_mockModule('inquirer', () => ({
-	default: {
-		prompt: promptMock,
-	},
+const stringInputMock = jest.fn<typeof stringInput>()
+jest.unstable_mockModule('../../../lib/user-query.js', () => ({
+	stringInput: stringInputMock,
 }))
 
 const { apiCommandMock, apiCommandBuilderMock } = apiCommandMocks('../../..')
@@ -89,7 +87,7 @@ describe('handler', () => {
 	} as ArgumentsCamelCase<CommandArgs>
 
 	it('prompts user for new name', async () => {
-		promptMock.mockResolvedValueOnce({ newName: 'Prompted New Name' })
+		stringInputMock.mockResolvedValueOnce('Prompted New Name')
 
 		const inputArgv = {
 			...baseInputArgv,
@@ -103,7 +101,7 @@ describe('handler', () => {
 			listOptions: { locationId: ['location-filter'] },
 		})
 		expect(chooseInstalledAppMock).toHaveBeenCalledExactlyOnceWith(command, undefined)
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ type: 'input' }))
+		expect(stringInputMock).toHaveBeenCalledTimes(1)
 		expect(apiInstalledAppsUpdateMock)
 			.toHaveBeenCalledExactlyOnceWith('chosen-installed-app-id', { displayName: 'Prompted New Name' })
 		expect(formatAndWriteItemMock).toHaveBeenCalledExactlyOnceWith(command, { tableFieldDefinitions }, updatedApp)
@@ -126,6 +124,6 @@ describe('handler', () => {
 		expect(apiInstalledAppsUpdateMock)
 			.toHaveBeenCalledExactlyOnceWith('chosen-installed-app-id', { displayName: 'Cmd Line New Name' })
 		expect(formatAndWriteItemMock).toHaveBeenCalledExactlyOnceWith(command, { tableFieldDefinitions }, updatedApp)
-		expect(promptMock).not.toHaveBeenCalled()
+		expect(stringInputMock).not.toHaveBeenCalled()
 	})
 })

--- a/src/__tests__/lib/command/util/hub-drivers.test.ts
+++ b/src/__tests__/lib/command/util/hub-drivers.test.ts
@@ -7,7 +7,7 @@ import type inquirer from 'inquirer'
 import type { Question } from 'inquirer'
 
 import type { DriverInfo } from '../../../../lib/live-logging.js'
-import type { askForBoolean } from '../../../../lib/user-query.js'
+import type { booleanInput } from '../../../../lib/user-query.js'
 import type { fatalError } from '../../../../lib/util.js'
 import { convertToId, stringTranslateToId } from '../../../../lib/command/command-util.js'
 import type { selectFromList } from '../../../../lib/command/select.js'
@@ -31,9 +31,9 @@ jest.unstable_mockModule('inquirer', () => ({
 	},
 }))
 
-const askForBooleanMock = jest.fn<typeof askForBoolean>()
+const booleanInputMock = jest.fn<typeof booleanInput>()
 jest.unstable_mockModule('../../../../lib/user-query.js', () => ({
-	askForBoolean: askForBooleanMock,
+	booleanInput: booleanInputMock,
 }))
 
 const fatalErrorMock = jest.fn<typeof fatalError>().mockReturnValue('never return' as never)
@@ -211,12 +211,12 @@ describe('checkServerIdentity', () => {
 	})
 
 	it('prompts user to confirm new host', async () => {
-		askForBooleanMock.mockResolvedValueOnce(true)
+		booleanInputMock.mockResolvedValueOnce(true)
 
 		await checkServerIdentity(command, 'hub2', hub2Certificate)
 
 		expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringMatching(/The authenticity of .* can't be established./))
-		expect(askForBooleanMock).toHaveBeenCalledExactlyOnceWith(
+		expect(booleanInputMock).toHaveBeenCalledExactlyOnceWith(
 			'Are you sure you want to continue connecting?',
 			{ default : false },
 		)
@@ -230,7 +230,7 @@ describe('checkServerIdentity', () => {
 	})
 
 	it('fails if user rejects host', async () => {
-		askForBooleanMock.mockResolvedValueOnce(false)
+		booleanInputMock.mockResolvedValueOnce(false)
 
 		expect(await checkServerIdentity(command, 'hub2', hub2Certificate)).toBe('never return')
 

--- a/src/__tests__/lib/item-input/command-helpers.test.ts
+++ b/src/__tests__/lib/item-input/command-helpers.test.ts
@@ -5,7 +5,7 @@ import inquirer from 'inquirer'
 import type { Profile } from '../../../lib/cli-config.js'
 import type { red } from '../../../lib/colors.js'
 import type { cancelCommand } from '../../../lib/util.js'
-import type { askForBoolean } from '../../../lib/user-query.js'
+import type { booleanInput } from '../../../lib/user-query.js'
 import {
 	cancelAction,
 	editAction,
@@ -43,9 +43,9 @@ jest.unstable_mockModule('../../../lib/util.js', () => ({
 	cancelCommand: cancelCommandMock,
 }))
 
-const askForBooleanMock = jest.fn<typeof askForBoolean>()
+const booleanInputMock = jest.fn<typeof booleanInput>()
 jest.unstable_mockModule('../../../lib/user-query.js', () => ({
-	askForBoolean: askForBooleanMock,
+	booleanInput: booleanInputMock,
 }))
 
 const jsonOutputFormatterMock = jest.fn<OutputFormatter<SimpleType>>()
@@ -228,7 +228,7 @@ describe('updateFromUserInput', () => {
 
 	it('allows previewing JSON', async () => {
 		promptMock.mockResolvedValueOnce({ action: previewJSONAction })
-		askForBooleanMock.mockResolvedValueOnce(false)
+		booleanInputMock.mockResolvedValueOnce(false)
 		promptMock.mockResolvedValueOnce({ action: finishAction })
 
 		expect(await updateFromUserInput(commandMock, inputDefMock, simpleValue, { dryRun: false }))
@@ -238,7 +238,7 @@ describe('updateFromUserInput', () => {
 		expect(jsonFormatterMock).toHaveBeenCalledExactlyOnceWith(4)
 		expect(jsonOutputFormatterMock).toHaveBeenCalledTimes(1)
 		expect(jsonOutputFormatterMock).toHaveBeenCalledWith(simpleValue)
-		expect(askForBooleanMock).toHaveBeenCalledWith(
+		expect(booleanInputMock).toHaveBeenCalledWith(
 			'formatted JSON\n\nWould you like to edit further?',
 			{ default: false },
 		)
@@ -246,7 +246,7 @@ describe('updateFromUserInput', () => {
 
 	it('allows editing after preview', async () => {
 		promptMock.mockResolvedValueOnce({ action: previewJSONAction })
-		askForBooleanMock.mockResolvedValueOnce(true)
+		booleanInputMock.mockResolvedValueOnce(true)
 		updateFromUserInputMock.mockResolvedValueOnce(updatedValue)
 		promptMock.mockResolvedValueOnce({ action: finishAction })
 
@@ -261,7 +261,7 @@ describe('updateFromUserInput', () => {
 
 	it('sticks to original upon cancelation after editing after preview', async () => {
 		promptMock.mockResolvedValueOnce({ action: previewJSONAction })
-		askForBooleanMock.mockResolvedValueOnce(true)
+		booleanInputMock.mockResolvedValueOnce(true)
 		updateFromUserInputMock.mockResolvedValueOnce(cancelAction)
 		promptMock.mockResolvedValueOnce({ action: finishAction })
 
@@ -276,7 +276,7 @@ describe('updateFromUserInput', () => {
 
 	it('allows previewing YAML', async () => {
 		promptMock.mockResolvedValueOnce({ action: previewYAMLAction })
-		askForBooleanMock.mockResolvedValueOnce(false)
+		booleanInputMock.mockResolvedValueOnce(false)
 		promptMock.mockResolvedValueOnce({ action: finishAction })
 
 		expect(await updateFromUserInput(commandMock, inputDefMock, simpleValue, { dryRun: false }))
@@ -285,7 +285,7 @@ describe('updateFromUserInput', () => {
 		expect(promptMock).toHaveBeenCalledTimes(2)
 		expect(yamlFormatterMock).toHaveBeenCalledExactlyOnceWith(2)
 		expect(yamlOutputFormatterMock).toHaveBeenCalledExactlyOnceWith(simpleValue)
-		expect(askForBooleanMock).toHaveBeenCalledWith(
+		expect(booleanInputMock).toHaveBeenCalledWith(
 			'formatted YAML\n\nWould you like to edit further?',
 			{ default: false },
 		)
@@ -294,7 +294,7 @@ describe('updateFromUserInput', () => {
 	it('accepts indent level from config', async () => {
 		const commandMock = buildCommandMock({}, { indent: 13 })
 		promptMock.mockResolvedValueOnce({ action: previewYAMLAction })
-		askForBooleanMock.mockResolvedValueOnce(false)
+		booleanInputMock.mockResolvedValueOnce(false)
 		promptMock.mockResolvedValueOnce({ action: finishAction })
 
 		expect(await updateFromUserInput(commandMock, inputDefMock, simpleValue, { dryRun: false }))

--- a/src/__tests__/lib/item-input/misc.test.ts
+++ b/src/__tests__/lib/item-input/misc.test.ts
@@ -4,21 +4,21 @@ import inquirer from 'inquirer'
 
 import {
 	cancelOption,
-	DefaultValueFunction,
-	InputDefinition,
-	InputDefinitionValidateFunction,
+	type DefaultValueFunction,
+	type InputDefinition,
+	type InputDefinitionValidateFunction,
 	uneditable,
 } from '../../../lib/item-input/defs.js'
-import {
-	askForBoolean,
-	askForInteger,
-	askForString,
-	askForOptionalInteger,
-	askForOptionalString,
+import type {
+	booleanInput,
+	integerInput,
+	optionalIntegerInput,
+	optionalStringInput,
+	stringInput,
 	ValidateFunction,
 } from '../../../lib/user-query.js'
 import { stringFromUnknown } from '../../../lib/util.js'
-import { ListSelectionDefOptions, OptionalDefPredicateFn } from '../../../lib/item-input/misc.js'
+import type { ListSelectionDefOptions, OptionalDefPredicateFn } from '../../../lib/item-input/misc.js'
 import { buildInputDefMock } from '../../test-lib/input-type-mock.js'
 
 
@@ -29,17 +29,17 @@ jest.unstable_mockModule('inquirer', () => ({
 		Separator: inquirer.Separator,
 	},
 }))
-const askForBooleanMock = jest.fn<typeof askForBoolean>()
-const askForIntegerMock = jest.fn<typeof askForInteger>()
-const askForOptionalIntegerMock = jest.fn<typeof askForOptionalInteger>()
-const askForStringMock = jest.fn<typeof askForString>()
-const askForOptionalStringMock = jest.fn<typeof askForOptionalString>()
+const booleanInputMock = jest.fn<typeof booleanInput>()
+const integerInputMock = jest.fn<typeof integerInput>()
+const optionalIntegerInputMock = jest.fn<typeof optionalIntegerInput>()
+const optionalStringInputMock = jest.fn<typeof optionalStringInput>()
+const stringInputMock = jest.fn<typeof stringInput>()
 jest.unstable_mockModule('../../../lib/user-query.js', () => ({
-	askForBoolean: askForBooleanMock,
-	askForInteger: askForIntegerMock,
-	askForOptionalInteger: askForOptionalIntegerMock,
-	askForString: askForStringMock,
-	askForOptionalString: askForOptionalStringMock,
+	booleanInput: booleanInputMock,
+	integerInput: integerInputMock,
+	optionalIntegerInput: optionalIntegerInputMock,
+	optionalStringInput: optionalStringInputMock,
+	stringInput: stringInputMock,
 }))
 
 
@@ -69,9 +69,9 @@ describe('validateWithContext', () => {
 		['string1'],
 		['string1', 'string2'],
 	])('passes specified context, %s, to new validation function', (context) => {
-		const validate = jest.fn<ValidateFunction>()
+		const validate = jest.fn<ValidateFunction<string>>()
 		validate.mockReturnValue('validation result')
-		const withContext = validateWithContextFn(validate, context) as ValidateFunction
+		const withContext = validateWithContextFn(validate, context) as ValidateFunction<string>
 
 		expect(withContext).toBeDefined()
 		expect(withContext('input string')).toBe('validation result')
@@ -112,12 +112,12 @@ describe('optionalStringDef', () => {
 		})
 
 		test('build', async () => {
-			askForOptionalStringMock.mockResolvedValueOnce('user input')
+			optionalStringInputMock.mockResolvedValueOnce('user input')
 
 			expect(await def.buildFromUserInput()).toBe('user input')
 
-			expect(askForOptionalStringMock).toHaveBeenCalledTimes(1)
-			expect(askForOptionalStringMock).toHaveBeenCalledWith('String Def (optional)',
+			expect(optionalStringInputMock).toHaveBeenCalledTimes(1)
+			expect(optionalStringInputMock).toHaveBeenCalledWith('String Def (optional)',
 				{ validate: undefined })
 		})
 
@@ -126,31 +126,31 @@ describe('optionalStringDef', () => {
 		})
 
 		test('update', async () => {
-			askForOptionalStringMock.mockResolvedValueOnce('updated')
+			optionalStringInputMock.mockResolvedValueOnce('updated')
 
 			expect(await def.updateFromUserInput('original')).toBe('updated')
 
-			expect(askForOptionalStringMock).toHaveBeenCalledTimes(1)
-			expect(askForOptionalStringMock).toHaveBeenCalledWith('String Def (optional)',
+			expect(optionalStringInputMock).toHaveBeenCalledTimes(1)
+			expect(optionalStringInputMock).toHaveBeenCalledWith('String Def (optional)',
 				{ default: 'original', validate: undefined })
 		})
 	})
 
 	describe('with validation', () => {
-		const validateMock = jest.fn<InputDefinitionValidateFunction>()
+		const validateMock = jest.fn<InputDefinitionValidateFunction<string>>()
 		const def = optionalStringDef('String Def', { validate: validateMock })
 
 		test('build', async () => {
 			const context = ['context item']
-			askForOptionalStringMock.mockResolvedValueOnce('user input')
+			optionalStringInputMock.mockResolvedValueOnce('user input')
 
 			expect(await def.buildFromUserInput(context)).toBe('user input')
 
-			expect(askForOptionalStringMock).toHaveBeenCalledTimes(1)
-			expect(askForOptionalStringMock).toHaveBeenCalledWith('String Def (optional)',
+			expect(optionalStringInputMock).toHaveBeenCalledTimes(1)
+			expect(optionalStringInputMock).toHaveBeenCalledWith('String Def (optional)',
 				{ validate: expect.any(Function) })
 
-			const validateFn = askForOptionalStringMock.mock.calls[0][1]?.validate as ValidateFunction
+			const validateFn = optionalStringInputMock.mock.calls[0][1]?.validate as ValidateFunction<string>
 			validateMock.mockReturnValueOnce('validation answer')
 			expect(validateFn('input string')).toBe('validation answer')
 			expect(validateMock).toHaveBeenCalledTimes(1)
@@ -159,15 +159,15 @@ describe('optionalStringDef', () => {
 
 		test('update', async () => {
 			const context = ['context item']
-			askForOptionalStringMock.mockResolvedValueOnce('updated')
+			optionalStringInputMock.mockResolvedValueOnce('updated')
 
 			expect(await def.updateFromUserInput('original', context)).toBe('updated')
 
-			expect(askForOptionalStringMock).toHaveBeenCalledTimes(1)
-			expect(askForOptionalStringMock).toHaveBeenCalledWith('String Def (optional)',
+			expect(optionalStringInputMock).toHaveBeenCalledTimes(1)
+			expect(optionalStringInputMock).toHaveBeenCalledWith('String Def (optional)',
 				{ default: 'original', validate: expect.any(Function) })
 
-			const validateFn = askForOptionalStringMock.mock.calls[0][1]?.validate as ValidateFunction
+			const validateFn = optionalStringInputMock.mock.calls[0][1]?.validate as ValidateFunction<string>
 			validateMock.mockReturnValueOnce('validation answer')
 			expect(validateFn('input string')).toBe('validation answer')
 			expect(validateMock).toHaveBeenCalledTimes(1)
@@ -185,12 +185,12 @@ describe('stringDef', () => {
 		})
 
 		test('build', async () => {
-			askForStringMock.mockResolvedValueOnce('user input')
+			stringInputMock.mockResolvedValueOnce('user input')
 
 			expect(await def.buildFromUserInput()).toBe('user input')
 
-			expect(askForStringMock).toHaveBeenCalledTimes(1)
-			expect(askForStringMock).toHaveBeenCalledWith('String Def', { validate: undefined })
+			expect(stringInputMock).toHaveBeenCalledTimes(1)
+			expect(stringInputMock).toHaveBeenCalledWith('String Def', { validate: undefined })
 		})
 
 		test('summarize', async () => {
@@ -198,30 +198,30 @@ describe('stringDef', () => {
 		})
 
 		test('update', async () => {
-			askForStringMock.mockResolvedValueOnce('updated')
+			stringInputMock.mockResolvedValueOnce('updated')
 
 			expect(await def.updateFromUserInput('original')).toBe('updated')
 
-			expect(askForStringMock).toHaveBeenCalledTimes(1)
-			expect(askForStringMock).toHaveBeenCalledWith('String Def', { default: 'original' })
+			expect(stringInputMock).toHaveBeenCalledTimes(1)
+			expect(stringInputMock).toHaveBeenCalledWith('String Def', { default: 'original' })
 		})
 	})
 
 	describe('with validation', () => {
-		const validateMock = jest.fn<InputDefinitionValidateFunction>()
+		const validateMock = jest.fn<InputDefinitionValidateFunction<string>>()
 		const def = stringDef('String Def', { validate: validateMock })
 
 		test('build', async () => {
 			const context = ['context item']
-			askForStringMock.mockResolvedValueOnce('user input')
+			stringInputMock.mockResolvedValueOnce('user input')
 
 			expect(await def.buildFromUserInput(context)).toBe('user input')
 
-			expect(askForStringMock).toHaveBeenCalledTimes(1)
-			expect(askForStringMock).toHaveBeenCalledWith('String Def',
+			expect(stringInputMock).toHaveBeenCalledTimes(1)
+			expect(stringInputMock).toHaveBeenCalledWith('String Def',
 				{ validate: expect.any(Function) })
 
-			const validateFn = askForStringMock.mock.calls[0][1]?.validate as ValidateFunction
+			const validateFn = stringInputMock.mock.calls[0][1]?.validate as ValidateFunction<string>
 			validateMock.mockReturnValueOnce('validation answer')
 			expect(validateFn('input string')).toBe('validation answer')
 			expect(validateMock).toHaveBeenCalledTimes(1)
@@ -230,15 +230,15 @@ describe('stringDef', () => {
 
 		test('update', async () => {
 			const context = ['context item']
-			askForStringMock.mockResolvedValueOnce('updated')
+			stringInputMock.mockResolvedValueOnce('updated')
 
 			expect(await def.updateFromUserInput('original', context)).toBe('updated')
 
-			expect(askForStringMock).toHaveBeenCalledTimes(1)
-			expect(askForStringMock).toHaveBeenCalledWith('String Def',
+			expect(stringInputMock).toHaveBeenCalledTimes(1)
+			expect(stringInputMock).toHaveBeenCalledWith('String Def',
 				{ default: 'original', validate: expect.any(Function) })
 
-			const validateFn = askForStringMock.mock.calls[0][1]?.validate as ValidateFunction
+			const validateFn = stringInputMock.mock.calls[0][1]?.validate as ValidateFunction<string>
 			validateMock.mockReturnValueOnce('validation answer')
 			expect(validateFn('input string')).toBe('validation answer')
 			expect(validateMock).toHaveBeenCalledTimes(1)
@@ -256,12 +256,12 @@ describe('optionalIntegerDef', () => {
 		})
 
 		test('build', async () => {
-			askForOptionalIntegerMock.mockResolvedValueOnce(17)
+			optionalIntegerInputMock.mockResolvedValueOnce(17)
 
 			expect(await def.buildFromUserInput()).toBe(17)
 
-			expect(askForOptionalIntegerMock).toHaveBeenCalledTimes(1)
-			expect(askForOptionalIntegerMock).toHaveBeenCalledWith('Integer Def (optional)',
+			expect(optionalIntegerInputMock).toHaveBeenCalledTimes(1)
+			expect(optionalIntegerInputMock).toHaveBeenCalledWith('Integer Def (optional)',
 				{ validate: undefined })
 		})
 
@@ -270,52 +270,53 @@ describe('optionalIntegerDef', () => {
 		})
 
 		test('update', async () => {
-			askForOptionalIntegerMock.mockResolvedValueOnce(13)
+			optionalIntegerInputMock.mockResolvedValueOnce(13)
 
 			expect(await def.updateFromUserInput(12)).toBe(13)
 
-			expect(askForOptionalIntegerMock).toHaveBeenCalledTimes(1)
-			expect(askForOptionalIntegerMock).toHaveBeenCalledWith('Integer Def (optional)',
+			expect(optionalIntegerInputMock).toHaveBeenCalledTimes(1)
+			expect(optionalIntegerInputMock).toHaveBeenCalledWith('Integer Def (optional)',
 				{ default: 12, validate: undefined })
 		})
 	})
 
 	describe('with validation', () => {
-		const validateMock = jest.fn<InputDefinitionValidateFunction>()
+		const validateMock = jest.fn<InputDefinitionValidateFunction<number | undefined>>()
 		const def = optionalIntegerDef('Integer Def', { validate: validateMock })
 
 		test('build', async () => {
 			const context = ['context item']
-			askForOptionalIntegerMock.mockResolvedValueOnce(11)
+			optionalIntegerInputMock.mockResolvedValueOnce(11)
 
 			expect(await def.buildFromUserInput(context)).toBe(11)
 
-			expect(askForOptionalIntegerMock).toHaveBeenCalledTimes(1)
-			expect(askForOptionalIntegerMock).toHaveBeenCalledWith('Integer Def (optional)',
+			expect(optionalIntegerInputMock).toHaveBeenCalledTimes(1)
+			expect(optionalIntegerInputMock).toHaveBeenCalledWith('Integer Def (optional)',
 				{ validate: expect.any(Function) })
 
-			const validateFn = askForOptionalIntegerMock.mock.calls[0][1]?.validate as ValidateFunction
+			const validateFn = optionalIntegerInputMock.mock.calls[0][1]?.validate as
+				ValidateFunction<number | undefined>
 			validateMock.mockReturnValueOnce('validation answer')
-			expect(validateFn('input string')).toBe('validation answer')
+			expect(validateFn(444)).toBe('validation answer')
 			expect(validateMock).toHaveBeenCalledTimes(1)
-			expect(validateMock).toHaveBeenCalledWith('input string', context)
+			expect(validateMock).toHaveBeenCalledWith(444, context)
 		})
 
 		test('update', async () => {
 			const context = ['context item']
-			askForOptionalIntegerMock.mockResolvedValueOnce(13)
+			optionalIntegerInputMock.mockResolvedValueOnce(13)
 
 			expect(await def.updateFromUserInput(12, context)).toBe(13)
 
-			expect(askForOptionalIntegerMock).toHaveBeenCalledTimes(1)
-			expect(askForOptionalIntegerMock).toHaveBeenCalledWith('Integer Def (optional)',
+			expect(optionalIntegerInputMock).toHaveBeenCalledTimes(1)
+			expect(optionalIntegerInputMock).toHaveBeenCalledWith('Integer Def (optional)',
 				{ default: 12, validate: expect.any(Function) })
 
-			const validateFn = askForOptionalIntegerMock.mock.calls[0][1]?.validate as ValidateFunction
+			const validateFn = optionalIntegerInputMock.mock.calls[0][1]?.validate as ValidateFunction<number | undefined>
 			validateMock.mockReturnValueOnce('validation answer')
-			expect(validateFn('input string')).toBe('validation answer')
+			expect(validateFn(22)).toBe('validation answer')
 			expect(validateMock).toHaveBeenCalledTimes(1)
-			expect(validateMock).toHaveBeenCalledWith('input string', context)
+			expect(validateMock).toHaveBeenCalledWith(22, context)
 		})
 	})
 })
@@ -329,12 +330,12 @@ describe('integerDef', () => {
 		})
 
 		test('build', async () => {
-			askForIntegerMock.mockResolvedValueOnce(11)
+			integerInputMock.mockResolvedValueOnce(11)
 
 			expect(await def.buildFromUserInput()).toBe(11)
 
-			expect(askForIntegerMock).toHaveBeenCalledTimes(1)
-			expect(askForIntegerMock).toHaveBeenCalledWith('Integer Def', { validate: undefined })
+			expect(integerInputMock).toHaveBeenCalledTimes(1)
+			expect(integerInputMock).toHaveBeenCalledWith('Integer Def', { validate: undefined })
 		})
 
 		test('summarize', async () => {
@@ -342,51 +343,51 @@ describe('integerDef', () => {
 		})
 
 		test('update', async () => {
-			askForIntegerMock.mockResolvedValueOnce(13)
+			integerInputMock.mockResolvedValueOnce(13)
 
 			expect(await def.updateFromUserInput(12)).toBe(13)
 
-			expect(askForIntegerMock).toHaveBeenCalledTimes(1)
-			expect(askForIntegerMock).toHaveBeenCalledWith('Integer Def', { default: 12 })
+			expect(integerInputMock).toHaveBeenCalledTimes(1)
+			expect(integerInputMock).toHaveBeenCalledWith('Integer Def', { default: 12 })
 		})
 	})
 
 	describe('with validation', () => {
-		const validateMock = jest.fn<InputDefinitionValidateFunction>()
+		const validateMock = jest.fn<InputDefinitionValidateFunction<number | undefined>>()
 		const def = integerDef('Integer Def', { validate: validateMock })
 
 		test('build', async () => {
 			const context = ['context item']
-			askForIntegerMock.mockResolvedValueOnce(17)
+			integerInputMock.mockResolvedValueOnce(17)
 
 			expect(await def.buildFromUserInput(context)).toBe(17)
 
-			expect(askForIntegerMock).toHaveBeenCalledTimes(1)
-			expect(askForIntegerMock).toHaveBeenCalledWith('Integer Def',
+			expect(integerInputMock).toHaveBeenCalledTimes(1)
+			expect(integerInputMock).toHaveBeenCalledWith('Integer Def',
 				{ validate: expect.any(Function) })
 
-			const validateFn = askForIntegerMock.mock.calls[0][1]?.validate as ValidateFunction
+			const validateFn = integerInputMock.mock.calls[0][1]?.validate as ValidateFunction<number | undefined>
 			validateMock.mockReturnValueOnce('validation answer')
-			expect(validateFn('input string')).toBe('validation answer')
+			expect(validateFn(7)).toBe('validation answer')
 			expect(validateMock).toHaveBeenCalledTimes(1)
-			expect(validateMock).toHaveBeenCalledWith('input string', context)
+			expect(validateMock).toHaveBeenCalledWith(7, context)
 		})
 
 		test('update', async () => {
 			const context = ['context item']
-			askForIntegerMock.mockResolvedValueOnce(19)
+			integerInputMock.mockResolvedValueOnce(19)
 
 			expect(await def.updateFromUserInput(18, context)).toBe(19)
 
-			expect(askForIntegerMock).toHaveBeenCalledTimes(1)
-			expect(askForIntegerMock).toHaveBeenCalledWith('Integer Def',
+			expect(integerInputMock).toHaveBeenCalledTimes(1)
+			expect(integerInputMock).toHaveBeenCalledWith('Integer Def',
 				{ default: 18, validate: expect.any(Function) })
 
-			const validateFn = askForIntegerMock.mock.calls[0][1]?.validate as ValidateFunction
+			const validateFn = integerInputMock.mock.calls[0][1]?.validate as ValidateFunction<number | undefined>
 			validateMock.mockReturnValueOnce('validation answer')
-			expect(validateFn('input string')).toBe('validation answer')
+			expect(validateFn(65536)).toBe('validation answer')
 			expect(validateMock).toHaveBeenCalledTimes(1)
-			expect(validateMock).toHaveBeenCalledWith('input string', context)
+			expect(validateMock).toHaveBeenCalledWith(65536, context)
 		})
 	})
 })
@@ -399,12 +400,12 @@ describe('booleanDef', () => {
 	})
 
 	test('build', async () => {
-		askForBooleanMock.mockResolvedValueOnce(false)
+		booleanInputMock.mockResolvedValueOnce(false)
 
 		expect(await def.buildFromUserInput()).toBe(false)
 
-		expect(askForBooleanMock).toHaveBeenCalledTimes(1)
-		expect(askForBooleanMock).toHaveBeenCalledWith('Boolean Def', undefined)
+		expect(booleanInputMock).toHaveBeenCalledTimes(1)
+		expect(booleanInputMock).toHaveBeenCalledWith('Boolean Def', undefined)
 	})
 
 	test('summarize', async () => {
@@ -413,12 +414,12 @@ describe('booleanDef', () => {
 	})
 
 	test('update', async () => {
-		askForBooleanMock.mockResolvedValueOnce(false)
+		booleanInputMock.mockResolvedValueOnce(false)
 
 		expect(await def.updateFromUserInput(true)).toBe(false)
 
-		expect(askForBooleanMock).toHaveBeenCalledTimes(1)
-		expect(askForBooleanMock).toHaveBeenCalledWith('Boolean Def', { default: true })
+		expect(booleanInputMock).toHaveBeenCalledTimes(1)
+		expect(booleanInputMock).toHaveBeenCalledWith('Boolean Def', { default: true })
 	})
 })
 

--- a/src/__tests__/lib/user-query.test.ts
+++ b/src/__tests__/lib/user-query.test.ts
@@ -1,162 +1,127 @@
 import { jest } from '@jest/globals'
 
-import type inquirer from 'inquirer'
+import type { confirm, input } from '@inquirer/prompts'
 
 import type { ValidateFunction } from '../../lib/user-query.js'
 import type { DefaultValueFunction } from '../../lib/item-input/defs.js'
 
 
-const promptMock = jest.fn<typeof inquirer.prompt>()
-jest.unstable_mockModule('inquirer', () => ({
-	default: {
-		prompt: promptMock,
-	},
+const confirmMock = jest.fn<typeof confirm>()
+const inputMock = jest.fn<typeof input>().mockResolvedValue('')
+jest.unstable_mockModule('@inquirer/prompts', () => ({
+	confirm: confirmMock,
+	input: inputMock,
 }))
 
 const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => { /*no-op*/ })
 
 
 const {
-	askForBoolean,
-	askForInteger,
-	askForNumber,
-	askForOptionalInteger,
-	askForString,
-	askForOptionalString,
-	numberTransformer,
+	booleanInput,
+	displayNoneForEmpty,
+	integerInput,
+	optionalIntegerInput,
+	optionalNumberInput,
+	optionalStringInput,
+	stringInput,
 } = await import('../../lib/user-query.js')
 
 
-describe('numberTransformer', () => {
-	it.each(['', 'input value', '7'])('returns input value unchanged when not final', value => {
-		expect(numberTransformer(value, { value }, { isFinal: false })).toBe(value)
+
+describe('displayNoneForEmpty', () => {
+	it.each(['', 'input value', '7'])('returns input value %s unchanged when not final', value => {
+		expect(displayNoneForEmpty(value, { isFinal: false })).toBe(value)
 	})
 
-	it.each(['input value', '7'])('returns input value unchanged when not empty', value => {
-		expect(numberTransformer(value, { value }, { isFinal: true })).toBe(value)
+	it.each(['input value', '7'])('returns input value %s unchanged when final', value => {
+		expect(displayNoneForEmpty(value, { isFinal: true })).toBe(value)
 	})
 
 	it('returns "none" when isFinal and input value is empty', () => {
-		expect(numberTransformer('', { value: '' }, { isFinal: true })).toBe('none')
+		expect(displayNoneForEmpty('', { isFinal: true })).toBe('none')
 	})
 })
 
-describe('askForOptionalString', () => {
+describe('optionalStringInput', () => {
 	it('asks user correct question', async () => {
-		promptMock.mockResolvedValue({ value: 'entered value' })
+		inputMock.mockResolvedValueOnce('entered value')
 
-		expect(await askForOptionalString('prompt message')).toBe('entered value')
+		expect(await optionalStringInput('prompt message')).toBe('entered value')
 
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith({
-			type: 'input',
-			name: 'value',
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith({
 			message: 'prompt message',
+			required: false,
 		})
 	})
 
 	it('returns nothing entered as undefined', async () => {
-		promptMock.mockResolvedValue({ value: '' })
+		expect(await optionalStringInput('prompt message')).toBe(undefined)
 
-		expect(await askForOptionalString('prompt message')).toBe(undefined)
-
-		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(inputMock).toHaveBeenCalledTimes(1)
 	})
 
 	it('passes validate to inquirer', async () => {
-		promptMock.mockResolvedValue({ value: '' })
+		const validateMock = jest.fn<ValidateFunction<string>>().mockReturnValueOnce(true)
 
-		const validateMock = jest.fn<ValidateFunction>().mockReturnValueOnce(true)
+		expect(await optionalStringInput('prompt message', { validate: validateMock })).toBe(undefined)
 
-		expect(await askForOptionalString('prompt message', { validate: validateMock }))
-			.toBe(undefined)
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ validate: expect.any(Function) }))
 
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
-			validate: expect.any(Function),
-		}))
-
-		const generatedValidate = (promptMock.mock.calls[0][0] as { validate: ValidateFunction })
-			.validate
+		const generatedValidate = (inputMock.mock.calls[0][0] as { validate: ValidateFunction<string> }).validate
 		expect(generatedValidate('input string')).toBe(true)
 		expect(validateMock).toHaveBeenCalledExactlyOnceWith('input string')
 	})
 
 	it('does not include validate when there is none', async () => {
-		promptMock.mockResolvedValue({ value: '' })
+		expect(await optionalStringInput('prompt message', { validate: undefined })).toBe(undefined)
 
-		expect(await askForOptionalString('prompt message', { validate: undefined }))
-			.toBe(undefined)
-
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith(expect.not.objectContaining({
-			validate: undefined,
-		}))
-	})
-
-	it('does not include validate when there is none', async () => {
-		promptMock.mockResolvedValue({ value: '' })
-
-		expect(await askForOptionalString('prompt message', { validate: undefined })).toBe(undefined)
-
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith(expect.not.objectContaining({
-			validate: undefined,
-		}))
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ validate: undefined }))
 	})
 
 	it('passes default to inquirer', async () => {
-		promptMock.mockResolvedValue({ value: '' })
+		expect(await optionalStringInput('prompt message', { default: 'default value' })).toBe(undefined)
 
-		expect(await askForOptionalString('prompt message', { default: 'default value' }))
-			.toBe(undefined)
-
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
-			default: 'default value',
-		}))
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ default: 'default value' }))
 	})
 
 	it('calls default function to get default', async () => {
 		const defaultMock = jest.fn<DefaultValueFunction<string>>()
 			.mockReturnValueOnce('calculated default')
-		promptMock.mockResolvedValue({ value: 'entered value' })
+		inputMock.mockResolvedValueOnce('entered value')
 
-		expect(await askForOptionalString('prompt message', { default: defaultMock }))
-			.toBe('entered value')
+		expect(await optionalStringInput('prompt message', { default: defaultMock })).toBe('entered value')
 
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
-			default: 'calculated default',
-		}))
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ default: 'calculated default' }))
 		expect(defaultMock).toHaveBeenCalledExactlyOnceWith()
 	})
 
 	it('displays help text when "?" entered', async () => {
-		promptMock.mockResolvedValueOnce({ value: '?' })
-		promptMock.mockResolvedValueOnce({ value: 'entered value' })
+		inputMock.mockResolvedValueOnce('?')
+		inputMock.mockResolvedValueOnce('entered value')
 
-		expect(await askForOptionalString('prompt message', { helpText: 'help text' }))
-			.toBe('entered value')
+		expect(await optionalStringInput('prompt message', { helpText: 'help text' })).toBe('entered value')
 
-		expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
-			message: 'prompt message (? for help)',
-		}))
+		expect(inputMock).toHaveBeenCalledWith(expect.objectContaining({ message: 'prompt message (? for help)' }))
 		expect(consoleLogSpy).toHaveBeenLastCalledWith('help text')
 	})
 
 	it('allows "?" even with custom validate function', async () => {
-		const validateMock = jest.fn<ValidateFunction>().mockReturnValue(true)
-		promptMock.mockResolvedValueOnce({ value: '?' })
-		promptMock.mockResolvedValueOnce({ value: 'entered value' })
+		const validateMock = jest.fn<ValidateFunction<string>>().mockReturnValue(true)
+		inputMock.mockResolvedValueOnce('?')
+		inputMock.mockResolvedValueOnce('entered value')
 
-		expect(await askForOptionalString(
+		expect(await optionalStringInput(
 			'prompt message',
 			{ helpText: 'help text', validate: validateMock },
 		)).toBe('entered value')
 
-		expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
+		expect(inputMock).toHaveBeenCalledWith(expect.objectContaining({
 			message: 'prompt message (? for help)',
 			validate: expect.any(Function),
 		}))
 		expect(consoleLogSpy).toHaveBeenLastCalledWith('help text')
 
-		const generatedValidate = (promptMock.mock.calls[0][0] as { validate: ValidateFunction })
-			.validate
+		const generatedValidate = (inputMock.mock.calls[0][0] as { validate: ValidateFunction<string> }).validate
 		expect(generatedValidate('?')).toBeTrue()
 		expect(validateMock).toHaveBeenCalledTimes(0)
 
@@ -166,335 +131,321 @@ describe('askForOptionalString', () => {
 	})
 })
 
-describe('askForString', () => {
+describe('stringInput', () => {
 	it('requires input', async () => {
-		promptMock.mockResolvedValue({ value: 'entered value' })
+		inputMock.mockResolvedValueOnce('entered value')
 
-		expect(await askForString('prompt message')).toBe('entered value')
+		expect(await stringInput('prompt message')).toBe('entered value')
 
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
-			validate: expect.any(Function),
-		}))
-
-		const validateFunction = (promptMock.mock.calls[0][0] as { validate: ValidateFunction })
-			.validate
-
-		expect(validateFunction('')).toBe('value is required')
-		expect(validateFunction('a')).toBe(true)
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ required: true }))
 	})
 
 	it('incorporates supplied validation', async () => {
-		promptMock.mockResolvedValue({ value: 'entered value' })
+		inputMock.mockResolvedValueOnce('entered value')
 
-		const validateMock = jest.fn<ValidateFunction>()
+		const validateMock = jest.fn<ValidateFunction<string>>()
 
-		expect(await askForString('prompt message', { validate: validateMock }))
+		expect(await stringInput('prompt message', { validate: validateMock }))
 			.toBe('entered value')
 
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith({
-			type: 'input',
-			name: 'value',
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith({
 			message: 'prompt message',
+			required: true,
 			validate: expect.any(Function),
 		})
 
-		const validateFunction = (promptMock.mock.calls[0][0] as { validate: ValidateFunction })
-			.validate
+		const validateFunction = (inputMock.mock.calls[0][0] as { validate: ValidateFunction<string> }).validate
 
 		validateMock.mockReturnValue(true)
-
-		expect(validateFunction('')).toBe('value is required')
-		expect(validateMock).toHaveBeenCalledTimes(0)
 
 		expect(validateFunction('a')).toBe(true)
 		expect(validateMock).toHaveBeenCalledExactlyOnceWith('a')
 	})
 })
 
-describe('askForOptionalInteger', () => {
+describe('optionalIntegerInput', () => {
+	const getValidateFunction = async (): Promise<ValidateFunction<string>> => {
+		await optionalIntegerInput('prompt message')
+		return (inputMock.mock.calls[0][0] as { validate: ValidateFunction<string> }).validate
+	}
+
 	it('asks user correct question', async () => {
-		promptMock.mockResolvedValue({ value: '5' })
+		inputMock.mockResolvedValueOnce('5')
 
-		expect(await askForOptionalInteger('prompt message')).toBe(5)
+		expect(await optionalIntegerInput('prompt message')).toBe(5)
 
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith({
-			type: 'input',
-			name: 'value',
-			message: 'prompt message',
-			transformer: numberTransformer,
-		})
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ message: 'prompt message' }))
 	})
 
 	it('returns nothing entered as undefined', async () => {
-		promptMock.mockResolvedValue({ value: '' })
+		expect(await optionalIntegerInput('prompt message')).toBe(undefined)
 
-		expect(await askForOptionalInteger('prompt message')).toBe(undefined)
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ required: false }))
 
-		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(inputMock).toHaveBeenCalledTimes(1)
 	})
 
 	it('returns "0" entered as 0', async () => {
-		promptMock.mockResolvedValue({ value: '0' })
+		inputMock.mockResolvedValueOnce('0')
 
-		expect(await askForOptionalInteger('prompt message')).toBe(0)
+		expect(await optionalIntegerInput('prompt message')).toBe(0)
 
-		expect(promptMock).toHaveBeenCalledTimes(1)
+		expect(inputMock).toHaveBeenCalledTimes(1)
 	})
 
 	it('passes validate to inquirer', async () => {
-		promptMock.mockResolvedValue({ value: '' })
+		const validateMock = jest.fn<ValidateFunction<number | undefined>>().mockReturnValueOnce(true)
 
-		const validateMock = jest.fn<ValidateFunction>().mockReturnValueOnce(true)
+		expect(await optionalIntegerInput('prompt message', { validate: validateMock })).toBe(undefined)
 
-		expect(await askForOptionalInteger('prompt message', { validate: validateMock }))
-			.toBe(undefined)
-
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
 			validate: expect.any(Function),
 		}))
 
-		const generatedValidate = (promptMock.mock.calls[0][0] as { validate: ValidateFunction })
-			.validate
-		expect(generatedValidate('input string')).toBe(true)
-		expect(validateMock).toHaveBeenCalledExactlyOnceWith('input string')
+		const generatedValidate = (inputMock.mock.calls[0][0] as { validate: ValidateFunction<string> }).validate
+		expect(generatedValidate('13')).toBe(true)
+		expect(validateMock).toHaveBeenCalledExactlyOnceWith(13)
 	})
 
-	it('does not include validate when there is none', async () => {
-		promptMock.mockResolvedValue({ value: '' })
-
-		expect(await askForOptionalInteger('prompt message', { validate: undefined }))
-			.toBe(undefined)
-
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith(expect.not.objectContaining({
-			validate: undefined,
-		}))
+	it('reports an empty string as valid', async () => {
+		const generatedValidate = await getValidateFunction()
+		expect(generatedValidate('')).toBe(true)
 	})
 
-	it('does not include validate when there is none', async () => {
-		promptMock.mockResolvedValue({ value: '' })
+	it.each(['0', '7', '21553992'])(
+		'reports %s as valid',
+		async value => {
+			const generatedValidate = await getValidateFunction()
+			expect(generatedValidate(value)).toBe(true)
+		},
+	)
 
-		expect(await askForOptionalInteger('prompt message', { validate: undefined })).toBe(undefined)
-
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith(expect.not.objectContaining({
-			validate: undefined,
-		}))
+	it.each(['-5.5', 'abc', 'PI', '0.3', '3.0', 'twelve', '1/3', '7i + 3'])('reports %s as invalid', async value => {
+		const generatedValidate = await getValidateFunction()
+		expect(generatedValidate(value)).toBe(`"${value}" is not a valid integer`)
 	})
 
 	it('passes default to inquirer', async () => {
-		promptMock.mockResolvedValue({ value: '5' })
+		inputMock.mockResolvedValueOnce('5')
 
-		expect(await askForOptionalInteger('prompt message', { default: 5 })).toBe(5)
+		expect(await optionalIntegerInput('prompt message', { default: 5 })).toBe(5)
 
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
-			default: 5,
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+			default: '5',
 		}))
 	})
 
 	it('calls default function to get default', async () => {
+		inputMock.mockResolvedValueOnce('72')
 		const defaultMock = jest.fn<DefaultValueFunction<number>>().mockReturnValueOnce(27)
-		promptMock.mockResolvedValue({ value: '72' })
 
-		expect(await askForOptionalInteger('prompt message', { default: defaultMock })).toBe(72)
+		expect(await optionalIntegerInput('prompt message', { default: defaultMock })).toBe(72)
 
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
-			default: 27,
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+			default: '27',
 		}))
 		expect(defaultMock).toHaveBeenCalledExactlyOnceWith()
 	})
 
 	it('displays help text when "?" entered', async () => {
-		promptMock.mockResolvedValueOnce({ value: '?' })
-		promptMock.mockResolvedValueOnce({ value: '13' })
+		inputMock.mockResolvedValueOnce('?')
+		inputMock.mockResolvedValueOnce('13')
 
-		expect(await askForOptionalInteger('prompt message', { helpText: 'help text' })).toBe(13)
+		expect(await optionalIntegerInput('prompt message', { helpText: 'help text' })).toBe(13)
 
-		expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
+		expect(inputMock).toHaveBeenCalledWith(expect.objectContaining({
 			message: 'prompt message (? for help)',
 		}))
 		expect(consoleLogSpy).toHaveBeenLastCalledWith('help text')
 	})
 
 	it('allows "?" even with custom validate function', async () => {
-		const validateMock = jest.fn<ValidateFunction>().mockReturnValue(true)
-		promptMock.mockResolvedValueOnce({ value: '?' })
-		promptMock.mockResolvedValueOnce({ value: 32 })
+		const validateMock = jest.fn<ValidateFunction<number | undefined>>().mockReturnValue(true)
+		inputMock.mockResolvedValueOnce('?')
+		inputMock.mockResolvedValueOnce('32')
 
-		expect(await askForOptionalInteger(
+		expect(await optionalIntegerInput(
 			'prompt message',
 			{ helpText: 'help text', validate: validateMock },
 		)).toBe(32)
 
-		expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
+		expect(inputMock).toHaveBeenCalledWith(expect.objectContaining({
 			message: 'prompt message (? for help)',
 			validate: expect.any(Function),
 		}))
 		expect(consoleLogSpy).toHaveBeenLastCalledWith('help text')
 
-		const generatedValidate = (promptMock.mock.calls[0][0] as { validate: ValidateFunction })
-			.validate
+		const generatedValidate = (inputMock.mock.calls[0][0] as { validate: ValidateFunction<string> }).validate
 		expect(generatedValidate('?')).toBeTrue()
 		expect(validateMock).toHaveBeenCalledTimes(0)
-
-		validateMock.mockReturnValueOnce('please enter better input')
-		expect(generatedValidate('bad input')).toBe('please enter better input')
-		expect(validateMock).toHaveBeenCalledExactlyOnceWith('bad input')
 	})
 })
 
-describe('askForInteger', () => {
+describe('integerInput', () => {
 	it('requires input', async () => {
-		promptMock.mockResolvedValue({ value: '43' })
+		inputMock.mockResolvedValueOnce('43')
 
-		expect(await askForInteger('prompt message')).toBe(43)
+		expect(await integerInput('prompt message')).toBe(43)
 
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
-			validate: expect.any(Function),
-		}))
-
-		const validateFunction = (promptMock.mock.calls[0][0] as { validate: ValidateFunction })
-			.validate
-
-		expect(validateFunction('')).toBe('value is required')
-		expect(validateFunction('a')).toBe(true)
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ required: true }))
 	})
 
 	it('incorporates supplied validation', async () => {
-		promptMock.mockResolvedValue({ value: '7' })
+		inputMock.mockResolvedValueOnce('7')
 
-		const validateMock = jest.fn<ValidateFunction>()
+		const validateMock = jest.fn<ValidateFunction<number | undefined>>()
 
-		expect(await askForInteger('prompt message', { validate: validateMock })).toBe(7)
+		expect(await integerInput('prompt message', { validate: validateMock })).toBe(7)
 
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
 			validate: expect.any(Function),
 		}))
 
-		const validateFunction = (promptMock.mock.calls[0][0] as { validate: ValidateFunction })
-			.validate
+		const generatedValidate = (inputMock.mock.calls[0][0] as { validate: ValidateFunction<string> }).validate
 
 		validateMock.mockReturnValue(true)
 
-		expect(validateFunction('')).toBe('value is required')
-		expect(validateMock).toHaveBeenCalledTimes(0)
-
-		expect(validateFunction('a')).toBe(true)
-		expect(validateMock).toHaveBeenCalledExactlyOnceWith('a')
+		expect(generatedValidate('77')).toBe(true)
+		expect(validateMock).toHaveBeenCalledExactlyOnceWith(77)
 	})
 })
 
-describe('askForNumber', () => {
-	it.each`
-		input         | expected
-		${'-1'}       | ${-1}
-		${'0'}        | ${0}
-		${'3.141592'} | ${3.141592}
-		${''}         | ${undefined}
-	`('returns number entered', async ({ input, expected }) => {
-		promptMock.mockResolvedValue({ value: input })
-
-		const result = await askForNumber('prompt message')
-
-		expect(result).toBe(expected)
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith({
-			type: 'input',
-			name: 'value',
-			message: 'prompt message',
-			transformer: numberTransformer,
-			validate: expect.any(Function),
-		})
-	})
-
-	const getValidateFunction = async (min?: number, max?: number): Promise<ValidateFunction> => {
-		promptMock.mockResolvedValue({ value: '' })
-
-		const result = await askForNumber('prompt message', min, max)
-
-		expect(result).toBe(undefined)
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith({
-			type: 'input',
-			name: 'value',
-			message: 'prompt message',
-			transformer: numberTransformer,
-			validate: expect.any(Function),
-		})
-
-		return (promptMock.mock.calls[0][0] as { validate: ValidateFunction }).validate
+describe('optionalNumberInput', () => {
+	const getValidateFunction = async (): Promise<ValidateFunction<string>> => {
+		await optionalNumberInput('prompt message')
+		return (inputMock.mock.calls[0][0] as { validate: ValidateFunction<string> }).validate
 	}
 
-	it('validates empty as acceptable', async () => {
-		const validateFunction = await getValidateFunction()
-		expect(validateFunction('')).toBe(true)
+	it('asks user correct question', async () => {
+		inputMock.mockResolvedValueOnce('5')
+
+		expect(await optionalNumberInput('prompt message')).toBe(5)
+
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ message: 'prompt message' }))
+	})
+
+	it('returns nothing entered as undefined', async () => {
+		expect(await optionalNumberInput('prompt message')).toBe(undefined)
+
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ required: false }))
+
+		expect(inputMock).toHaveBeenCalledTimes(1)
+	})
+
+	it('returns "0" entered as 0', async () => {
+		inputMock.mockResolvedValueOnce('0')
+
+		expect(await optionalNumberInput('prompt message')).toBe(0)
+
+		expect(inputMock).toHaveBeenCalledTimes(1)
+	})
+
+	it('passes validate to inquirer', async () => {
+		const validateMock = jest.fn<ValidateFunction<number | undefined>>().mockReturnValueOnce(true)
+
+		expect(await optionalNumberInput('prompt message', { validate: validateMock })).toBe(undefined)
+
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+			validate: expect.any(Function),
+		}))
+
+		const generatedValidate = (inputMock.mock.calls[0][0] as { validate: ValidateFunction<string> }).validate
+		expect(generatedValidate('13')).toBe(true)
+		expect(validateMock).toHaveBeenCalledExactlyOnceWith(13)
+	})
+
+	it('reports an empty string as valid', async () => {
+		const generatedValidate = await getValidateFunction()
+		expect(generatedValidate('')).toBe(true)
 	})
 
 	it.each(['-5.5', '0', '0.3', '3.0', '7', '21553992'])(
-		'validates numbers as acceptable',
+		'reports %s as valid',
 		async value => {
-			const validateFunction = await getValidateFunction()
-			expect(validateFunction(value)).toBe(true)
+			const generatedValidate = await getValidateFunction()
+			expect(generatedValidate(value)).toBe(true)
 		},
 	)
 
-	it.each(['abc', 'PI', 'twelve', '1/3'])('invalidates non-number values', async value => {
-		const validateFunction = await getValidateFunction()
-		expect(validateFunction(value)).toBe(`${value} is not a valid number`)
+	it.each(['abc', 'PI', 'twelve', '1/3', '7i + 3'])('reports %s as invalid', async value => {
+		const generatedValidate = await getValidateFunction()
+		expect(generatedValidate(value)).toBe(`"${value}" is not a valid number`)
 	})
 
-	it.each(['-10.5', '0', '7.3', '2155.3992'])(
-		'validates >= min values as acceptable',
-		async value => {
-			const validateFunction = await getValidateFunction(-10.5)
-			expect(validateFunction(value)).toBe(true)
-		},
-	)
+	it('passes default to inquirer', async () => {
+		inputMock.mockResolvedValueOnce('5')
 
-	it.each(['0', '1', '3.1416', '10.009'])('invalidates < min values', async value => {
-		const validateFunction = await getValidateFunction(10.01)
-		expect(validateFunction(value)).toBe('must be no less than 10.01')
+		expect(await optionalNumberInput('prompt message', { default: 5.7 })).toBe(5)
+
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+			default: '5.7',
+		}))
 	})
 
-	it('invalidates < min values (0 min)', async () => {
-		const validateFunction = await getValidateFunction(0)
-		expect(validateFunction('-0.1')).toBe('must be no less than 0')
+	it('calls default function to get default', async () => {
+		inputMock.mockResolvedValueOnce('72.7')
+		const defaultMock = jest.fn<DefaultValueFunction<number>>().mockReturnValueOnce(27.3)
+
+		expect(await optionalNumberInput('prompt message', { default: defaultMock })).toBe(72.7)
+
+		expect(inputMock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+			default: '27.3',
+		}))
+		expect(defaultMock).toHaveBeenCalledExactlyOnceWith()
 	})
 
-	it.each(['0', '15', '15.3'])('validates <= max values as acceptable', async value => {
-		const validateFunction = await getValidateFunction(undefined, 15.3)
-		expect(validateFunction(value)).toBe(true)
+	it('displays help text when "?" entered', async () => {
+		inputMock.mockResolvedValueOnce('?')
+		inputMock.mockResolvedValueOnce('13')
+
+		expect(await optionalNumberInput('prompt message', { helpText: 'help text' })).toBe(13)
+
+		expect(inputMock).toHaveBeenCalledWith(expect.objectContaining({
+			message: 'prompt message (? for help)',
+		}))
+		expect(consoleLogSpy).toHaveBeenLastCalledWith('help text')
 	})
 
-	it.each(['9.7501', '12', '100'])('invalidates > max values', async value => {
-		const validateFunction = await getValidateFunction(undefined, 9.75)
-		expect(validateFunction(value)).toBe('must be no more than 9.75')
-	})
+	it('allows "?" even with custom validate function', async () => {
+		const validateMock = jest.fn<ValidateFunction<number | undefined>>().mockReturnValue(true)
+		inputMock.mockResolvedValueOnce('?')
+		inputMock.mockResolvedValueOnce('32')
 
-	it('invalidates > max values (0 max)', async () => {
-		const validateFunction = await getValidateFunction(undefined, 0)
-		expect(validateFunction('0.01')).toBe('must be no more than 0')
+		expect(await optionalNumberInput(
+			'prompt message',
+			{ helpText: 'help text', validate: validateMock },
+		)).toBe(32)
+
+		expect(inputMock).toHaveBeenCalledWith(expect.objectContaining({
+			message: 'prompt message (? for help)',
+			validate: expect.any(Function),
+		}))
+		expect(consoleLogSpy).toHaveBeenLastCalledWith('help text')
+
+		const generatedValidate = (inputMock.mock.calls[0][0] as { validate: ValidateFunction<string> }).validate
+		expect(generatedValidate('?')).toBeTrue()
+		expect(validateMock).toHaveBeenCalledTimes(0)
 	})
 })
 
-describe('askForBoolean', () => {
+describe('booleanInput', () => {
 	it('defaults to true', async () => {
-		promptMock.mockResolvedValueOnce({ answer: false })
+		confirmMock.mockResolvedValueOnce(false)
 
-		expect(await askForBoolean('Are you absolutely certain?')).toBe(false)
+		expect(await booleanInput('Are you absolutely certain?')).toBe(false)
 
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith({
-			type: 'confirm',
-			name: 'answer',
+		expect(confirmMock).toHaveBeenCalledExactlyOnceWith({
 			message: 'Are you absolutely certain?',
 			default: true,
 		})
 	})
 
 	it('accepts alternate default', async () => {
-		promptMock.mockResolvedValueOnce({ answer: true })
+		confirmMock.mockResolvedValueOnce(true)
 
-		expect(await askForBoolean('Are you absolutely certain?', { default: false })).toBe(true)
+		expect(await booleanInput('Are you absolutely certain?', { default: false })).toBe(true)
 
-		expect(promptMock).toHaveBeenCalledExactlyOnceWith({
-			type: 'confirm',
-			name: 'answer',
+		expect(confirmMock).toHaveBeenCalledExactlyOnceWith({
 			message: 'Are you absolutely certain?',
 			default: false,
 		})

--- a/src/__tests__/lib/validate-util.test.ts
+++ b/src/__tests__/lib/validate-util.test.ts
@@ -1,6 +1,13 @@
 import { jest } from '@jest/globals'
 
-import { emailValidate, httpsURLValidate, integerValidateFn, localhostOrHTTPSValidate, stringValidateFn, urlValidate } from '../../lib/validate-util.js'
+import {
+	emailValidate,
+	httpsURLValidate,
+	localhostOrHTTPSValidate,
+	numberValidateFn,
+	stringValidateFn,
+	urlValidate,
+} from '../../lib/validate-util.js'
 
 
 describe('stringValidateFn', () => {
@@ -64,47 +71,45 @@ describe('stringValidateFn', () => {
 	})
 })
 
-describe('integerValidateFn', () => {
+describe('numberValidateFn', () => {
 	it('throws exception if min is greater than max', () => {
-		expect(() => integerValidateFn({ min: 10, max: 9 })).toThrow('max must be >= min')
+		expect(() => numberValidateFn({ min: 10, max: 9 })).toThrow('max must be >= min')
 	})
 
-	it('requires a valid integer', () => {
-		const fn = integerValidateFn()
-		expect(fn('not an integer')).toBe('"not an integer" is not a valid integer')
-		expect(fn('3.2')).toBe('"3.2" is not a valid integer')
-		expect(fn('81')).toBe(true)
+	it('accepts nullish values', () => {
+		expect(numberValidateFn()(null as unknown as undefined)).toBe(true)
+		expect(numberValidateFn()(undefined)).toBe(true)
 	})
 
 	it.each`
 		min   | input   | expected
-		${12} | ${'13'} | ${true}
-		${13} | ${'13'} | ${true}
-		${14} | ${'13'} | ${'must be no less than 14'}
+		${12} | ${13} | ${true}
+		${13} | ${13} | ${true}
+		${14} | ${13} | ${'must be no less than 14'}
 	`('validates minimum value', ({ min, input, expected }) => {
-		const fn = integerValidateFn({ min })
+		const fn = numberValidateFn({ min })
 		expect(fn(input)).toBe(expected)
 	})
 
 	it.each`
 		max   | input   | expected
-		${12} | ${'13'} | ${'must be no more than 12'}
-		${13} | ${'13'} | ${true}
-		${14} | ${'13'} | ${true}
+		${12} | ${13} | ${'must be no more than 12'}
+		${13} | ${13} | ${true}
+		${14} | ${13} | ${true}
 	`('validates maximum value', ({ max, input, expected }) => {
-		const fn = integerValidateFn({ max })
+		const fn = numberValidateFn({ max })
 		expect(fn(input)).toBe(expected)
 	})
 
 	it.each`
 		min   | max   | input   | expected
-		${12} | ${14} | ${'11'} | ${'must be no less than 12'}
-		${12} | ${14} | ${'12'} | ${true}
-		${12} | ${14} | ${'13'} | ${true}
-		${12} | ${14} | ${'14'} | ${true}
-		${12} | ${14} | ${'15'} | ${'must be no more than 14'}
+		${12} | ${14} | ${11} | ${'must be no less than 12'}
+		${12} | ${14} | ${12} | ${true}
+		${12} | ${14} | ${13} | ${true}
+		${12} | ${14} | ${14} | ${true}
+		${12} | ${14} | ${15} | ${'must be no more than 14'}
 	`('validates minimum and maximum together value', ({ min, max, input, expected }) => {
-		const fn = integerValidateFn({ min, max })
+		const fn = numberValidateFn({ min, max })
 		expect(fn(input)).toBe(expected)
 	})
 })
@@ -121,6 +126,7 @@ describe('urlValidate', () => {
 	it.each([
 		'I love NeoPixels. I hope you do too.',
 		'74',
+		'http:/missing.a.slash',
 	])('rejects "%s"', (input) => {
 		expect(urlValidate(input)).toBe('must be a valid URL')
 	})
@@ -145,6 +151,7 @@ describe('httpsURLValidate', () => {
 	it.each([
 		'I love NeoPixels. I hope you do too.',
 		'74',
+		'https:/missing.a.slash',
 	])('rejects "%s" when https required', (input) => {
 		expect(httpsURLValidate(input)).toBe('must be a valid URL with https protocol')
 	})

--- a/src/commands/config/reset.ts
+++ b/src/commands/config/reset.ts
@@ -1,7 +1,7 @@
 import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 
 import { resetManagedConfig } from '../../lib/cli-config.js'
-import { askForBoolean } from '../../lib/user-query.js'
+import { booleanInput } from '../../lib/user-query.js'
 import {
 	smartThingsCommand,
 	smartThingsCommandBuilder,
@@ -30,7 +30,7 @@ const handler = async (argv: ArgumentsCamelCase<CommandArgs>): Promise<void> => 
 
 	const message = 'Are you sure you want to clear saved answers to questions' +
 		`${command.profileName === 'default' ? '' : ` for the profile ${command.profileName}`}?`
-	const confirmed = await askForBoolean(message, { default: false })
+	const confirmed = await booleanInput(message, { default: false })
 
 	if (confirmed) {
 		await resetManagedConfig(command.cliConfig, command.profileName)

--- a/src/commands/devicepreferences/create.ts
+++ b/src/commands/devicepreferences/create.ts
@@ -4,12 +4,26 @@ import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 import { type DevicePreferenceCreate, type PreferenceType } from '@smartthings/core-sdk'
 
 import { apiDocsURL } from '../../lib/command/api-command.js'
-import { apiOrganizationCommand, apiOrganizationCommandBuilder, type APIOrganizationCommandFlags } from '../../lib/command/api-organization-command.js'
-import { inputAndOutputItem, inputAndOutputItemBuilder, type InputAndOutputItemFlags } from '../../lib/command/input-and-output-item.js'
+import {
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+	type APIOrganizationCommandFlags,
+} from '../../lib/command/api-organization-command.js'
+import {
+	inputAndOutputItem,
+	inputAndOutputItemBuilder,
+	type InputAndOutputItemFlags,
+} from '../../lib/command/input-and-output-item.js'
 import { userInputProcessor } from '../../lib/command/input-processor.js'
 import { tableFieldDefinitions } from '../../lib/command/util/devicepreferences-util.js'
-import { askForNumber, askForOptionalInteger, askForOptionalString, askForString, type ValidateFunction } from '../../lib/user-query.js'
-import { integerValidateFn } from '../../lib/validate-util.js'
+import {
+	optionalIntegerInput,
+	optionalNumberInput,
+	optionalStringInput,
+	stringInput,
+	type ValidateFunction,
+} from '../../lib/user-query.js'
+import { numberValidateFn } from '../../lib/validate-util.js'
 
 
 export type CommandArgs =
@@ -43,12 +57,12 @@ const builder = (yargs: Argv): Argv<CommandArgs> =>
 		.epilog(apiDocsURL('createPreference'))
 
 const getInputFromUser = async (): Promise<DevicePreferenceCreate> => {
-	const validateName: ValidateFunction = input => !input || input.match(/^[a-z][a-zA-Z0-9]{2,23}$/)
+	const validateName: ValidateFunction<string> = input => !input || input.match(/^[a-z][a-zA-Z0-9]{2,23}$/)
 		? true
 		: 'must be camelCase starting with a lowercase letter and 3-24 characters'
-	const name = await askForOptionalString('Preference name:', { validate: validateName })
-	const title = await askForString('Preference title:')
-	const description = await askForOptionalString('Preference description:')
+	const name = await optionalStringInput('Preference name:', { validate: validateName })
+	const title = await stringInput('Preference title:')
+	const description = await optionalStringInput('Preference description:')
 
 	const required = (await inquirer.prompt({
 		type: 'confirm',
@@ -69,11 +83,12 @@ const getInputFromUser = async (): Promise<DevicePreferenceCreate> => {
 	}
 
 	if (preferenceType === 'integer') {
-		const min = await askForOptionalInteger('Optional minimum value.')
-		const max = await askForOptionalInteger('Optional maximum value.',
-			{ validate: integerValidateFn({ min }) })
-		const defaultValue = await askForOptionalInteger('Optional default value.',
-			{ validate: integerValidateFn({ min, max }) })
+		const min = await optionalIntegerInput('Optional minimum value.')
+		const max = await optionalIntegerInput('Optional maximum value.', { validate: numberValidateFn({ min }) })
+		const defaultValue = await optionalIntegerInput(
+			'Optional default value.',
+			{ validate: numberValidateFn({ min, max }) },
+		)
 		return {
 			...base, preferenceType, definition: {
 				minimum: min ?? undefined,
@@ -84,14 +99,17 @@ const getInputFromUser = async (): Promise<DevicePreferenceCreate> => {
 	}
 
 	if (preferenceType === 'number') {
-		const minimum = await askForNumber('Optional minimum value.')
-		const maximum = await askForNumber('Optional maximum value.', minimum)
-		const defaultValue = await askForNumber('Optional default value.', minimum, maximum)
+		const min = await optionalNumberInput('Optional minimum value.')
+		const max = await optionalNumberInput('Optional maximum value.', { validate: numberValidateFn({ min }) })
+		const defaultValue = await optionalNumberInput(
+			'Optional default value.',
+			{ validate: numberValidateFn({ min, max }) },
+		)
 		return {
 			...base, preferenceType, definition: {
-				minimum: minimum ?? undefined,
-				maximum: maximum ?? undefined,
-				default: defaultValue ?? undefined,
+				minimum: min,
+				maximum: max,
+				default: defaultValue,
 			},
 		}
 	}
@@ -113,9 +131,11 @@ const getInputFromUser = async (): Promise<DevicePreferenceCreate> => {
 	}
 
 	if (preferenceType === 'string') {
-		const minLength = await askForOptionalInteger('Optional minimum length.')
-		const maxLength = await askForOptionalInteger('Optional maximum length.',
-			{ validate: integerValidateFn({ min: minLength }) })
+		const minLength = await optionalIntegerInput('Optional minimum length.', { validate: numberValidateFn({ min: 0 }) })
+		const maxLength = await optionalIntegerInput(
+			'Optional maximum length.',
+			{ validate: numberValidateFn({ min: minLength || 1 }) },
+		)
 		const stringType = (await inquirer.prompt({
 			type: 'list',
 			name: 'stringType',
@@ -123,7 +143,7 @@ const getInputFromUser = async (): Promise<DevicePreferenceCreate> => {
 			choices: ['text', 'password', 'paragraph'],
 			default: 'text',
 		})).stringType as 'text' | 'password' | 'paragraph'
-		const defaultValue = await askForOptionalString('Optional default value.', {
+		const defaultValue = await optionalStringInput('Optional default value.', {
 			validate: input => {
 				if (minLength !== undefined && input.length < minLength) {
 					return `default must be no less than minLength (${minLength}) characters`
@@ -145,16 +165,16 @@ const getInputFromUser = async (): Promise<DevicePreferenceCreate> => {
 	}
 
 	if (preferenceType === 'enumeration') {
-		const firstName = await askForString('Enter a name (key) for the first option.')
-		let value = await askForString('Enter a value for the first option.')
+		const firstName = await stringInput('Enter a name (key) for the first option.')
+		let value = await stringInput('Enter a value for the first option.')
 
 		const options: { [name: string]: string } = { [firstName]: value }
 
 		let name: string | undefined
 		do {
-			name = await askForOptionalString('Enter a name (key) for the next option or press enter to continue.')
+			name = await optionalStringInput('Enter a name (key) for the next option or press enter to continue.')
 			if (name) {
-				value = await askForString('Enter a value for the option.')
+				value = await stringInput('Enter a value for the option.')
 				options[name] = value
 			}
 		} while (name)

--- a/src/commands/installedapps/rename.ts
+++ b/src/commands/installedapps/rename.ts
@@ -1,8 +1,8 @@
-import inquirer from 'inquirer'
 import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 
 import { type InstalledAppListOptions } from '@smartthings/core-sdk'
 
+import { stringInput } from '../../lib/user-query.js'
 import { apiCommand, apiCommandBuilder, type APICommandFlags } from '../../lib/command/api-command.js'
 import {
 	formatAndWriteItem,
@@ -56,12 +56,7 @@ const handler = async (argv: ArgumentsCamelCase<CommandArgs>): Promise<void> => 
 	const listOptions: InstalledAppListOptions = { locationId: argv.location }
 	const installedAppId = await chooseInstalledAppFn({ verbose: argv.verbose, listOptions })(command, argv.id)
 
-	const displayName = argv.newName ??
-		(await inquirer.prompt({
-			type: 'input',
-			name: 'newName',
-			message: 'Enter new installed app name:',
-		})).newName
+	const displayName = argv.newName ?? await stringInput('Enter new installed app name:')
 	const updatedApp = await command.client.installedApps.update(installedAppId, { displayName })
 	await formatAndWriteItem(command, { tableFieldDefinitions }, updatedApp)
 }

--- a/src/lib/command/util/hub-drivers.ts
+++ b/src/lib/command/util/hub-drivers.ts
@@ -5,7 +5,7 @@ import inquirer from 'inquirer'
 
 import { type Sorting } from '../io-defs.js'
 import { type DriverInfo } from '../../live-logging.js'
-import { askForBoolean } from '../../user-query.js'
+import { booleanInput } from '../../user-query.js'
 import { fatalError } from '../../util.js'
 import { convertToId, stringTranslateToId } from '../command-util.js'
 import { selectFromList, type SelectFromListConfig } from '../select.js'
@@ -93,7 +93,7 @@ export const checkServerIdentity = async (
 	if (!known || known.fingerprint !== cert.fingerprint) {
 		console.warn(`The authenticity of ${authority} can't be established. Certificate fingerprint is` +
 			` ${cert.fingerprint}`)
-		const verified = await askForBoolean('Are you sure you want to continue connecting?', { default: false })
+		const verified = await booleanInput('Are you sure you want to continue connecting?', { default: false })
 		if (!verified) {
 			return fatalError('Hub verification failed.')
 		}

--- a/src/lib/item-input/command-helpers.ts
+++ b/src/lib/item-input/command-helpers.ts
@@ -14,7 +14,7 @@ import {
 } from './defs.js'
 import { cancelCommand } from '../util.js'
 import { BuildOutputFormatterFlags } from '../command/output-builder.js'
-import { askForBoolean } from '../user-query.js'
+import { booleanInput } from '../user-query.js'
 
 
 export type UpdateFromUserInputOptions = {
@@ -45,7 +45,7 @@ export const updateFromUserInput = async <T extends object>(
 			?? (formatter === yamlFormatter ? 2 : 4)
 		const output = formatter(indent)(retVal)
 
-		const editAgain = await askForBoolean(
+		const editAgain = await booleanInput(
 			output + '\n\nWould you like to edit further?',
 			{ default: false },
 		)

--- a/src/lib/item-input/defs.ts
+++ b/src/lib/item-input/defs.ts
@@ -80,8 +80,7 @@ export type InputDefinition<T> = {
  * of `ValidationFunction` since `context` is optional. i.e. Any function that conforms to
  * `ValidateFunction` will work for a `InputDefinitionValidateFunction` as well.
  */
-export type InputDefinitionValidateFunction = (input: string,
-	context?: unknown[]) => true | string | Promise<true | string>
+export type InputDefinitionValidateFunction<T> = (input: T, context?: unknown[]) => true | string
 export type DefaultValueFunction<T> = (context?: unknown[]) => T
 export type InputDefinitionDefaultValueOrFn<T> = T | DefaultValueFunction<T>
 

--- a/src/lib/item-input/misc.ts
+++ b/src/lib/item-input/misc.ts
@@ -1,51 +1,57 @@
 import inquirer, { ChoiceCollection } from 'inquirer'
 
 import {
-	askForBoolean,
-	AskForBooleanOptions,
-	askForInteger,
-	AskForIntegerOptions,
-	askForOptionalInteger,
-	askForOptionalString,
-	askForString,
-	AskForStringOptions,
-	DefaultValueOrFn,
-	ValidateFunction,
+	booleanInput,
+	BooleanInputOptions,
+	integerInput,
+	IntegerInputOptions,
+	optionalIntegerInput,
+	type DefaultValueOrFn,
+	optionalStringInput,
+	stringInput,
+	type OptionalStringInputOptions,
+	type ValidateFunction,
 } from '../../lib/user-query.js'
 import {
-	CancelAction,
-	InputDefinition,
-	InputDefinitionDefaultValueOrFn,
-	InputDefinitionValidateFunction,
-	Uneditable,
+	type CancelAction,
+	type InputDefinition,
+	type InputDefinitionDefaultValueOrFn,
+	type InputDefinitionValidateFunction,
+	type Uneditable,
 	cancelOption,
 	uneditable,
 } from '../../lib/item-input/defs.js'
 import { stringFromUnknown } from '../util.js'
 
 
-export const validateWithContextFn = (validate?: InputDefinitionValidateFunction, context?: unknown[]): ValidateFunction | undefined =>
+export const validateWithContextFn = <T>(
+	validate?: InputDefinitionValidateFunction<T>,
+	context?: unknown[],
+): ValidateFunction<T> | undefined =>
 	validate
-		? (input: string): true | string | Promise<string | true> => validate(input, context)
+		? (input: T): true | string => validate(input, context)
 		: undefined
 
-export const defaultWithContextFn = <T extends string | number>(def?: InputDefinitionDefaultValueOrFn<T>, context?: unknown[]): DefaultValueOrFn<T> | undefined =>
+export const defaultWithContextFn = <T extends string | number>(
+	def?: InputDefinitionDefaultValueOrFn<T>,
+	context?: unknown[],
+): DefaultValueOrFn<T> | undefined =>
 	typeof def === 'function' ? () => def(context) : def
 
-export type StringDefOptions = Omit<AskForStringOptions, 'default' | 'validate'> & {
+export type StringDefOptions = Omit<OptionalStringInputOptions, 'default' | 'validate'> & {
 	default?: InputDefinitionDefaultValueOrFn<string>
-	validate?: InputDefinitionValidateFunction
+	validate?: InputDefinitionValidateFunction<string>
 }
 export const optionalStringDef = (name: string, options?: StringDefOptions): InputDefinition<string | undefined> => {
 	const buildFromUserInput = async (context?: unknown[]): Promise<string | undefined> =>
-		askForOptionalString(`${name} (optional)`, {
+		optionalStringInput(`${name} (optional)`, {
 			...options,
 			default: defaultWithContextFn(options?.default, context),
 			validate: validateWithContextFn(options?.validate, context),
 		})
 	const summarizeForEdit = (value: string): string => value
 	const updateFromUserInput = (original: string, context?: unknown[]): Promise<string | undefined> =>
-		askForOptionalString(`${name} (optional)`,
+		optionalStringInput(`${name} (optional)`,
 			{ ...options, default: original, validate: validateWithContextFn(options?.validate, context) })
 
 	return { name, buildFromUserInput, summarizeForEdit, updateFromUserInput }
@@ -53,7 +59,7 @@ export const optionalStringDef = (name: string, options?: StringDefOptions): Inp
 
 export const stringDef = (name: string, options?: StringDefOptions): InputDefinition<string> => {
 	const buildFromUserInput = async (context?: unknown[]): Promise<string> =>
-		askForString(name,
+		stringInput(name,
 			{
 				...options,
 				default: defaultWithContextFn(options?.default, context),
@@ -61,49 +67,49 @@ export const stringDef = (name: string, options?: StringDefOptions): InputDefini
 			})
 	const summarizeForEdit = (value: string): string => value
 	const updateFromUserInput = (original: string, context?: unknown[]): Promise<string> =>
-		askForString(name,
+		stringInput(name,
 			{ ...options, default: original, validate: validateWithContextFn(options?.validate, context) })
 
 	return { name, buildFromUserInput, summarizeForEdit, updateFromUserInput }
 }
 
-export type NumberDefOptions = Omit<AskForIntegerOptions, 'default'> & {
+export type NumberDefOptions = Omit<IntegerInputOptions<number>, 'default'> & {
 	default?: InputDefinitionDefaultValueOrFn<number>
 }
 export const optionalIntegerDef = (name: string, options?: NumberDefOptions): InputDefinition<number | undefined> => {
 	const buildFromUserInput = async (context?: unknown[]): Promise<number | undefined> =>
-		askForOptionalInteger(`${name} (optional)`, {
+		optionalIntegerInput(`${name} (optional)`, {
 			...options,
 			default: defaultWithContextFn(options?.default, context),
-			validate: validateWithContextFn(options?.validate, context),
+			validate: validateWithContextFn<number | undefined>(options?.validate, context),
 		})
 	const summarizeForEdit = (value: number | undefined): string => String(value)
 	const updateFromUserInput = (original: number | undefined, context?: unknown[]): Promise<number | undefined> =>
-		askForOptionalInteger(`${name} (optional)`,
-			{ ...options, default: original, validate: validateWithContextFn(options?.validate, context) })
+		optionalIntegerInput(`${name} (optional)`,
+			{ ...options, default: original, validate: validateWithContextFn<number | undefined>(options?.validate, context) })
 
 	return { name, buildFromUserInput, summarizeForEdit, updateFromUserInput }
 }
 export const integerDef = (name: string, options?: NumberDefOptions): InputDefinition<number> => {
 	const buildFromUserInput = async (context?: unknown[]): Promise<number> =>
-		askForInteger(name, {
+		integerInput(name, {
 			...options,
 			default: defaultWithContextFn(options?.default, context),
-			validate: validateWithContextFn(options?.validate, context),
+			validate: validateWithContextFn<number | undefined>(options?.validate, context),
 		})
 	const summarizeForEdit = (value: number): string => String(value)
 	const updateFromUserInput = (original: number | undefined, context?: unknown[]): Promise<number> =>
-		askForInteger(name,
-			{ ...options, default: original, validate: validateWithContextFn(options?.validate, context) })
+		integerInput(name,
+			{ ...options, default: original, validate: validateWithContextFn<number | undefined>(options?.validate, context) })
 
 	return { name, buildFromUserInput, summarizeForEdit, updateFromUserInput }
 }
 
-export type BooleanDefOptions = AskForBooleanOptions
+export type BooleanDefOptions = BooleanInputOptions
 export const booleanDef = (name: string, options?: BooleanDefOptions): InputDefinition<boolean> => {
-	const buildFromUserInput = async (): Promise<boolean> => askForBoolean(name, options)
+	const buildFromUserInput = async (): Promise<boolean> => booleanInput(name, options)
 	const summarizeForEdit = (value: boolean): string => value ? 'Yes' : 'No'
-	const updateFromUserInput = async (original: boolean): Promise<boolean> => askForBoolean(name, { default: original })
+	const updateFromUserInput = async (original: boolean): Promise<boolean> => booleanInput(name, { default: original })
 
 	return { name, buildFromUserInput, summarizeForEdit, updateFromUserInput }
 }


### PR DESCRIPTION
* added new inquirer dependency
* updated `user-query` module
    * use new inquirer
    * gave functions better names
    * made their APIs more consistent with each other
    * custom validators for number and integer functions now take `number | undefined` instead of `string` and the query function does the number validation before passing the input on to custom validator as a number
* fixed issue that `urlValidateFn` was allowing URLs missing a `/` like `https:/invalid-url.com`

The old inquirer is still included. A second PR will update the rest of the code and remove it entirely.