### PR TITLE
fix: fix bug preventing editing of apps with no icon image set

### DIFF
--- a/.changeset/spotty-books-taste.md
+++ b/.changeset/spotty-books-taste.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+fix bug preventing interactive editing of apps with no icon image set

--- a/packages/cli/src/commands/apps/update.ts
+++ b/packages/cli/src/commands/apps/update.ts
@@ -68,7 +68,7 @@ export default class AppUpdateCommand extends APICommand<typeof AppUpdateCommand
 				appType, classifications, displayName, description,
 			} = await this.client.apps.get(appId)
 			const startingRequest: AppUpdateRequest = {
-				appName, appType, classifications, displayName, description, singleInstance, iconImage, ui,
+				appName, appType, classifications, displayName, description, singleInstance, iconImage: iconImage ?? {}, ui,
 			}
 			const propertyInputDefs: InputDefsByProperty<AppUpdateRequest> = {
 				displayName: stringDef('Display Name'),


### PR DESCRIPTION
When there is no icon image set, editing an app failed because the whole `iconImage` field was missing. Added an empty object if `iconImage` is not present.