### PR TITLE
chore: enable Intel MacOS binary but add note for minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The SmartThings CLI is a tool to help with developing SmartApps and drivers for 
 
 ### Homebrew (MacOS)
 
+Note that the MacOS binaries require at least MacOS 13.5.
+
 ```console
 brew install smartthingscommunity/smartthings/smartthings
 ```

--- a/src/build-tools/build-binaries.ts
+++ b/src/build-tools/build-binaries.ts
@@ -11,8 +11,7 @@ const targets = [
 	'linux-arm64',
 	'linux-x64',
 	'mac-arm64',
-	// The Intel Mac Build still isn't working properly yet.
-	// 'mac-x64',
+	'mac-x64',
 	'windows-x64',
 ]
 const nodeVersion = process.version.substring(1)


### PR DESCRIPTION
* enabled MacOS Intel binary
* added a note mentioning at least MacOS 13.5 is required for MacOS versions