### PR TITLE
fix: hide `--token` flag and be more specific with environment variab…

### DIFF
--- a/src/__tests__/lib/command/smartthings-command.test.ts
+++ b/src/__tests__/lib/command/smartthings-command.test.ts
@@ -68,11 +68,10 @@ const {
 
 
 test('smartThingsCommandBuilder', () => {
-	const { envMock, optionMock, argvMock } = buildArgvMock<object, SmartThingsCommandFlags>()
+	const { optionMock, argvMock } = buildArgvMock<object, SmartThingsCommandFlags>()
 
 	expect(smartThingsCommandBuilder(argvMock)).toBe(argvMock)
 
-	expect(envMock).toHaveBeenCalledTimes(1)
 	expect(optionMock).toHaveBeenCalledTimes(2)
 })
 

--- a/src/lib/command/api-command.ts
+++ b/src/lib/command/api-command.ts
@@ -29,7 +29,13 @@ export type APICommandFlags = SmartThingsCommandFlags & {
 
 export const apiCommandBuilder = <T extends object>(yargs: Argv<T>): Argv<T & APICommandFlags> =>
 	smartThingsCommandBuilder(yargs)
-		.option('token', { alias: 't', desc: 'the auth token to use', type: 'string' })
+		.option('token', {
+			alias: 't',
+			desc: 'the auth token to use',
+			type: 'string',
+			default: process.env.SMARTTHINGS_TOKEN,
+			hidden: true,
+		})
 		.option('language', {
 			desc: 'ISO language code or "NONE" to not specify a language. Defaults to the OS locale',
 			type: 'string',

--- a/src/lib/command/smartthings-command.ts
+++ b/src/lib/command/smartthings-command.ts
@@ -18,12 +18,12 @@ export type SmartThingsCommandFlags = {
 export const smartThingsCommandBuilder = <T extends object = object>(
 	yargs: Argv<T>,
 ): Argv<T & SmartThingsCommandFlags> =>
-	yargs.env('SMARTTHINGS')
+	yargs
 		.option('profile', {
 			alias: 'p',
 			describe: 'configuration profile',
 			type: 'string',
-			default: 'default',
+			default: process.env.SMARTTHINGS_PROFILE ?? 'default',
 		})
 		// This option is temporary and will be removed when removing automatic copy
 		// of old configuration files. (See also yargs-transition-temp.ts.)


### PR DESCRIPTION
* hide the `--token` command line option
* handle `SMARTTHINGS_PROFILE` and `SMARTTHINGS_TOKEN` environment variables explicitly rather than supporting all environment variables that start with `SMARTTHINGS_`.