### PR TITLE
refactor: switch to new location of itemInputHelpText, in help.ts

### DIFF
--- a/src/__tests__/commands/apps/oauth/generate.test.ts
+++ b/src/__tests__/commands/apps/oauth/generate.test.ts
@@ -10,6 +10,7 @@ import type {
 	SmartThingsClient,
 } from '@smartthings/core-sdk'
 
+import type { itemInputHelpText } from '../../../../lib/help.js'
 import type { APICommand, APICommandFlags } from '../../../../lib/command/api-command.js'
 import type {
 	inputAndOutputItem,
@@ -24,11 +25,15 @@ import { apiCommandMocks } from '../../../test-lib/api-command-mock.js'
 import { buildInputDefMock } from '../../../test-lib/input-type-mock.js'
 
 
+const itemInputHelpTextMock = jest.fn<typeof itemInputHelpText>()
+jest.unstable_mockModule('../../../../lib/help.js', () => ({
+	itemInputHelpText: itemInputHelpTextMock,
+}))
+
 const {
 	apiCommandMock,
 	apiCommandBuilderMock,
 	apiDocsURLMock,
-	itemInputHelpTextMock,
 } = apiCommandMocks('../../../..')
 
 const inputAndOutputItemMock =

--- a/src/__tests__/commands/apps/oauth/update.test.ts
+++ b/src/__tests__/commands/apps/oauth/update.test.ts
@@ -11,6 +11,7 @@ import type {
 	SmartThingsClient,
 } from '@smartthings/core-sdk'
 
+import type { itemInputHelpText } from '../../../../lib/help.js'
 import type { APICommand, APICommandFlags } from '../../../../lib/command/api-command.js'
 import type {
 	inputAndOutputItem,
@@ -25,11 +26,15 @@ import { apiCommandMocks } from '../../../test-lib/api-command-mock.js'
 import { buildInputDefMock } from '../../../test-lib/input-type-mock.js'
 
 
+const itemInputHelpTextMock = jest.fn<typeof itemInputHelpText>()
+jest.unstable_mockModule('../../../../lib/help.js', () => ({
+	itemInputHelpText: itemInputHelpTextMock,
+}))
+
 const {
 	apiCommandMock,
 	apiCommandBuilderMock,
 	apiDocsURLMock,
-	itemInputHelpTextMock,
 } = apiCommandMocks('../../../..')
 
 const inputAndOutputItemMock =

--- a/src/__tests__/lib/command/api-command.test.ts
+++ b/src/__tests__/lib/command/api-command.test.ts
@@ -1,8 +1,8 @@
 import { jest } from '@jest/globals'
 
-import { osLocale } from 'os-locale'
+import type { osLocale } from 'os-locale'
 
-import {
+import type {
 	Authenticator,
 	Logger,
 	RESTClientConfig,
@@ -10,18 +10,18 @@ import {
 	WarningFromHeader,
 } from '@smartthings/core-sdk'
 
-import {
+import type {
 	SmartThingsCommand,
 	SmartThingsCommandFlags,
 	smartThingsCommand,
 	smartThingsCommandBuilder,
 } from '../../../lib/command/smartthings-command.js'
-import { newBearerTokenAuthenticator, newSmartThingsClient } from '../../../lib/command/util/st-client-wrapper.js'
-import { coreSDKLoggerFromLog4JSLogger } from '../../../lib/log-utils.js'
-import { defaultClientIdProvider, loginAuthenticator } from '../../../lib/login-authenticator.js'
-import { TableGenerator } from '../../../lib/table-generator.js'
+import type { newBearerTokenAuthenticator, newSmartThingsClient } from '../../../lib/command/util/st-client-wrapper.js'
+import type { coreSDKLoggerFromLog4JSLogger } from '../../../lib/log-utils.js'
+import { defaultClientIdProvider, type loginAuthenticator } from '../../../lib/login-authenticator.js'
+import type { TableGenerator } from '../../../lib/table-generator.js'
 import { buildArgvMock } from '../../test-lib/builder-mock.js'
-import { CLIConfig } from '../../../lib/cli-config.js'
+import type { CLIConfig } from '../../../lib/cli-config.js'
 
 
 const { errorMock, loggerMock } = await import('../../test-lib/logger-mock.js')
@@ -92,7 +92,6 @@ const {
 	apiCommand,
 	apiCommandBuilder,
 	apiDocsURL,
-	itemInputHelpText,
 	userAgent,
 } = await import('../../../lib/command/api-command.js')
 
@@ -109,21 +108,6 @@ describe('apiDocsURL', () => {
 			.toBe('For API information, see:\n' +
 				'  https://developer.smartthings.com/docs/api/public/#operation/getDevice\n' +
 				'  https://developer.smartthings.com/docs/api/public/#operation/getDevices')
-	})
-})
-
-describe('itemInputHelpText', () => {
-	it('works with external URLs', () => {
-		expect(itemInputHelpText('https://adafruit.com', 'https://digikey.com'))
-			.toBe('More information can be found at:\n' +
-				'  https://adafruit.com\n' +
-				'  https://digikey.com')
-	})
-
-	it('builds URLs like `apiDocsURL`', () => {
-		expect(itemInputHelpText('getDevice'))
-			.toBe('More information can be found at:\n' +
-				'  https://developer.smartthings.com/docs/api/public/#operation/getDevice')
 	})
 })
 

--- a/src/__tests__/test-lib/api-command-mock.ts
+++ b/src/__tests__/test-lib/api-command-mock.ts
@@ -7,32 +7,27 @@ import {
 	type APICommandFlags,
 	type apiCommand,
 	type apiDocsURL,
-	type itemInputHelpText,
 } from '../../lib/command/api-command.js'
 import { buildArgvMockStub, type BuilderFunctionMock } from './builder-mock.js'
 
 
 export const apiCommandMocks = <T extends APICommandFlags = APICommandFlags>(prefix: string): {
 	apiDocsURLMock: jest.Mock<typeof apiDocsURL>
-	itemInputHelpTextMock: jest.Mock<typeof itemInputHelpText>
 	apiCommandMock: jest.Mock<typeof apiCommand>
 	apiCommandBuilderMock: BuilderFunctionMock<Argv<T>>
 } => {
 	const apiDocsURLMock = jest.fn<typeof apiDocsURL>()
-	const itemInputHelpTextMock = jest.fn<typeof itemInputHelpText>()
 	const apiCommandBuilderMock = buildArgvMockStub<T>()
 	const apiCommandMock = jest.fn<typeof apiCommand>()
 	jest.unstable_mockModule(`${prefix}/lib/command/api-command.js`, () => ({
 		userAgent,
 		apiDocsURL: apiDocsURLMock,
-		itemInputHelpText: itemInputHelpTextMock,
 		apiCommandBuilder: apiCommandBuilderMock,
 		apiCommand: apiCommandMock,
 	}))
 
 	return {
 		apiDocsURLMock,
-		itemInputHelpTextMock,
 		apiCommandBuilderMock,
 		apiCommandMock,
 	}

--- a/src/commands/apps/oauth/generate.ts
+++ b/src/commands/apps/oauth/generate.ts
@@ -2,19 +2,19 @@ import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 
 import type { GenerateAppOAuthRequest, GenerateAppOAuthResponse } from '@smartthings/core-sdk'
 
-import { TableFieldDefinition } from '../../../lib/table-generator.js'
+import { itemInputHelpText } from '../../../lib/help.js'
+import { type TableFieldDefinition } from '../../../lib/table-generator.js'
 import {
 	apiCommand,
 	apiCommandBuilder,
-	APICommandFlags,
+	type APICommandFlags,
 	apiDocsURL,
-	itemInputHelpText,
 } from '../../../lib/command/api-command.js'
 import {
 	inputAndOutputItem,
 	inputAndOutputItemBuilder,
-	InputAndOutputItemConfig,
-	InputAndOutputItemFlags,
+	type InputAndOutputItemConfig,
+	type InputAndOutputItemFlags,
 } from '../../../lib/command/input-and-output-item.js'
 import { inputProcessor } from '../../../lib/command/input-processor.js'
 import { chooseApp } from '../../../lib/command/util/apps-util.js'

--- a/src/commands/apps/oauth/update.ts
+++ b/src/commands/apps/oauth/update.ts
@@ -2,12 +2,12 @@ import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 
 import { AppOAuthRequest } from '@smartthings/core-sdk'
 
+import { itemInputHelpText } from '../../../lib/help.js'
 import {
 	apiCommand,
 	apiCommandBuilder,
 	APICommandFlags,
 	apiDocsURL,
-	itemInputHelpText,
 } from '../../../lib/command/api-command.js'
 import {
 	inputAndOutputItem,

--- a/src/lib/command/api-command.ts
+++ b/src/lib/command/api-command.ts
@@ -21,10 +21,6 @@ const toURL = (nameOrURL: string): string => nameOrURL.startsWith('http')
 
 export const apiDocsURL = (...names: string[]): string => 'For API information, see:\n  ' +
 	names.map(name => toURL(name)).join('\n  ')
-
-
-export const itemInputHelpText = (...namesOrURLs: string[]): string => 'More information can be found at:\n  ' +
-	namesOrURLs.map(nameOrURL => toURL(nameOrURL)).join('\n  ')
 // TODO: END REMOVE
 
 export type APICommandFlags = SmartThingsCommandFlags & {


### PR DESCRIPTION
I know I said two pull request for adding sub-command and topic help in the last one but I've decided to add a third since this naturally breaks out. (I might just do the rest of it in multiple PRs too since there will be a lot of files touched.)

This pull request removes the old copy of `itemInputHelpText` and updates references to it to use the new location.