### PR TITLE
chore: (hopefully) fix to build process

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -120,23 +120,23 @@ jobs:
 
       - name: Debug List Files after Download, Windows
         if: runner.os == 'Windows'
-        run: Get-ChildItem -Path dist_bin
+        run: Get-ChildItem
 
       - name: Debug List Files after Download
         if: runner.os != 'Windows'
-        run: ls -l dist_bin
+        run: ls -l
 
       - name: Extract Linux Binary
         if: runner.os == 'Linux'
-        run: tar xvf dist_bin/smartthings-linux-x64.tgz
+        run: tar xvf smartthings-linux-x64.tgz
 
       - name: Extract MacOS Binary
         if: runner.os == 'macOS'
-        run: tar xvf dist_bin/smartthings-mac-arm64.tgz
+        run: tar xvf smartthings-mac-arm64.tgz
 
       - name: Extract Windows Binary
         if: runner.os == 'Windows'
-        run: Expand-Archive -Path dist_bin\smartthings-windows-x64.zip -DestinationPath "${{ github.workspace }}"
+        run: Expand-Archive -Path smartthings-windows-x64.zip -DestinationPath "${{ github.workspace }}"
 
       - uses: actions/setup-python@v6.1.0
         with:
@@ -188,7 +188,7 @@ jobs:
           name: Binaries
 
       - name: Debug Downloaded Artifacts
-        run: ls -l dist_bin/smartthings-*.{tgz,zip}
+        run: ls -l smartthings-*.{tgz,zip}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6.1.0
@@ -202,7 +202,7 @@ jobs:
           tag_name: ${{ needs.npm-release.outputs.cli-tag }}
           generate_release_notes: true
           prerelease: false
-          files: 'dist_bin/smartthings-*.{tgz,zip}'
+          files: 'smartthings-*.{tgz,zip}'
 
   homebrew-formula:
     needs: [npm-release, github-release]
@@ -259,10 +259,10 @@ jobs:
           name: Binaries
 
       - name: Debug List Files after Download
-        run: Get-ChildItem -Path dist_bin
+        run: Get-ChildItem
 
       - name: Extract Windows Binary
-        run: Expand-Archive -Path dist_bin\smartthings-windows-x64.zip -DestinationPath "${{ github.workspace }}\wix"
+        run: Expand-Archive -Path smartthings-windows-x64.zip -DestinationPath "${{ github.workspace }}\wix"
 
       - name: Debug List Files after Extraction
         run: Get-ChildItem -Path .\wix

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
 		"test-watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch --reporters=default",
 		"test-coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage=true",
 		"prepack": "tsc && npm run readme",
-		"version": "npm run readme && git add README.md && changeset version && npm i --package-lock-only && npm run build && npm run version -w packages/cli",
+		"version": "npm run build && npm run readme && git add README.md && changeset version && npm i --package-lock-only && npm run compile && npm run version -w packages/cli",
 		"release": "npm run build && changeset publish",
 		"package": "tsx src/build-tools/build-binaries.ts"
 	},


### PR DESCRIPTION
* removed `dist_bin` expectation from downloaded artifacts (what the upload artifact action does is [rather complicated](https://github.com/actions/upload-artifact?tab=readme-ov-file#upload-using-multiple-paths-and-exclusions) and it turns out, it is not including this directory in the path of the uploaded zip file
* the repository needs to be build before the `readme` script can be run