### PR TITLE
chore: put back released check but get published status directly from changesets

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -12,11 +12,12 @@ jobs:
     # don't run on forks
     if: ${{ github.repository_owner == 'SmartThingsCommunity' }}
 
-    name: Release
+    name: NPM Release
 
     runs-on: ubuntu-latest
 
     outputs:
+      cli-released: ${{ steps.changesets.outputs.published }}
       cli-version: ${{ steps.cli-metadata.outputs.version }}
       cli-tag: ${{ steps.cli-metadata.outputs.tag }}
 
@@ -47,8 +48,8 @@ jobs:
 
       - name: Debug Published Packages
         run: |
-          echo "Published Packages:"
-          echo '${{ steps.changesets.outputs.publishedPackages }}' | jq .
+          echo 'Published Packages: ${{ steps.changesets.outputs.publishedPackages }}' | jq .
+          echo 'Published: ${{ steps.changesets.outputs.published }}'
 
       - name: Derive Required Metadata
         id: cli-metadata
@@ -169,6 +170,8 @@ jobs:
   github-release:
     needs: [npm-release, package]
 
+    if: needs.npm-release.outputs.cli-released == 'true'
+
     name: Create Github Release
 
     runs-on: ubuntu-latest
@@ -207,6 +210,8 @@ jobs:
   homebrew-formula:
     needs: [npm-release, github-release]
 
+    if: needs.npm-release.outputs.cli-released == 'true'
+
     name: Bump Homebrew Formula
 
     runs-on: macos-latest
@@ -231,6 +236,8 @@ jobs:
 
   windows-installer:
     needs: [npm-release, package, github-release]
+
+    if: needs.npm-release.outputs.cli-released == 'true'
 
     name: Release Windows Installer
 


### PR DESCRIPTION
Put back in code that only runs some jobs if the `changesets` step of the npm-release job actually publishes, but changed slightly how it determines whether a publish happens or not. (Previously it had code that checked specifically if the packages/cli package was published but this is no longer a mono-repo.

For those not familiar with this somewhat unusual setup, the `changesets` step of the `npm-release` job does either one of two things:

1. If this is a "normal commit" (which should include new change sets in the .changeset directory), it should create (or update if one already exists) a pull request for doing a release.
2. If this is a merge of a pull request created by option 1, a release is actually made.

I think there might be something still broken though because I would have expected that PR to be generated even though other later steps are failing. We might have to force it with a new fake changeset or something.