### PR TITLE
fix: add organization options back to edge commands that use it

### DIFF
--- a/.changeset/curvy-yaks-strive.md
+++ b/.changeset/curvy-yaks-strive.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+add organization options back to edge commands that use them

--- a/src/__tests__/commands/edge/channels/delete.test.ts
+++ b/src/__tests__/commands/edge/channels/delete.test.ts
@@ -5,11 +5,15 @@ import type { ArgumentsCamelCase, Argv } from 'yargs'
 import { ChannelsEndpoint } from '@smartthings/core-sdk'
 
 import type { CommandArgs } from '../../../../commands/edge/channels/delete.js'
-import type { buildEpilog } from '../../../../lib/help.js'
-import type { APICommand, APICommandFlags } from '../../../../lib/command/api-command.js'
 import type { CLIConfig, resetManagedConfigKey } from '../../../../lib/cli-config.js'
+import type { buildEpilog } from '../../../../lib/help.js'
+import type {
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+	APIOrganizationCommand,
+	APIOrganizationCommandFlags,
+} from '../../../../lib/command/api-organization-command.js'
 import type { chooseChannel } from '../../../../lib/command/util/edge/channels-choose.js'
-import { apiCommandMocks } from '../../../test-lib/api-command-mock.js'
 import { buildArgvMock } from '../../../test-lib/builder-mock.js'
 
 
@@ -23,7 +27,12 @@ jest.unstable_mockModule('../../../../lib/help.js', () => ({
 	buildEpilog: buildEpilogMock,
 }))
 
-const { apiCommandMock, apiCommandBuilderMock } = apiCommandMocks('../../../..')
+const apiOrganizationCommandMock = jest.fn<typeof apiOrganizationCommand>()
+const apiOrganizationCommandBuilderMock = jest.fn<typeof apiOrganizationCommandBuilder>()
+jest.unstable_mockModule('../../../../lib/command/api-organization-command.js', () => ({
+	apiOrganizationCommand: apiOrganizationCommandMock,
+	apiOrganizationCommandBuilder: apiOrganizationCommandBuilderMock,
+}))
 
 const chooseChannelMock = jest.fn<typeof chooseChannel>().mockResolvedValue('chosen-channel-id')
 jest.unstable_mockModule('../../../../lib/command/util/edge/channels-choose.js', () => ({
@@ -44,14 +53,14 @@ test('builder', () => {
 		exampleMock,
 		epilogMock,
 		argvMock,
-	} = buildArgvMock<APICommandFlags, CommandArgs>()
+	} = buildArgvMock<APIOrganizationCommandFlags, CommandArgs>()
 
-	apiCommandBuilderMock.mockReturnValue(argvMock)
+	apiOrganizationCommandBuilderMock.mockReturnValue(argvMock)
 
 	const builder = cmd.builder as (yargs: Argv<object>) => Argv<CommandArgs>
 	expect(builder(yargsMock)).toBe(argvMock)
 
-	expect(apiCommandBuilderMock).toHaveBeenCalledExactlyOnceWith(yargsMock)
+	expect(apiOrganizationCommandBuilderMock).toHaveBeenCalledExactlyOnceWith(yargsMock)
 
 	expect(positionalMock).toHaveBeenCalledTimes(1)
 	expect(optionMock).toHaveBeenCalledTimes(0)
@@ -74,12 +83,12 @@ test('handler', async () => {
 			},
 		},
 		cliConfig,
-	} as unknown as APICommand
-	apiCommandMock.mockResolvedValueOnce(command)
+	} as unknown as APIOrganizationCommand<ArgumentsCamelCase<CommandArgs>>
+	apiOrganizationCommandMock.mockResolvedValueOnce(command)
 
 	await expect(cmd.handler(inputArgv)).resolves.not.toThrow()
 
-	expect(apiCommandMock).toHaveBeenCalledExactlyOnceWith(inputArgv)
+	expect(apiOrganizationCommandMock).toHaveBeenCalledExactlyOnceWith(inputArgv)
 	expect(chooseChannelMock).toHaveBeenCalledExactlyOnceWith(
 		command,
 		'cmd-line-id',

--- a/src/__tests__/commands/edge/channels/metainfo.test.ts
+++ b/src/__tests__/commands/edge/channels/metainfo.test.ts
@@ -7,12 +7,16 @@ import type { CommandArgs } from '../../../../commands/edge/channels/metainfo.js
 import { ChannelsEndpoint, DriverChannelDetails, EdgeDriver } from '@smartthings/core-sdk'
 
 import type { buildEpilog } from '../../../../lib/help.js'
-import type { APICommand, APICommandFlags } from '../../../../lib/command/api-command.js'
+import type {
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+	APIOrganizationCommand,
+	APIOrganizationCommandFlags,
+} from '../../../../lib/command/api-organization-command.js'
 import type { CustomCommonOutputProducer } from '../../../../lib/command/format.js'
 import type { outputItemOrList, outputItemOrListBuilder } from '../../../../lib/command/listing-io.js'
 import { type buildTableOutput, listTableFieldDefinitions } from '../../../../lib/command/util/edge-drivers.js'
 import type { chooseChannel } from '../../../../lib/command/util/edge/channels-choose.js'
-import { apiCommandMocks } from '../../../test-lib/api-command-mock.js'
 import { buildArgvMock, buildArgvMockStub } from '../../../test-lib/builder-mock.js'
 import { tableGeneratorMock } from '../../../test-lib/table-mock.js'
 
@@ -22,7 +26,12 @@ jest.unstable_mockModule('../../../../lib/help.js', () => ({
 	buildEpilog: buildEpilogMock,
 }))
 
-const { apiCommandMock, apiCommandBuilderMock } = apiCommandMocks('../../../..')
+const apiOrganizationCommandMock = jest.fn<typeof apiOrganizationCommand>()
+const apiOrganizationCommandBuilderMock = jest.fn<typeof apiOrganizationCommandBuilder>()
+jest.unstable_mockModule('../../../../lib/command/api-organization-command.js', () => ({
+	apiOrganizationCommand: apiOrganizationCommandMock,
+	apiOrganizationCommandBuilder: apiOrganizationCommandBuilderMock,
+}))
 
 const outputItemOrListMock = jest.fn<typeof outputItemOrList<EdgeDriver>>()
 const outputItemOrListBuilderMock = jest.fn<typeof outputItemOrListBuilder>()
@@ -55,16 +64,16 @@ test('builder', async () => {
 		exampleMock,
 		epilogMock,
 		argvMock,
-	} = buildArgvMock<APICommandFlags, CommandArgs>()
+	} = buildArgvMock<APIOrganizationCommandFlags, CommandArgs>()
 
-	apiCommandBuilderMock.mockReturnValue(apiCommandBuilderArgvMock)
+	apiOrganizationCommandBuilderMock.mockReturnValue(apiCommandBuilderArgvMock)
 	outputItemOrListBuilderMock.mockReturnValue(argvMock)
 
 	const builder = cmd.builder as (yargs: Argv<object>) => Argv<CommandArgs>
 
 	expect(builder(yargsMock)).toBe(argvMock)
 
-	expect(apiCommandBuilderMock).toHaveBeenCalledExactlyOnceWith(yargsMock)
+	expect(apiOrganizationCommandBuilderMock).toHaveBeenCalledExactlyOnceWith(yargsMock)
 	expect(outputItemOrListBuilderMock).toHaveBeenCalledExactlyOnceWith(apiCommandBuilderArgvMock)
 	expect(positionalMock).toHaveBeenCalledTimes(1)
 	expect(optionMock).toHaveBeenCalledTimes(1)
@@ -92,14 +101,14 @@ describe('handler', () => {
 			},
 		},
 		tableGenerator: tableGeneratorMock,
-	} as unknown as APICommand
-	apiCommandMock.mockResolvedValue(command)
+	} as unknown as APIOrganizationCommand<ArgumentsCamelCase<CommandArgs>>
+	apiOrganizationCommandMock.mockResolvedValue(command)
 
 	const baseInputArgv = { profile: 'default' } as ArgumentsCamelCase<CommandArgs>
 	it('prompts for a channel and lists metadata', async () => {
 		await expect(cmd.handler(baseInputArgv)).resolves.not.toThrow()
 
-		expect(apiCommandMock).toHaveBeenCalledExactlyOnceWith(baseInputArgv)
+		expect(apiOrganizationCommandMock).toHaveBeenCalledExactlyOnceWith(baseInputArgv)
 		expect(chooseChannelMock).toHaveBeenCalledExactlyOnceWith(
 			command,
 			undefined,

--- a/src/__tests__/commands/edge/drivers/delete.test.ts
+++ b/src/__tests__/commands/edge/drivers/delete.test.ts
@@ -6,9 +6,13 @@ import type { DriversEndpoint } from '@smartthings/core-sdk'
 
 import type { CommandArgs } from '../../../../commands/edge/drivers/delete.js'
 import type { buildEpilog } from '../../../../lib/help.js'
-import type { APICommand, APICommandFlags } from '../../../../lib/command/api-command.js'
+import type {
+	APIOrganizationCommand,
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+	APIOrganizationCommandFlags,
+} from '../../../../lib/command/api-organization-command.js'
 import type { chooseDriver } from '../../../../lib/command/util/drivers-choose.js'
-import { apiCommandMocks } from '../../../test-lib/api-command-mock.js'
 import { buildArgvMock } from '../../../test-lib/builder-mock.js'
 
 
@@ -17,7 +21,12 @@ jest.unstable_mockModule('../../../../lib/help.js', () => ({
 	buildEpilog: buildEpilogMock,
 }))
 
-const { apiCommandMock, apiCommandBuilderMock } = apiCommandMocks('../../../..')
+const apiOrganizationCommandMock = jest.fn<typeof apiOrganizationCommand>()
+const apiOrganizationCommandBuilderMock = jest.fn<typeof apiOrganizationCommandBuilder>()
+jest.unstable_mockModule('../../../../lib/command/api-organization-command.js', () => ({
+	apiOrganizationCommand: apiOrganizationCommandMock,
+	apiOrganizationCommandBuilder: apiOrganizationCommandBuilderMock,
+}))
 
 const chooseDriverMock = jest.fn<typeof chooseDriver>().mockResolvedValue('chosen-driver-id')
 jest.unstable_mockModule('../../../../lib/command/util/drivers-choose.js', () => ({
@@ -38,14 +47,14 @@ test('builder', () => {
 		exampleMock,
 		epilogMock,
 		argvMock,
-	} = buildArgvMock<APICommandFlags, CommandArgs>()
+	} = buildArgvMock<APIOrganizationCommandFlags, CommandArgs>()
 
-	apiCommandBuilderMock.mockReturnValue(argvMock)
+	apiOrganizationCommandBuilderMock.mockReturnValue(argvMock)
 
 	const builder = cmd.builder as (yargs: Argv<object>) => Argv<CommandArgs>
 	expect(builder(yargsMock)).toBe(argvMock)
 
-	expect(apiCommandBuilderMock).toHaveBeenCalledExactlyOnceWith(yargsMock)
+	expect(apiOrganizationCommandBuilderMock).toHaveBeenCalledExactlyOnceWith(yargsMock)
 
 	expect(positionalMock).toHaveBeenCalledTimes(1)
 	expect(optionMock).toHaveBeenCalledTimes(0)
@@ -62,8 +71,8 @@ test('handler', async () => {
 				delete: apiDriversDeleteMock,
 			},
 		},
-	} as unknown as APICommand
-	apiCommandMock.mockResolvedValue(command)
+	} as unknown as APIOrganizationCommand<ArgumentsCamelCase<CommandArgs>>
+	apiOrganizationCommandMock.mockResolvedValue(command)
 
 	const inputArgv = {
 		profile: 'default',
@@ -72,7 +81,7 @@ test('handler', async () => {
 
 	await expect(cmd.handler(inputArgv)).resolves.not.toThrow()
 
-	expect(apiCommandMock).toHaveBeenCalledExactlyOnceWith(inputArgv)
+	expect(apiOrganizationCommandMock).toHaveBeenCalledExactlyOnceWith(inputArgv)
 	expect(chooseDriverMock)
 		.toHaveBeenCalledExactlyOnceWith(command, 'cmd-line-id', { promptMessage: 'Select a driver to delete.' })
 	expect(apiDriversDeleteMock).toHaveBeenCalledExactlyOnceWith('chosen-driver-id')

--- a/src/commands/edge/channels/assign.ts
+++ b/src/commands/edge/channels/assign.ts
@@ -1,13 +1,17 @@
 import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 
 import { buildEpilog } from '../../../lib/help.js'
-import { apiCommand, apiCommandBuilder, type APICommandFlags } from '../../../lib/command/api-command.js'
+import {
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+	type APIOrganizationCommandFlags,
+} from '../../../lib/command/api-organization-command.js'
 import { chooseChannel } from '../../../lib/command/util/edge/channels-choose.js'
 import { chooseDriver } from '../../../lib/command/util/drivers-choose.js'
 
 
 export type CommandArgs =
-	& APICommandFlags
+	& APIOrganizationCommandFlags
 	& {
 		driverId?: string
 		driverVersion?: string
@@ -19,7 +23,7 @@ const command = 'edge:channels:assign [driver-id] [driver-version]'
 const describe = 'assign a driver to a channel'
 
 const builder = (yargs: Argv): Argv<CommandArgs> =>
-	apiCommandBuilder(yargs)
+	apiOrganizationCommandBuilder(yargs)
 		.positional('driver-id', { describe: 'driver id', type: 'string' })
 		.positional('driver-version', { describe: 'driver version', type: 'string' })
 		.option('channel', { alias: 'C', describe: 'channel to assigned to', type: 'string' })
@@ -43,7 +47,7 @@ const builder = (yargs: Argv): Argv<CommandArgs> =>
 
 
 const handler = async (argv: ArgumentsCamelCase<CommandArgs>): Promise<void> => {
-	const command = await apiCommand(argv)
+	const command = await apiOrganizationCommand(argv)
 
 	const channelId = await chooseChannel(
 		command,

--- a/src/commands/edge/channels/create.ts
+++ b/src/commands/edge/channels/create.ts
@@ -3,20 +3,24 @@ import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 import { type Channel, type ChannelCreate } from '@smartthings/core-sdk'
 
 import { buildEpilog } from '../../../lib/help.js'
+import { type TableFieldDefinition } from '../../../lib/table-generator.js'
 import { stringInput } from '../../../lib/user-query.js'
 import { urlValidate } from '../../../lib/validate-util.js'
-import { apiCommand, apiCommandBuilder, type APICommandFlags } from '../../../lib/command/api-command.js'
+import {
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+	type APIOrganizationCommandFlags,
+} from '../../../lib/command/api-organization-command.js'
 import {
 	inputAndOutputItem,
 	inputAndOutputItemBuilder,
 	type InputAndOutputItemFlags,
 } from '../../../lib/command/input-and-output-item.js'
-import { type TableFieldDefinition } from '../../../lib/table-generator.js'
 import { userInputProcessor } from '../../../lib/command/input-processor.js'
 
 
 export type CommandArgs =
-	& APICommandFlags
+	& APIOrganizationCommandFlags
 	& InputAndOutputItemFlags
 
 const command = 'edge:channels:create'
@@ -27,7 +31,7 @@ const tableFieldDefinitions: TableFieldDefinition<Channel>[] = ['channelId', 'na
 	'type', 'termsOfServiceUrl', 'createdDate', 'lastModifiedDate']
 
 const builder = (yargs: Argv): Argv<CommandArgs> =>
-	inputAndOutputItemBuilder(apiCommandBuilder(yargs))
+	inputAndOutputItemBuilder(apiOrganizationCommandBuilder(yargs))
 		.example([
 			[
 				'$0 edge:channels:create',
@@ -41,7 +45,7 @@ const builder = (yargs: Argv): Argv<CommandArgs> =>
 		.epilog(buildEpilog({ command, apiDocs: 'createChannel' }))
 
 const handler = async (argv: ArgumentsCamelCase<CommandArgs>): Promise<void> => {
-	const command = await apiCommand(argv)
+	const command = await apiOrganizationCommand(argv)
 
 	const getInputFromUser = async (): Promise<ChannelCreate> => {
 		const name = await stringInput('Channel name:')

--- a/src/commands/edge/channels/delete.ts
+++ b/src/commands/edge/channels/delete.ts
@@ -2,12 +2,16 @@ import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 
 import { resetManagedConfigKey } from '../../../lib/cli-config.js'
 import { buildEpilog } from '../../../lib/help.js'
-import { apiCommand, apiCommandBuilder, type APICommandFlags } from '../../../lib/command/api-command.js'
+import {
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+	type APIOrganizationCommandFlags,
+} from '../../../lib/command/api-organization-command.js'
 import { chooseChannel } from '../../../lib/command/util/edge/channels-choose.js'
 
 
 export type CommandArgs =
-	& APICommandFlags
+	& APIOrganizationCommandFlags
 	& {
 		id?: string
 	}
@@ -17,7 +21,7 @@ const command = 'edge:channels:delete [id]'
 const describe = 'delete a channel'
 
 const builder = (yargs: Argv): Argv<CommandArgs> =>
-	apiCommandBuilder(yargs)
+	apiOrganizationCommandBuilder(yargs)
 		.positional('id', { describe: 'channel id', type: 'string' })
 		.example([
 			['$0 edge:channels:delete', 'choose the channel to delete from a list'],
@@ -30,7 +34,7 @@ const builder = (yargs: Argv): Argv<CommandArgs> =>
 
 
 const handler = async (argv: ArgumentsCamelCase<CommandArgs>): Promise<void> => {
-	const command = await apiCommand(argv)
+	const command = await apiOrganizationCommand(argv)
 
 	const id = await chooseChannel(command, argv.id, { promptMessage: 'Choose a channel to delete.' })
 	await command.client.channels.delete(id)

--- a/src/commands/edge/channels/invites/create.ts
+++ b/src/commands/edge/channels/invites/create.ts
@@ -2,7 +2,11 @@ import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 
 import { type TableFieldDefinition } from '../../../../lib/table-generator.js'
 import { stringInput } from '../../../../lib/user-query.js'
-import { apiCommand, apiCommandBuilder, type APICommandFlags } from '../../../../lib/command/api-command.js'
+import {
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+	type APIOrganizationCommandFlags,
+} from '../../../../lib/command/api-organization-command.js'
 import { edgeCommand } from '../../../../lib/command/edge-command.js'
 import {
 	inputAndOutputItem,
@@ -17,7 +21,7 @@ import { buildEpilog } from '../../../../lib/help.js'
 
 
 export type CommandArgs =
-	& APICommandFlags
+	& APIOrganizationCommandFlags
 	& InputAndOutputItemFlags
 	& {
 		channel?: string
@@ -28,7 +32,7 @@ const command = 'edge:channels:invites:create'
 const describe = 'create an invitation'
 
 const builder = (yargs: Argv): Argv<CommandArgs> =>
-	inputAndOutputItemBuilder(apiCommandBuilder(yargs))
+	inputAndOutputItemBuilder(apiOrganizationCommandBuilder(yargs))
 		.option('channel', {
 			alias: 'C',
 			describe: 'channel id',
@@ -45,7 +49,7 @@ const builder = (yargs: Argv): Argv<CommandArgs> =>
 		.epilog(buildEpilog({ command }))
 
 const handler = async (argv: ArgumentsCamelCase<CommandArgs>): Promise<void> => {
-	const command = edgeCommand(await apiCommand(argv))
+	const command = edgeCommand(await apiOrganizationCommand(argv))
 
 	const getInputFromUser = async (): Promise<InvitationCreate> => {
 		const channelId = await chooseChannel(command, argv.channel,

--- a/src/commands/edge/channels/invites/delete.ts
+++ b/src/commands/edge/channels/invites/delete.ts
@@ -1,14 +1,18 @@
 import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 
 import { buildEpilog } from '../../../../lib/help.js'
-import { apiCommand, apiCommandBuilder, type APICommandFlags } from '../../../../lib/command/api-command.js'
+import {
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+	type APIOrganizationCommandFlags,
+} from '../../../../lib/command/api-organization-command.js'
 import { edgeCommand } from '../../../../lib/command/edge-command.js'
 import { chooseChannel } from '../../../../lib/command/util/edge/channels-choose.js'
 import { chooseInviteFn } from '../../../../lib/command/util/edge-invites-choose.js'
 
 
 export type CommandArgs =
-	& APICommandFlags
+	& APIOrganizationCommandFlags
 	& {
 		channel?: string
 		id?: string
@@ -19,7 +23,7 @@ const command = 'edge:channels:invites:delete [id]'
 const describe = 'delete a channel invitation'
 
 const builder = (yargs: Argv): Argv<CommandArgs> =>
-	apiCommandBuilder(yargs)
+	apiOrganizationCommandBuilder(yargs)
 		.option('channel', {
 			alias: 'C',
 			describe: 'channel id',
@@ -41,7 +45,7 @@ const builder = (yargs: Argv): Argv<CommandArgs> =>
 		.epilog(buildEpilog({ command }))
 
 const handler = async (argv: ArgumentsCamelCase<CommandArgs>): Promise<void> => {
-	const command = edgeCommand(await apiCommand(argv))
+	const command = edgeCommand(await apiOrganizationCommand(argv))
 
 	const chooseInvite = async (): Promise<string> => {
 		if (argv.id) {

--- a/src/commands/edge/channels/metainfo.ts
+++ b/src/commands/edge/channels/metainfo.ts
@@ -3,7 +3,11 @@ import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 import type { EdgeDriver } from '@smartthings/core-sdk'
 
 import { buildEpilog } from '../../../lib/help.js'
-import { apiCommand, apiCommandBuilder, type APICommandFlags } from '../../../lib/command/api-command.js'
+import {
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+	type APIOrganizationCommandFlags,
+} from '../../../lib/command/api-organization-command.js'
 import {
 	outputItemOrList,
 	outputItemOrListBuilder,
@@ -15,7 +19,7 @@ import { chooseChannel } from '../../../lib/command/util/edge/channels-choose.js
 
 
 export type CommandArgs =
-	& APICommandFlags
+	& APIOrganizationCommandFlags
 	& OutputItemOrListFlags
 	& {
 		driverIdOrIndex?: string
@@ -27,7 +31,7 @@ const command = 'edge:channels:metainfo [driver-id-or-index]'
 const describe = 'display metadata about drivers assigned to channels'
 
 const builder = (yargs: Argv): Argv<CommandArgs> =>
-	outputItemOrListBuilder(apiCommandBuilder(yargs))
+	outputItemOrListBuilder(apiOrganizationCommandBuilder(yargs))
 		.positional('id-or-index', { describe: 'driver id or number in list', type: 'string' })
 		.option('channel', { alias: 'C', describe: 'channel id', type: 'string' })
 		.example([
@@ -52,7 +56,7 @@ const builder = (yargs: Argv): Argv<CommandArgs> =>
 		.epilog(buildEpilog({ command }))
 
 const handler = async (argv: ArgumentsCamelCase<CommandArgs>): Promise<void> => {
-	const command = await apiCommand(argv)
+	const command = await apiOrganizationCommand(argv)
 
 	const channelId = await chooseChannel(
 		command,

--- a/src/commands/edge/channels/unassign.ts
+++ b/src/commands/edge/channels/unassign.ts
@@ -1,13 +1,17 @@
 import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 
 import { buildEpilog } from '../../../lib/help.js'
-import { apiCommand, apiCommandBuilder, type APICommandFlags } from '../../../lib/command/api-command.js'
+import {
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+	type APIOrganizationCommandFlags,
+} from '../../../lib/command/api-organization-command.js'
 import { chooseChannelFn } from '../../../lib/command/util/edge/channels-choose.js'
 import { chooseDriverFromChannelFn } from '../../../lib/command/util/drivers-choose.js'
 
 
 export type CommandArgs =
-	& APICommandFlags
+	& APIOrganizationCommandFlags
 	& {
 		driverId?: string
 		channel?: string
@@ -18,7 +22,7 @@ const command = 'edge:channels:unassign [driver-id]'
 const describe = 'remove a driver from a channel'
 
 const builder = (yargs: Argv): Argv<CommandArgs> =>
-	apiCommandBuilder(yargs)
+	apiOrganizationCommandBuilder(yargs)
 		.positional('driver-id', { describe: 'driver id', type: 'string' })
 		.option('channel', { alias: 'C', describe: 'channel to unassigned from', type: 'string' })
 		.example([
@@ -41,7 +45,7 @@ const builder = (yargs: Argv): Argv<CommandArgs> =>
 
 
 const handler = async (argv: ArgumentsCamelCase<CommandArgs>): Promise<void> => {
-	const command = await apiCommand(argv)
+	const command = await apiOrganizationCommand(argv)
 
 	const channelId = await chooseChannelFn({ withDriverId: argv.driverId })(
 		command,

--- a/src/commands/edge/channels/update.ts
+++ b/src/commands/edge/channels/update.ts
@@ -3,7 +3,11 @@ import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 import { type Channel, type ChannelUpdate } from '@smartthings/core-sdk'
 
 import { buildEpilog } from '../../../lib/help.js'
-import { apiCommand, apiCommandBuilder, type APICommandFlags } from '../../../lib/command/api-command.js'
+import {
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+	type APIOrganizationCommandFlags,
+} from '../../../lib/command/api-organization-command.js'
 import {
 	inputAndOutputItem,
 	inputAndOutputItemBuilder,
@@ -14,7 +18,7 @@ import { tableFieldDefinitions } from '../../../lib/command/util/edge/channels-t
 
 
 export type CommandArgs =
-	& APICommandFlags
+	& APIOrganizationCommandFlags
 	& InputAndOutputItemFlags
 	& {
 		id?: string
@@ -25,7 +29,7 @@ const command = 'edge:channels:update [id]'
 const describe = 'update a channel'
 
 const builder = (yargs: Argv): Argv<CommandArgs> =>
-	inputAndOutputItemBuilder(apiCommandBuilder(yargs))
+	inputAndOutputItemBuilder(apiOrganizationCommandBuilder(yargs))
 		.positional('id', { describe: 'id of channel to update', type: 'string' })
 		.example([
 			[
@@ -40,7 +44,7 @@ const builder = (yargs: Argv): Argv<CommandArgs> =>
 		.epilog(buildEpilog({ command, apiDocs: 'updateChannel' }))
 
 const handler = async (argv: ArgumentsCamelCase<CommandArgs>): Promise<void> => {
-	const command = await apiCommand(argv)
+	const command = await apiOrganizationCommand(argv)
 
 	const id = await chooseChannel(
 		command,

--- a/src/commands/edge/drivers/delete.ts
+++ b/src/commands/edge/drivers/delete.ts
@@ -1,12 +1,16 @@
 import { type ArgumentsCamelCase, type Argv, type CommandModule } from 'yargs'
 
 import { buildEpilog } from '../../../lib/help.js'
-import { apiCommand, apiCommandBuilder, type APICommandFlags } from '../../../lib/command/api-command.js'
+import {
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+	type APIOrganizationCommandFlags,
+} from '../../../lib/command/api-organization-command.js'
 import { chooseDriver } from '../../../lib/command/util/drivers-choose.js'
 
 
 export type CommandArgs =
-	& APICommandFlags
+	& APIOrganizationCommandFlags
 	& {
 		id?: string
 	}
@@ -16,7 +20,7 @@ const command = 'edge:drivers:delete [id]'
 const describe = 'delete an edge driver'
 
 const builder = (yargs: Argv): Argv<CommandArgs> =>
-	apiCommandBuilder(yargs)
+	apiOrganizationCommandBuilder(yargs)
 		.positional('driver-id', { describe: 'id of driver to delete', type: 'string' })
 		.example([
 			['$0 edge:drivers:delete', 'prompt for a driver and delete it'],
@@ -28,7 +32,7 @@ const builder = (yargs: Argv): Argv<CommandArgs> =>
 		.epilog(buildEpilog({ command, apiDocs: 'deleteDriver' }))
 
 const handler = async (argv: ArgumentsCamelCase<CommandArgs>): Promise<void> => {
-	const command = await apiCommand(argv)
+	const command = await apiOrganizationCommand(argv)
 
 	const id = await chooseDriver(command, argv.id, { promptMessage: 'Select a driver to delete.' })
 	await command.client.drivers.delete(id)

--- a/src/commands/edge/drivers/package.ts
+++ b/src/commands/edge/drivers/package.ts
@@ -8,7 +8,11 @@ import { type EdgeDriver } from '@smartthings/core-sdk'
 
 import { buildEpilog } from '../../../lib/help.js'
 import { fatalError } from '../../../lib/util.js'
-import { apiCommand, apiCommandBuilder, type APICommandFlags } from '../../../lib/command/api-command.js'
+import {
+	apiOrganizationCommand,
+	apiOrganizationCommandBuilder,
+	type APIOrganizationCommandFlags,
+} from '../../../lib/command/api-organization-command.js'
 import { outputItem, outputItemBuilder, type OutputItemConfig } from '../../../lib/command/output-item.js'
 import {
 	buildTestFileMatchers,
@@ -24,7 +28,7 @@ import { chooseChannel } from '../../../lib/command/util/edge/channels-choose.js
 
 
 export type CommandArgs =
-	& APICommandFlags
+	& APIOrganizationCommandFlags
 	& {
 		projectDirectory?: string
 		buildOnly?: string
@@ -40,7 +44,7 @@ const command = 'edge:drivers:package [project-directory]'
 const describe = 'build and upload an edge package'
 
 const builder = (yargs: Argv): Argv<CommandArgs> =>
-	outputItemBuilder(apiCommandBuilder(yargs))
+	outputItemBuilder(apiOrganizationCommandBuilder(yargs))
 		.positional(
 			'project-directory',
 			{ describe: 'directory containing project to upload', type: 'string', default: '.' },
@@ -127,7 +131,7 @@ const builder = (yargs: Argv): Argv<CommandArgs> =>
 		.epilog(buildEpilog({ command, apiDocs: 'uploadDriverPackage' }))
 
 const handler = async (argv: ArgumentsCamelCase<CommandArgs>): Promise<void> => {
-	const command = await apiCommand(argv)
+	const command = await apiOrganizationCommand(argv)
 
 	const uploadAndPostProcess = async (archiveData: Uint8Array): Promise<void> => {
 		const config: OutputItemConfig<EdgeDriver> = {


### PR DESCRIPTION
In the oclif version of the CLI all edge commands included the organization flag regardless of whether they were used or not. In the translation to yargs, I overlooked a few commands that should have included the organization flag. This PR fixes that.

(Note that this does not add back the organization flag to all edge commands. Many of them did not use it.)

Fixes #812 