### PR TITLE
fix: make install via npm work again

### DIFF
--- a/.changeset/sour-snakes-sneeze.md
+++ b/.changeset/sour-snakes-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+fix binary installed via npm

--- a/bin/dev.cmd
+++ b/bin/dev.cmd
@@ -1,3 +1,0 @@
-@echo off
-
-node "%~dp0\dev" %*

--- a/bin/run
+++ b/bin/run
@@ -1,9 +1,0 @@
-#!/usr/bin/env node
-
-const oclif = require('@oclif/core')
-const log4js = require('log4js')
-
-oclif.run()
-	.then(oclif.flush)
-	.catch(oclif.Errors.handle)
-	.finally(log4js.shutdown)

--- a/bin/run.cmd
+++ b/bin/run.cmd
@@ -1,3 +1,0 @@
-@echo off
-
-node "%~dp0\run" %*

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"dist/src",
 		"dist/tsconfig.tsbuildinfo",
 		"README.md",
+		"package.json",
 		"/npm-shrinkwrap.json",
 		"!*/src/build-tools",
 		"!*/src/__tests__"

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { buildInstance } from './index.js'
 
 


### PR DESCRIPTION
* added missing hashbang line to run script (https://docs.npmjs.com/cli/v10/configuring-npm/package-json#bin)
* removed old unused oclif bin directory
* add package.json to deploy (used by `smartthings --version`)

Fixes #815 