### PR TITLE
fix: remove some unnecessary calls to the API

### DIFF
--- a/.changeset/tricky-ways-retire.md
+++ b/.changeset/tricky-ways-retire.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+remove some unnecessary calls to the API

--- a/src/__tests__/lib/command/util/util-util.test.ts
+++ b/src/__tests__/lib/command/util/util-util.test.ts
@@ -166,7 +166,8 @@ describe('createChooseFn', () => {
 		it('uses listItems from createChooseFn by default', async () => {
 			expect(await chooseSimpleType(command)).toBe('selected-simple-type-id')
 
-			expect(itemListMock).toHaveBeenCalledExactlyOnceWith(command)
+			// The list function should not be called until it's actually used.
+			expect(itemListMock).toHaveBeenCalledTimes(0)
 
 			const listItems = selectFromListMock.mock.calls[0][2].listItems
 
@@ -183,7 +184,7 @@ describe('createChooseFn', () => {
 			expect(await chooseSimpleType(command, undefined, { listItems: overridingListItemsMock }))
 				.toBe('selected-simple-type-id')
 
-			expect(overridingListItemsMock).toHaveBeenCalledExactlyOnceWith(command)
+			expect(overridingListItemsMock).toHaveBeenCalledTimes(0)
 			expect(itemListMock).not.toHaveBeenCalled()
 
 			const listItems = selectFromListMock.mock.calls[0][2].listItems


### PR DESCRIPTION
Commands that used `choose<Thing>` functions were calling the `list` endpoints even if the id was already chosen. This makes that list lazy so it won't actually call the API until it's used.