### PR TITLE
fix: revert axios to 1.13.3 to work around regression

### DIFF
--- a/.changeset/afraid-peaches-sit.md
+++ b/.changeset/afraid-peaches-sit.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+downgrade axios to work around regression

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
 			"dependencies": {
 				"@aws-sdk/client-lambda": "^3.994.0",
 				"@inquirer/prompts": "^7.8.6",
-				"@smartthings/core-sdk": "^8.5.0",
-				"axios": "1.13.5",
+				"@smartthings/core-sdk": "^8.5.1",
+				"axios": "1.13.3",
 				"chalk": "^5.6.2",
 				"env-paths": "^3.0.0",
 				"eventsource": "^4.1.0",
@@ -3981,13 +3981,13 @@
 			}
 		},
 		"node_modules/@smartthings/core-sdk": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-8.5.0.tgz",
-			"integrity": "sha512-0PH39onvLjc9hNwivQLXz9FTa13zdYAPKzZDbYmfbd7ZRILRWfUoSl79xUg+Q4yabdZyiJY+TFLf7pK9YL6W7A==",
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/@smartthings/core-sdk/-/core-sdk-8.5.1.tgz",
+			"integrity": "sha512-3PeoC4ZTR6W5r61pDKsRBPZ1Nxt+tL7uWfQZw9IDiTG12LhjY0W6rCV1+rf4aRcJkkHn1u4zLAwpcYCmBU+X0A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"async-mutex": "^0.5.0",
-				"axios": "^1.13.5",
+				"axios": "1.13.3",
 				"http-signature": "^1.4.0",
 				"lodash.isdate": "^4.0.1",
 				"lodash.isstring": "^4.0.1",
@@ -6248,13 +6248,13 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-			"integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+			"version": "1.13.3",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.3.tgz",
+			"integrity": "sha512-ERT8kdX7DZjtUm7IitEyV7InTHAF42iJuMArIiDIV5YtPanJkgw4hw5Dyg9fh0mihdWNn1GKaeIWErfe56UQ1g==",
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.11",
-				"form-data": "^4.0.5",
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.4",
 				"proxy-from-env": "^1.1.0"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
 	"dependencies": {
 		"@aws-sdk/client-lambda": "^3.994.0",
 		"@inquirer/prompts": "^7.8.6",
-		"@smartthings/core-sdk": "^8.5.0",
-		"axios": "1.13.5",
+		"@smartthings/core-sdk": "^8.5.1",
+		"axios": "1.13.3",
 		"chalk": "^5.6.2",
 		"env-paths": "^3.0.0",
 		"eventsource": "^4.1.0",


### PR DESCRIPTION
Reverted axios to 1.13.3 (and updated core SDK to version that has also reverted axios to 1.13.3) to work around regression.