### PR TITLE
fix: guard against undefined error in yargs fail callback

### DIFF
--- a/.changeset/fix-undefined-error-in-fail-callback.md
+++ b/.changeset/fix-undefined-error-in-fail-callback.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+Fix TypeError crash when running `smartthings` or `smartthings -h` without a subcommand. Yargs passes `undefined` as the error argument to the `.fail()` callback for validation failures; the `in` operator threw when the operand was `undefined`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export const buildInstance = (commands: CommandModule<object, any>[]): Argv => {
 		/* eslint-enable @typescript-eslint/naming-convention */
 		.completion('generate-completions-script', 'output completion script setup')
 		.fail((message, error, yargs) => {
-			if ('isAxiosError' in error && error.isAxiosError) {
+			if (error && 'isAxiosError' in error && error.isAxiosError) {
 				// We don't print axiosError.message here because it just duplicates the things
 				// we're displaying but unformatted.
 				const axiosError = error as AxiosError


### PR DESCRIPTION
## Summary

Running `smartthings` or `smartthings -h` without a subcommand crashes with a `TypeError` instead of showing usage help:

```
file:///opt/homebrew/lib/node_modules/@smartthings/cli/dist/src/index.js:30
        if ('isAxiosError' in error && error.isAxiosError) {
                           ^

TypeError: Cannot use 'in' operator to search for 'isAxiosError' in undefined
```

Yargs calls the `.fail()` callback with `(message, undefined, yargs)` when a validation failure is not caused by a thrown error (e.g. no subcommand provided, triggering `.demandCommand()`). The `in` operator throws a `TypeError` when its right-hand operand is `undefined`.

**Fix:** add a null-guard (`error &&`) before the `in` check so `undefined` falls through to the `else` branch, which correctly prints the yargs-generated message and help text.

## Test plan

- [ ] Run `smartthings` with no arguments — should print usage/help instead of crashing
- [ ] Run `smartthings -h` — should print help instead of crashing
- [ ] Run a command that triggers an Axios error — should still display the API error message correctly
- [ ] Run a command that throws a non-Axios error — should still display `error.message`

🤖 Generated with [Claude Code](https://claude.com/claude-code)