### PR TITLE
chore: remove forced override of got

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6566,6 +6566,26 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/clone-response": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			}
+		},
+		"node_modules/clone-response/node_modules/mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7207,6 +7227,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/decode-uri-component": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
 		"node_modules/decompress": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
@@ -7693,6 +7723,52 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/download/node_modules/@sindresorhus/is": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/cacheable-request": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+			"integrity": "sha512-vag0O2LKZ/najSoUwDbVlnlCFvhBE/7mGTY2B5FgCBDcRD+oVV1HYTOwM6JZfMg/hIcM6IwnTZ1uQQL5/X3xIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clone-response": "1.0.2",
+				"get-stream": "3.0.0",
+				"http-cache-semantics": "3.8.1",
+				"keyv": "3.0.0",
+				"lowercase-keys": "1.0.0",
+				"normalize-url": "2.0.1",
+				"responselike": "1.0.2"
+			}
+		},
+		"node_modules/download/node_modules/cacheable-request/node_modules/get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/cacheable-request/node_modules/lowercase-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+			"integrity": "sha512-RPlX0+PHuvxVDZ7xX+EBVAp4RsVxP/TdDSN2mJYdiq1Lc4Hz7EUSjUI7RZrKKlmrIzVhf6Jo2stj7++gVarS0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/download/node_modules/content-disposition": {
 			"version": "0.5.4",
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -7706,6 +7782,19 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/download/node_modules/decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/download/node_modules/get-stream": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -7717,6 +7806,89 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/download/node_modules/got": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+			"integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/is": "^0.7.0",
+				"cacheable-request": "^2.1.1",
+				"decompress-response": "^3.3.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"into-stream": "^3.1.0",
+				"is-retry-allowed": "^1.1.0",
+				"isurl": "^1.0.0-alpha5",
+				"lowercase-keys": "^1.0.0",
+				"mimic-response": "^1.0.0",
+				"p-cancelable": "^0.4.0",
+				"p-timeout": "^2.0.1",
+				"pify": "^3.0.0",
+				"safe-buffer": "^5.1.1",
+				"timed-out": "^4.0.1",
+				"url-parse-lax": "^3.0.0",
+				"url-to-options": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/got/node_modules/get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/got/node_modules/pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/http-cache-semantics": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/download/node_modules/json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/download/node_modules/keyv": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+			"integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-buffer": "3.0.0"
+			}
+		},
+		"node_modules/download/node_modules/lowercase-keys": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/download/node_modules/make-dir": {
@@ -7733,6 +7905,51 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/download/node_modules/mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/normalize-url": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+			"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"prepend-http": "^2.0.0",
+				"query-string": "^5.0.1",
+				"sort-keys": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/p-cancelable": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+			"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/download/node_modules/responselike": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+			"integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lowercase-keys": "^1.0.0"
+			}
+		},
 		"node_modules/download/node_modules/semver": {
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -7741,6 +7958,19 @@
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver"
+			}
+		},
+		"node_modules/download/node_modules/sort-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+			"integrity": "sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-plain-obj": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/dunder-proto": {
@@ -7756,6 +7986,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/duplexer3": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
+			"integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
@@ -9032,6 +9269,57 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0"
+			}
+		},
+		"node_modules/from2/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/from2/node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/from2/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/from2/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
 		"node_modules/fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -9981,6 +10269,20 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/into-stream": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+			"integrity": "sha512-TcdjPibTksa1NQximqep2r17ISRiNE9fwlfbg3F8ANdvP5/yrFTew86VcO//jk4QTaMlbjypPBq76HN2zaKfZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"from2": "^2.1.1",
+				"p-is-promise": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -10180,6 +10482,16 @@
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
 			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
 			"license": "MIT"
+		},
+		"node_modules/is-retry-allowed": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/is-safe-filename": {
 			"version": "0.1.1",
@@ -13574,6 +13886,16 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/p-is-promise": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+			"integrity": "sha512-zL7VE4JVS2IFSkR2GQKDSPEVxkoH43/p7oEnwpdCndKYJO0HVeRB7fA8TJwuLOTBREtK0ea8eHaxdwcpob5dmg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/p-limit": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -13948,6 +14270,16 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/prepend-http": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+			"integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/pretty-format": {
 			"version": "30.4.1",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
@@ -14057,6 +14389,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/query-string": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"decode-uri-component": "^0.2.0",
+				"object-assign": "^4.1.0",
+				"strict-uri-encode": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/queue-microtask": {
@@ -15068,6 +15415,16 @@
 				"queue-tick": "^1.0.1"
 			}
 		},
+		"node_modules/strict-uri-encode": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+			"integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -15567,6 +15924,16 @@
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
 			"dev": true
+		},
+		"node_modules/timed-out": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+			"integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/tinyexec": {
 			"version": "1.3.0",
@@ -16252,6 +16619,19 @@
 			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/url-parse-lax": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+			"integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"prepend-http": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/url-to-options": {

--- a/package.json
+++ b/package.json
@@ -107,9 +107,6 @@
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.67.0"
 	},
-	"overrides": {
-		"got": "^12.6.0"
-	},
 	"scripts": {
 		"lint": "eslint src",
 		"format": "eslint src --fix",


### PR DESCRIPTION
Forced override of `got` was causing build to fail because it couldn't download `nexe` builds.