### PR TITLE
fix: correct capability presentation examples

### DIFF
--- a/.changeset/cute-hornets-sleep.md
+++ b/.changeset/cute-hornets-sleep.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/cli": patch
+---
+
+Correct the capability presentation help examples to use the registered command name.

--- a/src/__tests__/commands/capabilities/presentation.test.ts
+++ b/src/__tests__/commands/capabilities/presentation.test.ts
@@ -86,7 +86,26 @@ test('builder', () => {
 	expect(capabilityIdOrIndexBuilderMock).toHaveBeenCalledExactlyOnceWith(apiOrganizationCommandBuilderArgvMock)
 	expect(formatAndWriteItemBuilderMock).toHaveBeenCalledExactlyOnceWith(capabilityIdOrIndexBuilderArgvMock)
 
-	expect(exampleMock).toHaveBeenCalledTimes(1)
+	expect(exampleMock).toHaveBeenCalledExactlyOnceWith([
+		[
+			'$0 capabilities:presentation',
+			'prompt for a capability and display its presentation information',
+		],
+		[
+			'$0 capabilities:presentation --namespace cathappy12345',
+			'prompt for a capability from the specified namespace and display its' +
+				' presentation information',
+		],
+		[
+			'$0 capabilities:presentation cathappy12345.myCapability',
+			'display details for a capability by id',
+		],
+		[
+			'$0 capabilities:presentation 1',
+			'display presentation information for the first capability in the list retrieved' +
+				' by running "smartthings capabilities"',
+		],
+	])
 	expect(optionMock).toHaveBeenCalledTimes(1)
 	expect(buildEpilogMock).toHaveBeenCalledTimes(1)
 	expect(epilogMock).toHaveBeenCalledTimes(1)

--- a/src/commands/capabilities/presentation.ts
+++ b/src/commands/capabilities/presentation.ts
@@ -40,20 +40,20 @@ export const builder = (yargs: Argv): Argv<CommandArgs> =>
 		})
 		.example([
 			[
-				'$0 capabilities:presentations',
+				'$0 capabilities:presentation',
 				'prompt for a capability and display its presentation information',
 			],
 			[
-				'$0 capabilities:presentations --namespace cathappy12345',
+				'$0 capabilities:presentation --namespace cathappy12345',
 				'prompt for a capability from the specified namespace and display its' +
 					' presentation information',
 			],
 			[
-				'$0 capabilities:presentations cathappy12345.myCapability',
+				'$0 capabilities:presentation cathappy12345.myCapability',
 				'display details for a capability by id',
 			],
 			[
-				'$0 capabilities:presentations 1',
+				'$0 capabilities:presentation 1',
 				'display presentation information for the first capability in the list retrieved' +
 					' by running "smartthings capabilities"',
 			],


### PR DESCRIPTION
## Summary

- correct the four `capabilities:presentation` help examples that used the
  non-existent `capabilities:presentations` command
- strengthen regression coverage to verify the complete example array
- add a patch changeset for `@smartthings/cli`

## Root cause

The command is registered as `capabilities:presentation`, but four independently
hard-coded help examples used `capabilities:presentations`. The existing builder
test only verified that the example builder was called once, so incorrect
example arguments were not detected.

## Verification

- [x] `npm run build`
- [x] `npm run test -- --runTestsByPath src/__tests__/commands/capabilities/presentation.test.ts --no-watchman`
- [x] `npm run lint`
- [x] `npm run test -- --no-watchman`
- [x] `git diff --check upstream/main...HEAD`
- [x] `node dist/src/run.js capabilities:presentation --help`

The built help output contains all four corrected singular examples and zero
`capabilities:presentations` examples. The README generator ran as part of
`npm run build` and produced no tracked README change.

Fixes #842

## Checklist

- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] Any required documentation has been added
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] I have added tests to cover my changes
